### PR TITLE
Fix ResourceBundle detection in Windows

### DIFF
--- a/src/main/java/org/eclipselabs/garbagecat/util/GcUtil.java
+++ b/src/main/java/org/eclipselabs/garbagecat/util/GcUtil.java
@@ -180,7 +180,7 @@ public class GcUtil {
      * @return The value for the given property file and key.
      */
     public static final String getPropertyValue(String propertyFile, String key) {
-        ResourceBundle rb = ResourceBundle.getBundle("META-INF" + System.getProperty("file.separator") + propertyFile);
+        ResourceBundle rb = ResourceBundle.getBundle("META-INF." + propertyFile);
         return rb.getString(key);
     }
 


### PR DESCRIPTION
Fix for `MissingResourceException: Can't find bundle for name META-INF\analysis, locale en_GB`