### PR TITLE
Migration from JUnit4 to JUnit5 (jupiter)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 				</configuration>
 			</plugin>
 			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-surefire-plugin</artifactId>
+			    <version>2.22.2</version>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.6.1</version>
 				<configuration>
@@ -93,9 +98,15 @@
 	</build>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.7.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>5.7.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.7.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>1.8.0.7</version>

--- a/src/main/java/org/eclipselabs/garbagecat/Main.java
+++ b/src/main/java/org/eclipselabs/garbagecat/Main.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -193,13 +192,12 @@ public class Main {
 
             // Bottlenecks
             List<String> bottlenecks = jvmRun.getBottlenecks();
-            if (bottlenecks.size() > 0) {
+            if (!bottlenecks.isEmpty()) {
                 bufferedWriter.write("========================================" + LINE_SEPARATOR);
                 bufferedWriter.write("Throughput less than " + jvmRun.getThroughputThreshold() + "%" + LINE_SEPARATOR);
                 bufferedWriter.write("----------------------------------------" + LINE_SEPARATOR);
-                Iterator<String> iterator = bottlenecks.iterator();
-                while (iterator.hasNext()) {
-                    bufferedWriter.write(iterator.next() + LINE_SEPARATOR);
+                for (String bottleneck : bottlenecks) {
+                    bufferedWriter.write(bottleneck + LINE_SEPARATOR);
                 }
             }
 
@@ -230,10 +228,8 @@ public class Main {
             if (jvmRun.getBlockingEventCount() > 0) {
                 bufferedWriter.write("Event Types: ");
                 List<LogEventType> eventTypes = jvmRun.getEventTypes();
-                Iterator<LogEventType> iterator = eventTypes.iterator();
                 boolean firstEvent = true;
-                while (iterator.hasNext()) {
-                    LogEventType eventType = iterator.next();
+                for (LogEventType eventType : eventTypes) {
                     // Only report GC events
                     if (JdkUtil.isReportable(eventType)) {
                         if (!firstEvent) {
@@ -245,7 +241,7 @@ public class Main {
                 }
                 bufferedWriter.write(LINE_SEPARATOR);
                 // Inverted parallelism. Only report if we have Serial/Parallel/CMS/G1 events with times data.
-                if (jvmRun.getCollectorFamilies() != null && jvmRun.getCollectorFamilies().size() > 0
+                if (jvmRun.getCollectorFamilies() != null && !jvmRun.getCollectorFamilies().isEmpty()
                         && jvmRun.getParallelCount() > 0) {
                     bufferedWriter.write("# Parallel Events: " + jvmRun.getParallelCount() + LINE_SEPARATOR);
                     bufferedWriter
@@ -459,17 +455,13 @@ public class Main {
                 bufferedWriter.write(unidentifiedLogLines.size() + " UNIDENTIFIED LOG LINE(S):" + LINE_SEPARATOR);
                 bufferedWriter.write("----------------------------------------" + LINE_SEPARATOR);
 
-                Iterator<String> iterator = unidentifiedLogLines.iterator();
-                while (iterator.hasNext()) {
-                    String unidentifiedLogLine = iterator.next();
+                for (String unidentifiedLogLine : unidentifiedLogLines) {
                     bufferedWriter.write(unidentifiedLogLine);
                     bufferedWriter.write(LINE_SEPARATOR);
                 }
                 bufferedWriter.write("========================================" + LINE_SEPARATOR);
             }
-        } catch (
-
-        FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/CmsPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/CmsPreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -703,7 +702,7 @@ public class CmsPreprocessAction implements PreprocessAction {
                 this.logEntry = matcher.group(1);
             }
             // Sometimes this is the end of a logging event
-            if (entangledLogLines.size() > 0 && newLoggingEvent(nextLogEntry)) {
+            if (!entangledLogLines.isEmpty() && newLoggingEvent(nextLogEntry)) {
                 clearEntangledLines(entangledLogLines);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
@@ -795,11 +794,9 @@ public class CmsPreprocessAction implements PreprocessAction {
      *            Log lines to be output out of order.
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/G1PreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/G1PreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -948,32 +947,33 @@ public class G1PreprocessAction implements PreprocessAction {
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine, String priorLogLine, String nextLogLine) {
-        boolean match = false;
-        if (logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_REMARK) || logLine.matches(REGEX_RETAIN_BEGINNING_MIXED)
-                || (logLine.matches(REGEX_RETAIN_BEGINNING_CLEANUP) && nextLogLine.matches(REGEX_RETAIN_END))
-                || logLine.matches(REGEX_RETAIN_BEGINNING_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK) || logLine.matches(REGEX_RETAIN_MIDDLE_FULL)
-                || logLine.matches(REGEX_RETAIN_MIDDLE) || logLine.matches(REGEX_RETAIN_MIDDLE_DURATION)
-                || logLine.matches(REGEX_RETAIN_END) || logLine.matches(REGEX_RETAIN_END_CONCURRENT_YOUNG)) {
-            match = true;
-        } else {
-            // TODO: Get rid of this and make them throwaway events?
-            for (int i = 0; i < REGEX_THROWAWAY.length; i++) {
-                if (logLine.matches(REGEX_THROWAWAY[i])) {
-                    match = true;
-                    break;
-                }
-            }
+        if (logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_REMARK) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_MIXED) //
+                || (logLine.matches(REGEX_RETAIN_BEGINNING_CLEANUP) && nextLogLine.matches(REGEX_RETAIN_END)) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_CONCURRENT) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT) //
+                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT) //
+                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE) //
+                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK) //
+                || logLine.matches(REGEX_RETAIN_MIDDLE_FULL) //
+                || logLine.matches(REGEX_RETAIN_MIDDLE) //
+                || logLine.matches(REGEX_RETAIN_MIDDLE_DURATION) //
+                || logLine.matches(REGEX_RETAIN_END) //
+                || logLine.matches(REGEX_RETAIN_END_CONCURRENT_YOUNG)) {
+            return true;
         }
-        return match;
+		// TODO: Get rid of this and make them throwaway events?
+		for (String element : REGEX_THROWAWAY) {
+		    if (logLine.matches(element)) {
+		        return true;
+		    }
+		}
+        return false;
     }
 
     /**
@@ -984,11 +984,9 @@ public class G1PreprocessAction implements PreprocessAction {
      * @return
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ParallelPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ParallelPreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -208,11 +207,9 @@ public class ParallelPreprocessAction implements PreprocessAction {
      * @return
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/SerialPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/SerialPreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -146,11 +145,9 @@ public class SerialPreprocessAction implements PreprocessAction {
      * @return
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ShenandoahPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ShenandoahPreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -371,11 +370,9 @@ public class ShenandoahPreprocessAction implements PreprocessAction {
      *            Log lines to be output out of order.
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/UnifiedPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/UnifiedPreprocessAction.java
@@ -12,7 +12,6 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk.unified;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -623,11 +622,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      * @return
      */
     private final void clearEntangledLines(List<String> entangledLogLines) {
-        if (entangledLogLines != null && entangledLogLines.size() > 0) {
+        if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
             // Output any entangled log lines
-            Iterator<String> iterator = entangledLogLines.iterator();
-            while (iterator.hasNext()) {
-                String logLine = iterator.next();
+            for (String logLine : entangledLogLines) {
                 this.logEntry = this.logEntry + Constants.LINE_SEPARATOR + logLine;
             }
             // Reset entangled log lines

--- a/src/main/java/org/eclipselabs/garbagecat/service/GcManager.java
+++ b/src/main/java/org/eclipselabs/garbagecat/service/GcManager.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -200,10 +199,8 @@ public class GcManager {
             }
 
             // output entangled log lines
-            if (entangledLogLines.size() > 0) {
-                Iterator<String> iterator = entangledLogLines.iterator();
-                while (iterator.hasNext()) {
-                    String logLine = iterator.next();
+            if (!entangledLogLines.isEmpty()) {
+                for (String logLine : entangledLogLines) {
                     bufferedWriter.write(Constants.LINE_SEPARATOR + logLine);
                 }
                 // Reset entangled log lines
@@ -416,10 +413,8 @@ public class GcManager {
             }
         } else {
             // Output any entangled log lines
-            if (entangledLogLines != null && entangledLogLines.size() > 0) {
-                Iterator<String> iterator = entangledLogLines.iterator();
-                while (iterator.hasNext()) {
-                    String logLine = iterator.next();
+            if (entangledLogLines != null && !entangledLogLines.isEmpty()) {
+                for (String logLine : entangledLogLines) {
                     if (preprocessedLogLine == null) {
                         preprocessedLogLine = logLine;
                     } else {
@@ -859,14 +854,12 @@ public class GcManager {
      *         throughput threshold goal.
      */
     private List<String> getBottlenecks(Jvm jvm, int throughputThreshold) {
-        ArrayList<String> bottlenecks = new ArrayList<String>();
+        List<String> bottlenecks = new ArrayList<String>();
         List<BlockingEvent> blockingEvents = jvmDao.getBlockingEvents();
-        Iterator<BlockingEvent> iterator = blockingEvents.iterator();
         BlockingEvent priorEvent = null;
-        while (iterator.hasNext()) {
-            BlockingEvent event = iterator.next();
+        for (BlockingEvent event : blockingEvents) {
             if (priorEvent != null && JdkUtil.isBottleneck(event, priorEvent, throughputThreshold)) {
-                if (bottlenecks.size() == 0) {
+                if (bottlenecks.isEmpty()) {
                     // Add current and prior event
                     if (jvm.getStartDate() != null) {
                         // Convert timestamps to date/time
@@ -974,7 +967,6 @@ public class GcManager {
      * @return True if the logging event can be thrown away, false if it should be kept.
      */
     private boolean isThrowawayEvent(String logLine) {
-        LogEvent event = JdkUtil.parseLogLine(logLine);
-        return event instanceof ThrowAwayEvent;
+        return JdkUtil.parseLogLine(logLine) instanceof ThrowAwayEvent;
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/util/jdk/Jvm.java
+++ b/src/main/java/org/eclipselabs/garbagecat/util/jdk/Jvm.java
@@ -19,7 +19,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1598,7 +1597,6 @@ public class Jvm {
      * @return the unaccounted disabled JVM options, null otherwise.
      */
     public String getUnaccountedDisabledOptions() {
-        String unaccountedDisabledOptions = null;
         String accountedDisabledOptions = "-XX:-HeapDumpOnOutOfMemoryError -XX:-BackgroundCompilation "
                 + "-XX:-PrintGCDetails -XX:-UseParNewGC -XX:-CMSClassUnloadingEnabled "
                 + "-XX:-PrintGCCause -XX:-UseBiasedLocking -XX:-UseCompressedOops "
@@ -1607,16 +1605,11 @@ public class Jvm {
                 + "-XX:-PrintAdaptiveSizePolicy -XX:-CMSParallelInitialMarkEnabled -XX:-CMSParallelRemarkEnabled "
                 + "-XX:-UseAdaptiveSizePolicy";
 
-        ArrayList<String> disabledOptions = getDisabledOptions();
-        Iterator<String> iterator = disabledOptions.iterator();
-        while (iterator.hasNext()) {
-            String disabledOption = iterator.next();
+        String unaccountedDisabledOptions = null;
+        for (String disabledOption : getDisabledOptions()) {
             if (accountedDisabledOptions.lastIndexOf(disabledOption) == -1) {
-                if (unaccountedDisabledOptions == null) {
-                    unaccountedDisabledOptions = disabledOption;
-                } else {
-                    unaccountedDisabledOptions = unaccountedDisabledOptions + ", " + disabledOption;
-                }
+				unaccountedDisabledOptions = unaccountedDisabledOptions == null ? disabledOption
+						: unaccountedDisabledOptions + ", " + disabledOption;
             }
         }
         return unaccountedDisabledOptions;
@@ -1633,7 +1626,6 @@ public class Jvm {
      * @return the option if it exists, null otherwise.
      */
     public String getUseAdaptiveSizePolicyDisabledOption() {
-        String regex = "(-XX:-UseAdaptiveSizePolicy)";
-        return getJvmOption(regex);
+        return getJvmOption("(-XX:-UseAdaptiveSizePolicy)");
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/util/jdk/unified/UnifiedUtil.java
+++ b/src/main/java/org/eclipselabs/garbagecat/util/jdk/unified/UnifiedUtil.java
@@ -13,11 +13,10 @@
 package org.eclipselabs.garbagecat.util.jdk.unified;
 
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipselabs.garbagecat.util.GcUtil;
-import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
+import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 
 /**
  * <p>
@@ -27,52 +26,50 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class UnifiedUtil {
+public final class UnifiedUtil {
+	
+	private UnifiedUtil() {
+		super();
+	}
 
     /**
      * @param eventTypes
      *            The JVM event types.
-     * @return True if the JVM events indicate unified logging (JDK9+), false otherwise.
+     * @return <code>true</code> if the JVM events indicate unified logging (JDK9+), false otherwise.
      */
-    public static final boolean isUnifiedLogging(List<JdkUtil.LogEventType> eventTypes) {
-        boolean isUnifiedLogging = false;
-        if (eventTypes.size() > 0) {
-            Iterator<JdkUtil.LogEventType> iterator = eventTypes.iterator();
-            while (iterator.hasNext() && !isUnifiedLogging) {
-                JdkUtil.LogEventType eventType = iterator.next();
-                switch (eventType) {
-                case HEAP_ADDRESS:
-                case HEAP_REGION_SIZE:
-                case UNIFIED_APPLICATION_STOPPED_TIME:
-                case UNIFIED_BLANK_LINE:
-                case UNIFIED_CONCURRENT:
-                case UNIFIED_CMS_INITIAL_MARK:
-                case UNIFIED_G1_CLEANUP:
-                case UNIFIED_G1_INFO:
-                case UNIFIED_G1_MIXED_PAUSE:
-                case UNIFIED_G1_YOUNG_INITIAL_MARK:
-                case UNIFIED_G1_YOUNG_PAUSE:
-                case UNIFIED_G1_YOUNG_PREPARE_MIXED:
-                case UNIFIED_OLD:
-                case UNIFIED_REMARK:
-                case UNIFIED_PARALLEL_COMPACTING_OLD:
-                case UNIFIED_PARALLEL_SCAVENGE:
-                case UNIFIED_PAR_NEW:
-                case UNIFIED_SERIAL_NEW:
-                case UNIFIED_SERIAL_OLD:
-                case UNIFIED_YOUNG:
-                case USING_CMS:
-                case USING_G1:
-                case USING_SHENANDOAH:
-                case USING_PARALLEL:
-                case USING_SERIAL:
-                    isUnifiedLogging = true;
-                    break;
-                default:
-                }
-            }
-        }
-        return isUnifiedLogging;
+    public static final boolean isUnifiedLogging(List<LogEventType> eventTypes) {
+        for (LogEventType eventType : eventTypes) {
+		    switch (eventType) {
+		    case HEAP_ADDRESS:
+		    case HEAP_REGION_SIZE:
+		    case UNIFIED_APPLICATION_STOPPED_TIME:
+		    case UNIFIED_BLANK_LINE:
+		    case UNIFIED_CONCURRENT:
+		    case UNIFIED_CMS_INITIAL_MARK:
+		    case UNIFIED_G1_CLEANUP:
+		    case UNIFIED_G1_INFO:
+		    case UNIFIED_G1_MIXED_PAUSE:
+		    case UNIFIED_G1_YOUNG_INITIAL_MARK:
+		    case UNIFIED_G1_YOUNG_PAUSE:
+		    case UNIFIED_G1_YOUNG_PREPARE_MIXED:
+		    case UNIFIED_OLD:
+		    case UNIFIED_REMARK:
+		    case UNIFIED_PARALLEL_COMPACTING_OLD:
+		    case UNIFIED_PARALLEL_SCAVENGE:
+		    case UNIFIED_PAR_NEW:
+		    case UNIFIED_SERIAL_NEW:
+		    case UNIFIED_SERIAL_OLD:
+		    case UNIFIED_YOUNG:
+		    case USING_CMS:
+		    case USING_G1:
+		    case USING_SHENANDOAH:
+		    case USING_PARALLEL:
+		    case USING_SERIAL:
+		        return true;
+		    default:
+		    }
+		}
+        return false;
     }
 
     /**

--- a/src/test/java/org/eclipselabs/garbagecat/TestMain.java
+++ b/src/test/java/org/eclipselabs/garbagecat/TestMain.java
@@ -12,23 +12,38 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_HELP_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_HELP_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_JVMOPTIONS_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_JVMOPTIONS_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_LATEST_VERSION_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_LATEST_VERSION_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_OUTPUT_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_OUTPUT_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_PREPROCESS_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_PREPROCESS_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_REORDER_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_REORDER_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_STARTDATETIME_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_STARTDATETIME_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_THRESHOLD_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_THRESHOLD_SHORT;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_VERSION_LONG;
+import static org.eclipselabs.garbagecat.util.Constants.OPTION_VERSION_SHORT;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
 
 import org.apache.commons.cli.CommandLine;
-import org.eclipselabs.garbagecat.util.Constants;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class TestMain {
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+class TestMain {
 
     @Test
-    public void testShortOptions() throws Exception {
+    void testShortOptions(@TempDir File temporaryFolder) throws Exception {
         // Method arguments
         String[] args = new String[] { //
                 "-h", //
@@ -45,32 +60,25 @@ public class TestMain {
                 "-v", //
                 "-l", //
                 // Instead of a file, use a location sure to exist.
-                temporaryFolder.getRoot().getAbsolutePath() //
+                temporaryFolder.getAbsolutePath() //
         };
         CommandLine cmd = OptionsParser.parseOptions(args);
         assertNotNull(cmd);
-        assertTrue("'-" + Constants.OPTION_HELP_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_HELP_SHORT));
-        assertTrue("'-" + Constants.OPTION_JVMOPTIONS_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_JVMOPTIONS_SHORT));
-        assertTrue("'-" + Constants.OPTION_PREPROCESS_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_PREPROCESS_SHORT));
-        assertTrue("'-" + Constants.OPTION_STARTDATETIME_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_STARTDATETIME_SHORT));
-        assertTrue("'-" + Constants.OPTION_THRESHOLD_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_THRESHOLD_SHORT));
-        assertTrue("'-" + Constants.OPTION_REORDER_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_REORDER_SHORT));
-        assertTrue("'-" + Constants.OPTION_OUTPUT_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_OUTPUT_SHORT));
-        assertTrue("'-" + Constants.OPTION_VERSION_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_VERSION_SHORT));
-        assertTrue("'-" + Constants.OPTION_LATEST_VERSION_SHORT + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_LATEST_VERSION_SHORT));
+        assertHasOption(cmd, OPTION_HELP_SHORT);
+        assertHasOption(cmd, OPTION_JVMOPTIONS_SHORT);
+        assertHasOption(cmd, OPTION_PREPROCESS_SHORT);
+        assertHasOption(cmd, OPTION_STARTDATETIME_SHORT);
+        assertHasOption(cmd, OPTION_THRESHOLD_SHORT);
+        assertHasOption(cmd, OPTION_REORDER_SHORT);
+        assertHasOption(cmd, OPTION_OUTPUT_SHORT);
+        assertHasOption(cmd, OPTION_VERSION_SHORT);
+        assertHasOption(cmd, OPTION_LATEST_VERSION_SHORT);
+        assertHasOption(cmd, OPTION_LATEST_VERSION_SHORT);
     }
 
-    @Test
-    public void testLongOptions() throws Exception {
+
+	@Test
+    void testLongOptions(@TempDir File tmpFolder) throws Exception {
         // Method arguments
         String[] args = new String[] { //
                 "--help", //
@@ -87,49 +95,42 @@ public class TestMain {
                 "--version", //
                 "--latest", //
                 // Instead of a file, use a location sure to exist.
-                temporaryFolder.getRoot().getAbsolutePath() //
+                tmpFolder.getAbsolutePath() //
         };
         CommandLine cmd = OptionsParser.parseOptions(args);
         assertNotNull(cmd);
-        assertTrue("'-" + Constants.OPTION_HELP_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_HELP_LONG));
-        assertTrue("'-" + Constants.OPTION_JVMOPTIONS_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_JVMOPTIONS_LONG));
-        assertTrue("'-" + Constants.OPTION_PREPROCESS_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_PREPROCESS_LONG));
-        assertTrue("'-" + Constants.OPTION_STARTDATETIME_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_STARTDATETIME_LONG));
-        assertTrue("'-" + Constants.OPTION_THRESHOLD_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_THRESHOLD_LONG));
-        assertTrue("'-" + Constants.OPTION_REORDER_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_REORDER_LONG));
-        assertTrue("'-" + Constants.OPTION_OUTPUT_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_OUTPUT_LONG));
-        assertTrue("'-" + Constants.OPTION_VERSION_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_VERSION_LONG));
-        assertTrue("'-" + Constants.OPTION_LATEST_VERSION_LONG + "' is a valid option",
-                cmd.hasOption(Constants.OPTION_LATEST_VERSION_LONG));
+		assertHasOption(cmd, OPTION_HELP_LONG);
+		assertHasOption(cmd, OPTION_JVMOPTIONS_LONG);
+		assertHasOption(cmd, OPTION_PREPROCESS_LONG);
+		assertHasOption(cmd, OPTION_STARTDATETIME_LONG);
+		assertHasOption(cmd, OPTION_THRESHOLD_LONG);
+		assertHasOption(cmd, OPTION_REORDER_LONG);
+		assertHasOption(cmd, OPTION_OUTPUT_LONG);
+		assertHasOption(cmd, OPTION_VERSION_LONG);
+		assertHasOption(cmd, OPTION_LATEST_VERSION_LONG);
     }
 
     @Test
-    public void testShortHelpOption() throws Exception {
+    void testShortHelpOption() throws Exception {
         // Method arguments
         String[] args = new String[] { "-h" };
         CommandLine cmd = OptionsParser.parseOptions(args);
         // CommandLine will be null if only the help option is passed in.
         assertNull(cmd);
-        assertTrue("'-h' is a valid option", true);
     }
 
     @Test
-    public void testLongHelpOption() throws Exception {
+    void testLongHelpOption() throws Exception {
         // Method arguments
         String[] args = new String[] { "--help" };
         // Pass null object since parseOptions is static
         CommandLine cmd = OptionsParser.parseOptions(args);
         // CommandLine will be null if only the help option is passed in.
         assertNull(cmd);
-        assertTrue("'--help' is a valid option", true);
+    }
+
+    private static void assertHasOption(CommandLine cmd, String option) {
+    	assertTrue(cmd.hasOption(option), "'-" + option + "' is a valid option");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestApplicationLoggingEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestApplicationLoggingEvent.java
@@ -12,130 +12,117 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType.APPLICATION_LOGGING;
+import static org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType.THREAD_DUMP;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestApplicationLoggingEvent {
+class TestApplicationLoggingEvent {
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "00:02:05,067 INFO  [STDOUT] log4j: setFile ended";
-        assertFalse(JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+		assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)),
+				APPLICATION_LOGGING + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testHhMmSsError() {
+    void testHhMmSsError() {
         String logLine = "00:02:05,067 INFO  [STDOUT] log4j: setFile ended";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
     }
 
     @Test
-    public void testHhMmSsInfo() {
+    void testHhMmSsInfo() {
         String logLine = "10:58:38,610 ERROR [ContainerBase] Servlet.service() for servlet "
                 + "HttpControllerServletXml threw exception java.lang.OutOfMemoryError: Java heap space";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
     }
 
     @Test
-    public void testHhMmSsWarn() {
+    void testHhMmSsWarn() {
         String logLine = "11:05:57,018 WARN  [JBossManagedConnectionPool] Throwable while attempting to "
                 + "get a new connection: null";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
     }
 
     @Test
-    public void testYyyyMmDd() {
+    void testYyyyMmDd() {
         String logLine = "2010-03-25 17:00:51,581 ERROR [example.com.servlet.DynamoServlet] "
                 + "getParameter(message.order) can't access property order in class java.lang.String";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
-    }
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
+	}
 
     @Test
-    public void testException() {
+    void testException() {
         String logLine = "java.sql.SQLException: pingDatabase failed status=-1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
     }
 
     @Test
-    public void testOracleException() {
+    void testOracleException() {
         String logLine = "ORA-12514, TNS:listener does not currently know of service requested in connect descriptor";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_LOGGING.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + APPLICATION_LOGGING + ".");
     }
 
     @Test
-    public void testStackTrace() {
+    void testStackTrace() {
         String logLine = "\tat oracle.jdbc.driver.SQLStateMapping.newSQLException(SQLStateMapping.java:70)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testStackTraceCausedBy() {
+    void testStackTraceCausedBy() {
         String logLine = "Caused by: java.sql.SQLException: Listener refused the connection with the following error:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testStackTraceEllipses() {
+    void testStackTraceEllipses() {
         String logLine = "\t... 56 more";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossDivider() {
+    void testJBossDivider() {
         String logLine = "=========================================================================";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossBootstrapEnvironement() {
+    void testJBossBootstrapEnvironement() {
         String logLine = "  JBoss Bootstrap Environment";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossHome() {
+    void testJBossHome() {
         String logLine = "  JBOSS_HOME: /opt/jboss/jboss-eap-4.3/jboss-as";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossJava() {
+    void testJBossJava() {
         String logLine = "  JAVA: /opt/java/bin/java";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossClasspath() {
+    void testJBossClasspath() {
         String logLine = "  CLASSPATH: /opt/jboss/jboss-eap-4.3/jboss-as/bin/run.jar:/opt/java/lib/tools.jar";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+		assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 
     @Test
-    public void testJBossJavaOptsWarning() {
+    void testJBossJavaOptsWarning() {
         String logLine = "JAVA_OPTS already set in environment; overriding default settings with values: -d64";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ApplicationLoggingEvent.match(logLine));
+        assertTrue(ApplicationLoggingEvent.match(logLine), "Log line not recognized as " + THREAD_DUMP + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestBlankLineEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestBlankLineEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,21 +27,19 @@ public class TestBlankLineEvent {
     @Test
     public void testParseLogLine() {
         String logLine = "";
-        assertTrue(JdkUtil.LogEventType.BLANK_LINE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof BlankLineEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof BlankLineEvent, JdkUtil.LogEventType.BLANK_LINE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "";
-        assertFalse(JdkUtil.LogEventType.BLANK_LINE.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.BLANK_LINE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.BLANK_LINE.toString() + ".",
-                BlankLineEvent.match(logLine));
+        assertTrue(BlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.BLANK_LINE.toString() + ".");
     }
+
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestBlankLineEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestBlankLineEvent.java
@@ -22,22 +22,22 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestBlankLineEvent {
+class TestBlankLineEvent {
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof BlankLineEvent, JdkUtil.LogEventType.BLANK_LINE.toString() + " not parsed.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.BLANK_LINE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "";
         assertTrue(BlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.BLANK_LINE.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestJvmRun.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestJvmRun.java
@@ -38,14 +38,14 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJvmRun {
+class TestJvmRun {
 
     /**
      * Test passing JVM options on the command line.
      * 
      */
     @Test
-    public void testJvmOptionsPassedInOnCommandLine() {
+    void testJvmOptionsPassedInOnCommandLine() {
         String options = "MGM was here!";
         GcManager gcManager = new GcManager();
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(options, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
@@ -57,7 +57,7 @@ public class TestJvmRun {
      * Test if -XX:+PrintReferenceGC enabled by inspecting logging events.
      */
     @Test
-    public void testPrintReferenceGCByLogging() {
+    void testPrintReferenceGCByLogging() {
         String jvmOptions = null;
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -73,7 +73,7 @@ public class TestJvmRun {
      * Test if -XX:+PrintReferenceGC enabled by inspecting jvm options.
      */
     @Test
-    public void testPrintReferenceGCByOptions() {
+    void testPrintReferenceGCByOptions() {
         String jvmOptions = "-Xss128k -XX:+PrintReferenceGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -86,7 +86,7 @@ public class TestJvmRun {
      * Test if -XX:+PrintStringDeduplicationStatistics enabled by inspecting jvm options.
      */
     @Test
-    public void testPrintStringDeduplicationStatistics() {
+    void testPrintStringDeduplicationStatistics() {
         String jvmOptions = "-Xss128k -XX:+PrintStringDeduplicationStatistics -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -99,7 +99,7 @@ public class TestJvmRun {
      * Test if PrintGCDetails disabled with -XX:-PrintGCDetails.
      */
     @Test
-    public void testPrintGCDetailsDisabled() {
+    void testPrintGCDetailsDisabled() {
         String jvmOptions = "-Xss128k -XX:-PrintGCDetails -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -113,7 +113,7 @@ public class TestJvmRun {
      * Test if PAR_NEW collector disabled with -XX:-UseParNewGC.
      */
     @Test
-    public void testUseParNewGcDisabled() {
+    void testUseParNewGcDisabled() {
         String jvmOptions = "-Xss128k -XX:-UseParNewGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -126,7 +126,7 @@ public class TestJvmRun {
      * Test percent swap free at threshold.
      */
     @Test
-    public void testPercentSwapFreeAtThreshold() {
+    void testPercentSwapFreeAtThreshold() {
         String jvmOptions = null;
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -142,7 +142,7 @@ public class TestJvmRun {
      * Test percent swap free below threshold.
      */
     @Test
-    public void testPercentSwapFreeBelowThreshold() {
+    void testPercentSwapFreeBelowThreshold() {
         String jvmOptions = null;
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -158,7 +158,7 @@ public class TestJvmRun {
      * Test physical memory equals heap + perm/metaspace.
      */
     @Test
-    public void testPhysicalMemoryEqualJvmAllocation() {
+    void testPhysicalMemoryEqualJvmAllocation() {
         String jvmOptions = "-Xmx1024M -XX:MaxPermSize=128M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -172,7 +172,7 @@ public class TestJvmRun {
      * Test physical memory less than heap + perm/metaspace.
      */
     @Test
-    public void testPhysicalMemoryLessThanJvmAllocation() {
+    void testPhysicalMemoryLessThanJvmAllocation() {
         String jvmOptions = "-Xmx1024M -XX:MaxPermSize=128M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -183,7 +183,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testLastTimestampNoEvents() {
+    void testLastTimestampNoEvents() {
         GcManager gcManager = new GcManager();
         gcManager.store(null, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
@@ -191,7 +191,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testSummaryStatsParallel() {
+    void testSummaryStatsParallel() {
         File testFile = TestUtil.getFile("dataset1.txt");
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
@@ -213,7 +213,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testSummaryStatsParNew() {
+    void testSummaryStatsParNew() {
         File testFile = TestUtil.getFile("dataset2.txt");
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
@@ -237,7 +237,7 @@ public class TestJvmRun {
      * Test parsing logging with -XX:+PrintGCApplicationConcurrentTime and -XX:+PrintGCApplicationStoppedTime output.
      */
     @Test
-    public void testParseLoggingWithApplicationTime() {
+    void testParseLoggingWithApplicationTime() {
         File testFile = TestUtil.getFile("dataset3.txt");
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
@@ -258,7 +258,7 @@ public class TestJvmRun {
      * .
      */
     @Test
-    public void testSplitParallelOldCompactingEventLogging() {
+    void testSplitParallelOldCompactingEventLogging() {
         File testFile = TestUtil.getFile("dataset28.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -276,7 +276,7 @@ public class TestJvmRun {
      * split across 2 lines.
      */
     @Test
-    public void testCombinedCmsConcurrentApplicationConcurrentTimeLogging() {
+    void testCombinedCmsConcurrentApplicationConcurrentTimeLogging() {
         File testFile = TestUtil.getFile("dataset19.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -291,7 +291,7 @@ public class TestJvmRun {
      * across 2 lines.
      */
     @Test
-    public void testCombinedCmsConcurrentApplicationStoppedTimeLogging() {
+    void testCombinedCmsConcurrentApplicationStoppedTimeLogging() {
         File testFile = TestUtil.getFile("dataset27.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -303,7 +303,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testRemoveBlankLines() {
+    void testRemoveBlankLines() {
         File testFile = TestUtil.getFile("dataset20.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -319,7 +319,7 @@ public class TestJvmRun {
      * Test <code>DateStampPreprocessAction</code>.
      */
     @Test
-    public void testDateStampPreprocessActionLogging() {
+    void testDateStampPreprocessActionLogging() {
         File testFile = TestUtil.getFile("dataset25.txt");
         GcManager gcManager = new GcManager();
         Calendar calendar = Calendar.getInstance();
@@ -338,7 +338,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testSummaryStatsStoppedTime() {
+    void testSummaryStatsStoppedTime() {
         File testFile = TestUtil.getFile("dataset41.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -365,7 +365,7 @@ public class TestJvmRun {
     }
 
     @Test
-    public void testSummaryStatsUnifiedStoppedTime() {
+    void testSummaryStatsUnifiedStoppedTime() {
         File testFile = TestUtil.getFile("dataset182.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -399,7 +399,7 @@ public class TestJvmRun {
      * 
      */
     @Test
-    public void testExplicitGcAnalsysisParallelSerialOld() {
+    void testExplicitGcAnalsysisParallelSerialOld() {
         File testFile = TestUtil.getFile("dataset56.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -417,7 +417,7 @@ public class TestJvmRun {
      * 
      */
     @Test
-    public void testHeaders() {
+    void testHeaders() {
         File testFile = TestUtil.getFile("dataset59.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -436,7 +436,7 @@ public class TestJvmRun {
      * 
      */
     @Test
-    public void testPrintTenuringDistributionPreprocessActionNoSpaceAfterGc() {
+    void testPrintTenuringDistributionPreprocessActionNoSpaceAfterGc() {
         File testFile = TestUtil.getFile("dataset66.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -450,7 +450,7 @@ public class TestJvmRun {
      * Test application stopped time w/o timestamps.
      */
     @Test
-    public void testApplicationStoppedTimeNoTimestamps() {
+    void testApplicationStoppedTimeNoTimestamps() {
         File testFile = TestUtil.getFile("dataset96.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -477,7 +477,7 @@ public class TestJvmRun {
      * dataset41.txt with 1000 seconds added to each timestamp.
      */
     @Test
-    public void testSummaryStatsPartialLog() {
+    void testSummaryStatsPartialLog() {
         File testFile = TestUtil.getFile("dataset98.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -506,7 +506,7 @@ public class TestJvmRun {
      * Test summary stats with batching.
      */
     @Test
-    public void testStoppedTime() {
+    void testStoppedTime() {
         File testFile = TestUtil.getFile("dataset103.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -536,7 +536,7 @@ public class TestJvmRun {
      * Test no gc logging events, only stopped time events.
      */
     @Test
-    public void testStoppedTimeWithoutGcEvents() {
+    void testStoppedTimeWithoutGcEvents() {
         File testFile = TestUtil.getFile("dataset108.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -550,7 +550,7 @@ public class TestJvmRun {
      * Test identifying <code>ParNewEvent</code> running in incremental mode.
      */
     @Test
-    public void testPrintGcApplicationConcurrentTimeAnalysis() {
+    void testPrintGcApplicationConcurrentTimeAnalysis() {
         File testFile = TestUtil.getFile("dataset104.txt");
         Jvm jvm = new Jvm(null, null);
         GcManager gcManager = new GcManager();

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestJvmRun.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestJvmRun.java
@@ -14,10 +14,10 @@ package org.eclipselabs.garbagecat.domain;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.BYTES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import org.eclipselabs.garbagecat.util.jdk.Analysis;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -50,7 +50,7 @@ public class TestJvmRun {
         GcManager gcManager = new GcManager();
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(options, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue("JVM options passed in are missing or have changed.", jvmRun.getJvm().getOptions().equals(options));
+        assertTrue(jvmRun.getJvm().getOptions().equals(options), "JVM options passed in are missing or have changed.");
     }
 
     /**
@@ -66,8 +66,7 @@ public class TestJvmRun {
         eventTypes.add(LogEventType.REFERENCE_GC);
         jvmRun.setEventTypes(eventTypes);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED), Analysis.WARN_PRINT_REFERENCE_GC_ENABLED + " analysis not identified.");
     }
 
     /**
@@ -80,8 +79,7 @@ public class TestJvmRun {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_REFERENCE_GC_ENABLED), Analysis.WARN_PRINT_REFERENCE_GC_ENABLED + " analysis not identified.");
     }
 
     /**
@@ -94,8 +92,7 @@ public class TestJvmRun {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_STRING_DEDUP_STATS_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_STRING_DEDUP_STATS_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_STRING_DEDUP_STATS_ENABLED), Analysis.WARN_PRINT_STRING_DEDUP_STATS_ENABLED + " analysis not identified.");
     }
 
     /**
@@ -108,10 +105,8 @@ public class TestJvmRun {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED));
-        assertFalse(Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED), Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING), Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis incorrectly identified.");
     }
 
     /**
@@ -124,8 +119,7 @@ public class TestJvmRun {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_CMS_PAR_NEW_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_PAR_NEW_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_PAR_NEW_DISABLED), Analysis.WARN_CMS_PAR_NEW_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -140,9 +134,8 @@ public class TestJvmRun {
         jvmRun.getJvm().setSwap(new Memory(1000, BYTES));
         jvmRun.getJvm().setSwapFree(new Memory(946, BYTES));
         jvmRun.doAnalysis();
-        assertEquals("Percent swap free not correct.", 95, jvmRun.getJvm().getPercentSwapFree());
-        assertFalse(Analysis.INFO_SWAPPING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SWAPPING));
+        assertEquals((long) 95,jvmRun.getJvm().getPercentSwapFree(),"Percent swap free not correct.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_SWAPPING), Analysis.INFO_SWAPPING + " analysis incorrectly identified.");
     }
 
     /**
@@ -157,9 +150,8 @@ public class TestJvmRun {
         jvmRun.getJvm().setSwap(new Memory(1000, BYTES));
         jvmRun.getJvm().setSwapFree(new Memory(945, BYTES));
         jvmRun.doAnalysis();
-        assertEquals("Percent swap free not correct.", 94, jvmRun.getJvm().getPercentSwapFree());
-        assertTrue(Analysis.INFO_SWAPPING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SWAPPING));
+        assertEquals((long) 94,jvmRun.getJvm().getPercentSwapFree(),"Percent swap free not correct.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_SWAPPING), Analysis.INFO_SWAPPING + " analysis not identified.");
     }
 
     /**
@@ -173,8 +165,7 @@ public class TestJvmRun {
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.getJvm().setPhysicalMemory(new Memory(1207959552, BYTES));
         jvmRun.doAnalysis();
-        assertFalse(Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY), Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.");
     }
 
     /**
@@ -188,8 +179,7 @@ public class TestJvmRun {
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.getJvm().setPhysicalMemory(new Memory(1207959551, BYTES));
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_PHYSICAL_MEMORY + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY), Analysis.ERROR_PHYSICAL_MEMORY + " analysis not identified.");
     }
 
     @Test
@@ -197,7 +187,7 @@ public class TestJvmRun {
         GcManager gcManager = new GcManager();
         gcManager.store(null, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertNull("Last GC event not correct.", jvmRun.getLastGcEvent());
+        assertNull(jvmRun.getLastGcEvent(),"Last GC event not correct.");
     }
 
     @Test
@@ -206,24 +196,20 @@ public class TestJvmRun {
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Max young space not calculated correctly.", kilobytes(248192), jvmRun.getMaxYoungSpace());
-        assertEquals("Max old space not calculated correctly.", kilobytes(786432), jvmRun.getMaxOldSpace());
-        assertEquals("NewRatio not calculated correctly.", 3, jvmRun.getNewRatio());
-        assertEquals("Max heap space not calculated correctly.", kilobytes(1034624), jvmRun.getMaxHeapSpace());
-        assertEquals("Max heap occupancy not calculated correctly.", kilobytes(1013058), jvmRun.getMaxHeapOccupancy());
-        assertEquals("Max pause not calculated correctly.", 2782, jvmRun.getMaxGcPause());
-        assertEquals("Max perm gen space not calculated correctly.", 159936, jvmRun.getMaxPermSpace());
-        assertEquals("Max perm gen occupancy not calculated correctly.", 76972, jvmRun.getMaxPermOccupancy());
-        assertEquals("Total GC duration not calculated correctly.", 5615, jvmRun.getTotalGcPause());
-        assertEquals("GC Event count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SCAVENGE));
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD));
-        assertTrue(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING));
-        assertTrue(Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL));
+        assertEquals(kilobytes(248192),jvmRun.getMaxYoungSpace(),"Max young space not calculated correctly.");
+        assertEquals(kilobytes(786432),jvmRun.getMaxOldSpace(),"Max old space not calculated correctly.");
+        assertEquals((long) 3,jvmRun.getNewRatio(),"NewRatio not calculated correctly.");
+        assertEquals(kilobytes(1034624),jvmRun.getMaxHeapSpace(),"Max heap space not calculated correctly.");
+        assertEquals(kilobytes(1013058),jvmRun.getMaxHeapOccupancy(),"Max heap occupancy not calculated correctly.");
+        assertEquals(2782,jvmRun.getMaxGcPause(),"Max pause not calculated correctly.");
+        assertEquals(159936,jvmRun.getMaxPermSpace(),"Max perm gen space not calculated correctly.");
+        assertEquals(76972,jvmRun.getMaxPermOccupancy(),"Max perm gen occupancy not calculated correctly.");
+        assertEquals((long) 5615,jvmRun.getTotalGcPause(),"Total GC duration not calculated correctly.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"GC Event count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SCAVENGE), JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD), JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING), Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL), Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.");
     }
 
     @Test
@@ -232,22 +218,19 @@ public class TestJvmRun {
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Max young space not calculated correctly.", kilobytes(348864), jvmRun.getMaxYoungSpace());
-        assertEquals("Max old space not calculated correctly.", kilobytes(699392), jvmRun.getMaxOldSpace());
-        assertEquals("NewRatio not calculated correctly.", 2, jvmRun.getNewRatio());
-        assertEquals("Max heap space not calculated correctly.", kilobytes(1048256), jvmRun.getMaxHeapSpace());
-        assertEquals("Max heap occupancy not calculated correctly.", kilobytes(424192), jvmRun.getMaxHeapOccupancy());
-        assertEquals("Max pause not calculated correctly.", 1070, jvmRun.getMaxGcPause());
-        assertEquals("Max perm gen space not calculated correctly.", 99804, jvmRun.getMaxPermSpace());
-        assertEquals("Max perm gen occupancy not calculated correctly.", 60155, jvmRun.getMaxPermOccupancy());
-        assertEquals("Total GC duration not calculated correctly.", 1283, jvmRun.getTotalGcPause());
-        assertEquals("GC Event count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.PAR_NEW.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue(JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(kilobytes(348864),jvmRun.getMaxYoungSpace(),"Max young space not calculated correctly.");
+        assertEquals(kilobytes(699392),jvmRun.getMaxOldSpace(),"Max old space not calculated correctly.");
+        assertEquals((long) 2,jvmRun.getNewRatio(),"NewRatio not calculated correctly.");
+        assertEquals(kilobytes(1048256),jvmRun.getMaxHeapSpace(),"Max heap space not calculated correctly.");
+        assertEquals(kilobytes(424192),jvmRun.getMaxHeapOccupancy(),"Max heap occupancy not calculated correctly.");
+        assertEquals(1070,jvmRun.getMaxGcPause(),"Max pause not calculated correctly.");
+        assertEquals(99804,jvmRun.getMaxPermSpace(),"Max perm gen space not calculated correctly.");
+        assertEquals(60155,jvmRun.getMaxPermOccupancy(),"Max perm gen occupancy not calculated correctly.");
+        assertEquals((long) 1283,jvmRun.getTotalGcPause(),"Total GC duration not calculated correctly.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"GC Event count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), JdkUtil.LogEventType.PAR_NEW.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     /**
@@ -259,19 +242,15 @@ public class TestJvmRun {
         GcManager gcManager = new GcManager();
         gcManager.store(testFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Max young space not calculated correctly.", kilobytes(1100288), jvmRun.getMaxYoungSpace());
-        assertEquals("Max old space not calculated correctly.", kilobytes(1100288), jvmRun.getMaxOldSpace());
-        assertEquals("NewRatio not calculated correctly.", 1, jvmRun.getNewRatio());
-        assertEquals("Event count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Should not be any unidentified log lines.", 0, jvmRun.getUnidentifiedLogLines().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME));
-        assertTrue(Analysis.INFO_NEW_RATIO_INVERTED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_NEW_RATIO_INVERTED));
+        assertEquals(kilobytes(1100288),jvmRun.getMaxYoungSpace(),"Max young space not calculated correctly.");
+        assertEquals(kilobytes(1100288),jvmRun.getMaxOldSpace(),"Max old space not calculated correctly.");
+        assertEquals((long) 1,jvmRun.getNewRatio(),"NewRatio not calculated correctly.");
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(0,jvmRun.getUnidentifiedLogLines().size(),"Should not be any unidentified log lines.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_NEW_RATIO_INVERTED), Analysis.INFO_NEW_RATIO_INVERTED + " analysis not identified.");
     }
 
     /**
@@ -285,15 +264,11 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD));
-        assertTrue(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED));
-        assertTrue(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED), Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED), Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.");
     }
 
     /**
@@ -307,9 +282,8 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -323,11 +297,9 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 
     @Test
@@ -337,11 +309,9 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME), Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.");
 
     }
 
@@ -363,9 +333,8 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, calendar.getTime());
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
     }
 
     @Test
@@ -375,27 +344,24 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.APPLICATION_STOPPED_TIME));
-        assertEquals("GC Event count not correct.", 2, jvmRun.getEventTypes().size());
-        assertEquals("GC pause total not correct.", 62, jvmRun.getTotalGcPause());
-        assertEquals("GC first timestamp not correct.", 2192, jvmRun.getFirstGcEvent().getTimestamp());
-        assertEquals("GC last timestamp not correct.", 2847, jvmRun.getLastGcEvent().getTimestamp());
-        assertEquals("GC last duration not correct.", 41453, jvmRun.getLastGcEvent().getDuration());
-        assertEquals("Stopped Time event count not correct.", 6, jvmRun.getStoppedTimeEventCount());
-        assertEquals("Stopped time total not correct.", 1064, jvmRun.getTotalStoppedTime());
-        assertEquals("Stopped first timestamp not correct.", 964, jvmRun.getFirstStoppedEvent().getTimestamp());
-        assertEquals("Stopped last timestamp not correct.", 3884, jvmRun.getLastStoppedEvent().getTimestamp());
-        assertEquals("Stopped last duration not correct.", 1000688, jvmRun.getLastStoppedEvent().getDuration());
-        assertEquals("JVM first event timestamp not correct.", 964, jvmRun.getFirstEvent().getTimestamp());
-        assertEquals("JVM last event timestamp not correct.", 3884, jvmRun.getLastEvent().getTimestamp());
-        assertEquals("JVM run duration not correct.", 4884, jvmRun.getJvmRunDuration());
-        assertEquals("GC throughput not correct.", 99, jvmRun.getGcThroughput());
-        assertEquals("Stopped time throughput not correct.", 78, jvmRun.getStoppedTimeThroughput());
-        assertTrue(Analysis.WARN_GC_STOPPED_RATIO + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO));
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.APPLICATION_STOPPED_TIME), JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + " not identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"GC Event count not correct.");
+        assertEquals((long) 62,jvmRun.getTotalGcPause(),"GC pause total not correct.");
+        assertEquals((long) 2192,jvmRun.getFirstGcEvent().getTimestamp(),"GC first timestamp not correct.");
+        assertEquals((long) 2847,jvmRun.getLastGcEvent().getTimestamp(),"GC last timestamp not correct.");
+        assertEquals(41453,jvmRun.getLastGcEvent().getDuration(),"GC last duration not correct.");
+        assertEquals(6,jvmRun.getStoppedTimeEventCount(),"Stopped Time event count not correct.");
+        assertEquals(1064,jvmRun.getTotalStoppedTime(),"Stopped time total not correct.");
+        assertEquals((long) 964,jvmRun.getFirstStoppedEvent().getTimestamp(),"Stopped first timestamp not correct.");
+        assertEquals((long) 3884,jvmRun.getLastStoppedEvent().getTimestamp(),"Stopped last timestamp not correct.");
+        assertEquals(1000688,jvmRun.getLastStoppedEvent().getDuration(),"Stopped last duration not correct.");
+        assertEquals((long) 964,jvmRun.getFirstEvent().getTimestamp(),"JVM first event timestamp not correct.");
+        assertEquals((long) 3884,jvmRun.getLastEvent().getTimestamp(),"JVM last event timestamp not correct.");
+        assertEquals((long) 4884,jvmRun.getJvmRunDuration(),"JVM run duration not correct.");
+        assertEquals((long) 99,jvmRun.getGcThroughput(),"GC throughput not correct.");
+        assertEquals((long) 78,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO), Analysis.WARN_GC_STOPPED_RATIO + " analysis not identified.");
     }
 
     @Test
@@ -405,33 +371,27 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CONCURRENT));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_CLEANUP));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_APPLICATION_STOPPED_TIME));
-        assertEquals("GC Event count not correct.", 5, jvmRun.getEventTypes().size());
-        assertEquals("GC pause total not correct.", 24, jvmRun.getTotalGcPause());
-        assertEquals("GC first timestamp not correct.", 53, jvmRun.getFirstGcEvent().getTimestamp());
-        assertEquals("GC last timestamp not correct.", 167, jvmRun.getLastGcEvent().getTimestamp());
-        assertEquals("GC last duration not correct.", 362, jvmRun.getLastGcEvent().getDuration());
-        assertEquals("Stopped Time event count not correct.", 12, jvmRun.getStoppedTimeEventCount());
-        assertEquals("Stopped time total not correct.", 25, jvmRun.getTotalStoppedTime());
-        assertEquals("Stopped first timestamp not correct.", 29, jvmRun.getFirstStoppedEvent().getTimestamp());
-        assertEquals("Stopped last timestamp not correct.", 167, jvmRun.getLastStoppedEvent().getTimestamp());
-        assertEquals("Stopped last duration not correct.", 418, jvmRun.getLastStoppedEvent().getDuration());
-        assertEquals("JVM first event timestamp not correct.", 29, jvmRun.getFirstEvent().getTimestamp());
-        assertEquals("JVM last event timestamp not correct.", 167, jvmRun.getLastEvent().getTimestamp());
-        assertEquals("JVM run duration not correct.", 167, jvmRun.getJvmRunDuration());
-        assertEquals("GC throughput not correct.", 86, jvmRun.getGcThroughput());
-        assertEquals("Stopped time throughput not correct.", 85, jvmRun.getStoppedTimeThroughput());
-        assertFalse(Analysis.WARN_GC_STOPPED_RATIO + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO));
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CONCURRENT), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_CLEANUP), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_APPLICATION_STOPPED_TIME), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not identified.");
+        assertEquals(5,jvmRun.getEventTypes().size(),"GC Event count not correct.");
+        assertEquals((long) 24,jvmRun.getTotalGcPause(),"GC pause total not correct.");
+        assertEquals((long) 53,jvmRun.getFirstGcEvent().getTimestamp(),"GC first timestamp not correct.");
+        assertEquals((long) 167,jvmRun.getLastGcEvent().getTimestamp(),"GC last timestamp not correct.");
+        assertEquals(362,jvmRun.getLastGcEvent().getDuration(),"GC last duration not correct.");
+        assertEquals(12,jvmRun.getStoppedTimeEventCount(),"Stopped Time event count not correct.");
+        assertEquals(25,jvmRun.getTotalStoppedTime(),"Stopped time total not correct.");
+        assertEquals((long) 29,jvmRun.getFirstStoppedEvent().getTimestamp(),"Stopped first timestamp not correct.");
+        assertEquals((long) 167,jvmRun.getLastStoppedEvent().getTimestamp(),"Stopped last timestamp not correct.");
+        assertEquals(418,jvmRun.getLastStoppedEvent().getDuration(),"Stopped last duration not correct.");
+        assertEquals((long) 29,jvmRun.getFirstEvent().getTimestamp(),"JVM first event timestamp not correct.");
+        assertEquals((long) 167,jvmRun.getLastEvent().getTimestamp(),"JVM last event timestamp not correct.");
+        assertEquals((long) 167,jvmRun.getJvmRunDuration(),"JVM run duration not correct.");
+        assertEquals((long) 86,jvmRun.getGcThroughput(),"GC throughput not correct.");
+        assertEquals((long) 85,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO), Analysis.WARN_GC_STOPPED_RATIO + " analysis incorrectly identified.");
     }
 
     /**
@@ -445,15 +405,11 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SCAVENGE));
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_SERIAL_PARALLEL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_SERIAL_PARALLEL));
-        assertTrue(Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SCAVENGE), JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD), JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_SERIAL_PARALLEL), Analysis.WARN_EXPLICIT_GC_SERIAL_PARALLEL + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL), Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.");
     }
 
     /**
@@ -467,17 +423,12 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS));
-        assertTrue(JdkUtil.LogEventType.HEADER_MEMORY.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY));
-        assertTrue(JdkUtil.LogEventType.HEADER_VERSION.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_DISABLED));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS), JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY), JdkUtil.LogEventType.HEADER_MEMORY.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION), JdkUtil.LogEventType.HEADER_VERSION.toString() + " not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_DISABLED), Analysis.WARN_EXPLICIT_GC_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -491,9 +442,8 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
     }
 
     /**
@@ -506,20 +456,20 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("GC pause total not correct.", 2097, jvmRun.getTotalGcPause());
-        assertEquals("GC first timestamp not correct.", 16517, jvmRun.getFirstGcEvent().getTimestamp());
-        assertEquals("GC last timestamp not correct.", 31432, jvmRun.getLastGcEvent().getTimestamp());
-        assertEquals("GC last duration not correct.", 271019, jvmRun.getLastGcEvent().getDuration());
-        assertEquals("Stopped time total not correct.", 1830, jvmRun.getTotalStoppedTime());
-        assertEquals("Stopped first timestamp not correct.", 0, jvmRun.getFirstStoppedEvent().getTimestamp());
-        assertEquals("Stopped last timestamp not correct.", 0, jvmRun.getLastStoppedEvent().getTimestamp());
-        assertEquals("Stopped last duration not correct.", 50, jvmRun.getLastStoppedEvent().getDuration());
-        assertEquals("JVM first event timestamp not correct.", 16517, jvmRun.getFirstEvent().getTimestamp());
-        assertEquals("JVM last event timestamp not correct.", 31432, jvmRun.getLastEvent().getTimestamp());
-        assertEquals("JVM run duration not correct.", 31703, jvmRun.getJvmRunDuration());
-        assertEquals("GC throughput not correct.", 93, jvmRun.getGcThroughput());
-        assertEquals("Stopped time throughput not correct.", 94, jvmRun.getStoppedTimeThroughput());
-        assertEquals("Inverted parallelism event count not correct.", 0, jvmRun.getInvertedParallelismCount());
+        assertEquals((long) 2097,jvmRun.getTotalGcPause(),"GC pause total not correct.");
+        assertEquals((long) 16517,jvmRun.getFirstGcEvent().getTimestamp(),"GC first timestamp not correct.");
+        assertEquals((long) 31432,jvmRun.getLastGcEvent().getTimestamp(),"GC last timestamp not correct.");
+        assertEquals(271019,jvmRun.getLastGcEvent().getDuration(),"GC last duration not correct.");
+        assertEquals(1830,jvmRun.getTotalStoppedTime(),"Stopped time total not correct.");
+        assertEquals((long) 0,jvmRun.getFirstStoppedEvent().getTimestamp(),"Stopped first timestamp not correct.");
+        assertEquals((long) 0,jvmRun.getLastStoppedEvent().getTimestamp(),"Stopped last timestamp not correct.");
+        assertEquals(50,jvmRun.getLastStoppedEvent().getDuration(),"Stopped last duration not correct.");
+        assertEquals((long) 16517,jvmRun.getFirstEvent().getTimestamp(),"JVM first event timestamp not correct.");
+        assertEquals((long) 31432,jvmRun.getLastEvent().getTimestamp(),"JVM last event timestamp not correct.");
+        assertEquals((long) 31703,jvmRun.getJvmRunDuration(),"JVM run duration not correct.");
+        assertEquals((long) 93,jvmRun.getGcThroughput(),"GC throughput not correct.");
+        assertEquals((long) 94,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
+        assertEquals((long) 0,jvmRun.getInvertedParallelismCount(),"Inverted parallelism event count not correct.");
     }
 
     /**
@@ -533,24 +483,23 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("GC event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertEquals("GC blocking event count not correct.", 2, jvmRun.getBlockingEventCount());
-        assertEquals("GC pause total not correct.", 62, jvmRun.getTotalGcPause());
-        assertEquals("GC first timestamp not correct.", 1002192, jvmRun.getFirstGcEvent().getTimestamp());
-        assertEquals("GC last timestamp not correct.", 1002847, jvmRun.getLastGcEvent().getTimestamp());
-        assertEquals("GC last duration not correct.", 41453, jvmRun.getLastGcEvent().getDuration());
-        assertEquals("Stopped Time event count not correct.", 6, jvmRun.getStoppedTimeEventCount());
-        assertEquals("Stopped time total not correct.", 1064, jvmRun.getTotalStoppedTime());
-        assertEquals("Stopped first timestamp not correct.", 1000964, jvmRun.getFirstStoppedEvent().getTimestamp());
-        assertEquals("Stopped last timestamp not correct.", 1003884, jvmRun.getLastStoppedEvent().getTimestamp());
-        assertEquals("Stopped last duration not correct.", 1000688, jvmRun.getLastStoppedEvent().getDuration());
-        assertEquals("JVM first event timestamp not correct.", 1000964, jvmRun.getFirstEvent().getTimestamp());
-        assertEquals("JVM last event timestamp not correct.", 1003884, jvmRun.getLastEvent().getTimestamp());
-        assertEquals("JVM run duration not correct.", 3920, jvmRun.getJvmRunDuration());
-        assertEquals("GC throughput not correct.", 98, jvmRun.getGcThroughput());
-        assertEquals("Stopped time throughput not correct.", 73, jvmRun.getStoppedTimeThroughput());
-        assertTrue(Analysis.WARN_GC_STOPPED_RATIO + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO));
+        assertEquals(2,jvmRun.getEventTypes().size(),"GC event type count not correct.");
+        assertEquals(2,jvmRun.getBlockingEventCount(),"GC blocking event count not correct.");
+        assertEquals((long) 62,jvmRun.getTotalGcPause(),"GC pause total not correct.");
+        assertEquals((long) 1002192,jvmRun.getFirstGcEvent().getTimestamp(),"GC first timestamp not correct.");
+        assertEquals((long) 1002847,jvmRun.getLastGcEvent().getTimestamp(),"GC last timestamp not correct.");
+        assertEquals(41453,jvmRun.getLastGcEvent().getDuration(),"GC last duration not correct.");
+        assertEquals(6,jvmRun.getStoppedTimeEventCount(),"Stopped Time event count not correct.");
+        assertEquals(1064,jvmRun.getTotalStoppedTime(),"Stopped time total not correct.");
+        assertEquals((long) 1000964,jvmRun.getFirstStoppedEvent().getTimestamp(),"Stopped first timestamp not correct.");
+        assertEquals((long) 1003884,jvmRun.getLastStoppedEvent().getTimestamp(),"Stopped last timestamp not correct.");
+        assertEquals(1000688,jvmRun.getLastStoppedEvent().getDuration(),"Stopped last duration not correct.");
+        assertEquals((long) 1000964,jvmRun.getFirstEvent().getTimestamp(),"JVM first event timestamp not correct.");
+        assertEquals((long) 1003884,jvmRun.getLastEvent().getTimestamp(),"JVM last event timestamp not correct.");
+        assertEquals((long) 3920,jvmRun.getJvmRunDuration(),"JVM run duration not correct.");
+        assertEquals((long) 98,jvmRun.getGcThroughput(),"GC throughput not correct.");
+        assertEquals((long) 73,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO), Analysis.WARN_GC_STOPPED_RATIO + " analysis not identified.");
     }
 
     /**
@@ -563,25 +512,24 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("GC event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertEquals("GC blocking event count not correct.", 160, jvmRun.getBlockingEventCount());
-        assertEquals("GC pause total not correct.", 2568199, jvmRun.getTotalGcPause());
-        assertEquals("GC first timestamp not correct.", 4364, jvmRun.getFirstGcEvent().getTimestamp());
-        assertEquals("GC last timestamp not correct.", 2801954, jvmRun.getLastGcEvent().getTimestamp());
-        assertEquals("GC last duration not correct.", 25963804, jvmRun.getLastGcEvent().getDuration());
-        assertEquals("Stopped Time event count not correct.", 151, jvmRun.getStoppedTimeEventCount());
-        assertEquals("Stopped time total not correct.", 2721420, jvmRun.getTotalStoppedTime());
-        assertEquals("Stopped first timestamp not correct.", 0, jvmRun.getFirstStoppedEvent().getTimestamp());
-        assertEquals("Stopped last timestamp not correct.", 0, jvmRun.getLastStoppedEvent().getTimestamp());
-        assertEquals("Stopped last duration not correct.", 36651675, jvmRun.getLastStoppedEvent().getDuration());
-        assertEquals("JVM first event timestamp not correct.", 4364, jvmRun.getFirstEvent().getTimestamp());
-        assertEquals("JVM last timestamp not correct.", 2801954, jvmRun.getLastEvent().getTimestamp());
-        assertEquals("JVM run duration not correct.", 2827917, jvmRun.getJvmRunDuration());
-        assertEquals("GC throughput not correct.", 9, jvmRun.getGcThroughput());
-        assertEquals("Stopped time throughput not correct.", 4, jvmRun.getStoppedTimeThroughput());
-        assertFalse(Analysis.WARN_GC_STOPPED_RATIO + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO));
-        assertEquals("Inverted parallelism event count not correct.", 0, jvmRun.getInvertedParallelismCount());
+        assertEquals(3,jvmRun.getEventTypes().size(),"GC event type count not correct.");
+        assertEquals(160,jvmRun.getBlockingEventCount(),"GC blocking event count not correct.");
+        assertEquals((long) 2568199,jvmRun.getTotalGcPause(),"GC pause total not correct.");
+        assertEquals((long) 4364,jvmRun.getFirstGcEvent().getTimestamp(),"GC first timestamp not correct.");
+        assertEquals((long) 2801954,jvmRun.getLastGcEvent().getTimestamp(),"GC last timestamp not correct.");
+        assertEquals(25963804,jvmRun.getLastGcEvent().getDuration(),"GC last duration not correct.");
+        assertEquals(151,jvmRun.getStoppedTimeEventCount(),"Stopped Time event count not correct.");
+        assertEquals(2721420,jvmRun.getTotalStoppedTime(),"Stopped time total not correct.");
+        assertEquals((long) 0,jvmRun.getFirstStoppedEvent().getTimestamp(),"Stopped first timestamp not correct.");
+        assertEquals((long) 0,jvmRun.getLastStoppedEvent().getTimestamp(),"Stopped last timestamp not correct.");
+        assertEquals(36651675,jvmRun.getLastStoppedEvent().getDuration(),"Stopped last duration not correct.");
+        assertEquals((long) 4364,jvmRun.getFirstEvent().getTimestamp(),"JVM first event timestamp not correct.");
+        assertEquals((long) 2801954,jvmRun.getLastEvent().getTimestamp(),"JVM last timestamp not correct.");
+        assertEquals((long) 2827917,jvmRun.getJvmRunDuration(),"JVM run duration not correct.");
+        assertEquals((long) 9,jvmRun.getGcThroughput(),"GC throughput not correct.");
+        assertEquals((long) 4,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_GC_STOPPED_RATIO), Analysis.WARN_GC_STOPPED_RATIO + " analysis incorrectly identified.");
+        assertEquals((long) 0,jvmRun.getInvertedParallelismCount(),"Inverted parallelism event count not correct.");
     }
 
     /**
@@ -595,7 +543,7 @@ public class TestJvmRun {
         gcManager.store(preprocessedFile, false);
         gcManager.store(testFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Stopped time throughput not correct.", 0, jvmRun.getStoppedTimeThroughput());
+        assertEquals((long) 0,jvmRun.getStoppedTimeThroughput(),"Stopped time throughput not correct.");
     }
 
     /**
@@ -609,8 +557,7 @@ public class TestJvmRun {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME), Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestTimesData.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestTimesData.java
@@ -20,16 +20,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestTimesData {
+class TestTimesData {
 
     @Test
-    public void testTimesData() {
+    void testTimesData() {
         String timesData = " [Times: user=0.44 sys=0.00, real=0.08 secs]";
         assertTrue(timesData.matches(TimesData.REGEX), "'" + timesData + "' is a valid duration.");
     }
 
     @Test
-    public void testTimesDataJdk9() {
+    void testTimesDataJdk9() {
         String timesData = " User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(timesData.matches(TimesData.REGEX_JDK9), "'" + timesData + "' is a valid duration.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestTimesData.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestTimesData.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -25,12 +25,12 @@ public class TestTimesData {
     @Test
     public void testTimesData() {
         String timesData = " [Times: user=0.44 sys=0.00, real=0.08 secs]";
-        assertTrue("'" + timesData + "' is a valid duration.", timesData.matches(TimesData.REGEX));
+        assertTrue(timesData.matches(TimesData.REGEX), "'" + timesData + "' is a valid duration.");
     }
 
     @Test
     public void testTimesDataJdk9() {
         String timesData = " User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("'" + timesData + "' is a valid duration.", timesData.matches(TimesData.REGEX_JDK9));
+        assertTrue(timesData.matches(TimesData.REGEX_JDK9), "'" + timesData + "' is a valid duration.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestUnknownEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestUnknownEvent.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnknownEvent {
+class TestUnknownEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "Mike was here!!!";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnknownEvent, "Log line not recognized as " + JdkUtil.LogEventType.UNKNOWN.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/TestUnknownEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/TestUnknownEvent.java
@@ -12,10 +12,10 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -26,7 +26,6 @@ public class TestUnknownEvent {
     @Test
     public void testLogLine() {
         String logLine = "Mike was here!!!";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNKNOWN.toString() + ".",
-                JdkUtil.parseLogLine(logLine) instanceof UnknownEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnknownEvent, "Log line not recognized as " + JdkUtil.LogEventType.UNKNOWN.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationConcurrentTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationConcurrentTimeEvent.java
@@ -22,80 +22,80 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestApplicationConcurrentTimeEvent {
+class TestApplicationConcurrentTimeEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Application time: 130.5284640 seconds   ";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "Application time: 130.5284640 seconds   ";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "Application time: 130.5284640 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineWithSpacesAtEnd() {
+    void testLogLineWithSpacesAtEnd() {
         String logLine = "Application time: 130.5284640 seconds   ";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineWithTimestamp() {
+    void testLogLineWithTimestamp() {
         String logLine = "0.193: Application time: 0.0430320 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineNoTimestampStartingSemicolon() {
+    void testLogLineNoTimestampStartingSemicolon() {
         String logLine = ": Application time: 1.0001619 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2016-12-21T14:28:11.159-0500: 0.311: Application time: 0.0060964 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestampTimestampDatestamp() {
+    void testLogLineDatestampTimestampDatestamp() {
         String logLine = "2020-02-19T07:18:10.490-0500: 698914.875: 2020-02-19T07:18:10.490-0500: Application time: "
                 + "0.0000605 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestampTimestampDatestampMissingColonSpace() {
+    void testLogLineDatestampTimestampDatestampMissingColonSpace() {
         String logLine = "2020-02-19T11:46:53.624-0500: 715038.009: 2020-02-19T11:46:53.624-0500Application time: "
                 + "0.0001082 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestamp() {
+    void testLogLineDatestampDatestampTimestamp() {
         String logLine = "2020-02-19T12:41:32.898-0500: 2020-02-19T12:41:32.898-0500: 718317.283: Application time: "
                 + "0.0000496 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestampTimestamp() {
+    void testLogLineDatestampDatestampTimestampTimestamp() {
         String logLine = "2020-02-19T10:24:29.418-0500: 2020-02-19T10:24:29.418-0500: 710093.803: 710093.803: "
                 + "Application time: 0.0000610 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestampTimestampMisplacedSemicolons() {
+    void testLogLineDatestampDatestampTimestampTimestampMisplacedSemicolons() {
         String logLine = "2020-02-19T10:09:47.141-05002020-02-19T10:09:47.141-0500: : 709211.526: "
                 + "709211.526Application time: 0.0000505 seconds";
         assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationConcurrentTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationConcurrentTimeEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,91 +27,77 @@ public class TestApplicationConcurrentTimeEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "Application time: 130.5284640 seconds   ";
-        assertFalse(
-                JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "Application time: 130.5284640 seconds   ";
-        assertFalse(
-                JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "Application time: 130.5284640 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineWithSpacesAtEnd() {
         String logLine = "Application time: 130.5284640 seconds   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineWithTimestamp() {
         String logLine = "0.193: Application time: 0.0430320 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineNoTimestampStartingSemicolon() {
         String logLine = ": Application time: 1.0001619 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestamp() {
         String logLine = "2016-12-21T14:28:11.159-0500: 0.311: Application time: 0.0060964 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestampTimestampDatestamp() {
         String logLine = "2020-02-19T07:18:10.490-0500: 698914.875: 2020-02-19T07:18:10.490-0500: Application time: "
                 + "0.0000605 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestampTimestampDatestampMissingColonSpace() {
         String logLine = "2020-02-19T11:46:53.624-0500: 715038.009: 2020-02-19T11:46:53.624-0500Application time: "
                 + "0.0001082 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestampDatestampTimestamp() {
         String logLine = "2020-02-19T12:41:32.898-0500: 2020-02-19T12:41:32.898-0500: 718317.283: Application time: "
                 + "0.0000496 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestampDatestampTimestampTimestamp() {
         String logLine = "2020-02-19T10:24:29.418-0500: 2020-02-19T10:24:29.418-0500: 710093.803: 710093.803: "
                 + "Application time: 0.0000610 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineDatestampDatestampTimestampTimestampMisplacedSemicolons() {
         String logLine = "2020-02-19T10:09:47.141-05002020-02-19T10:09:47.141-0500: : 709211.526: "
                 + "709211.526Application time: 0.0000505 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationConcurrentTimeEvent.match(logLine));
+        assertTrue(ApplicationConcurrentTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationStoppedTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationStoppedTimeEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,122 +28,110 @@ public class TestApplicationStoppedTimeEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "1,065: Total time for which application threads were stopped: 0,0001610 seconds";
-        assertFalse(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "Total time for which application threads were stopped: 0.0968457 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 96845, event.getDuration());
+        assertEquals((long) 0,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(96845,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithSpacesAtEnd() {
         String logLine = "Total time for which application threads were stopped: 0.0968457 seconds  ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8() {
         String logLine = "1.977: Total time for which application threads were stopped: 0.0002054 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1977, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 205, event.getDuration());
+        assertEquals((long) 1977,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(205,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineJdk8Update40() {
         String logLine = "4.483: Total time for which application threads were stopped: 0.0018237 seconds, Stopping "
                 + "threads took: 0.0017499 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4483, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 1823, event.getDuration());
+        assertEquals((long) 4483,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(1823,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithCommas() {
         String logLine = "1,065: Total time for which application threads were stopped: 0,0001610 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1065, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 161, event.getDuration());
+        assertEquals((long) 1065,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(161,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithNegativeTime() {
         String logLine = "51185.692: Total time for which application threads were stopped: -0.0005950 seconds, "
                 + "Stopping threads took: 0.0003310 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 51185692, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", -595, event.getDuration());
+        assertEquals((long) 51185692,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(-595,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestamp() {
         String logLine = "2015-05-04T18:08:00.244+0000: 0.964: Total time for which application threads were stopped: "
                 + "0.0001390 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 964, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 139, event.getDuration());
+        assertEquals((long) 964,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(139,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineDoubleDatestamp() {
         String logLine = "2016-11-08T02:06:23.230-0800: 2016-11-08T02:06:23.230-0800: 8290.973: Total time for which "
                 + "application threads were stopped: 0.2409380 seconds, Stopping threads took: 0.0001210 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 8290973, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 240938, event.getDuration());
+        assertEquals((long) 8290973,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(240938,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestampDatestampTimestampMisplacedSemicolonTimestamp() {
         String logLine = "2016-11-10T06:14:13.216-0500: 2016-11-10T06:14:13.216-0500672303.818: : 672303.818: Total "
                 + "time for which application threads were stopped: 0.2934160 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 672303818, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 293416, event.getDuration());
+        assertEquals((long) 672303818,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(293416,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTimestampDatestampTimestamp() {
         String logLine = "1514293.426: 2017-01-20T23:35:06.553-0500: 1514293.426: Total time for which application "
                 + "threads were stopped: 0.0233250 seconds, Stopping threads took: 0.0000290 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1514293426, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 23325, event.getDuration());
+        assertEquals((long) 1514293426,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(23325,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestampTimestampTimestampNoColon() {
         String logLine = "2017-01-20T23:57:51.722-0500: 1515658.594: 2017-01-20T23:57:51.722-0500Total time for which "
                 + "application threads were stopped: 0.0245350 seconds, Stopping threads took: 0.0000460 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1515658594, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 24535, event.getDuration());
+        assertEquals((long) 1515658594,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(24535,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -151,33 +139,30 @@ public class TestApplicationStoppedTimeEvent {
         String logLine = "2017-01-21T00:58:08.000-0500: 2017-01-21T00:58:08.000-0500: 1519274.873: 1519274.873Total "
                 + "time for which application threads were stopped: 0.0220410 seconds, Stopping threads took: "
                 + "0.0000290 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1519274873, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 22041, event.getDuration());
+        assertEquals((long) 1519274873,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(22041,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineMislacedColonTimestampDatestampTimestampTimestamp() {
         String logLine = ": 1523468.7792017-01-21T02:08:01.907-0500: : 1523468.779: Total time for which application "
                 + "threads were stopped: 0.0268610 seconds, Stopping threads took: 0.0000300 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1523468779, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 26861, event.getDuration());
+        assertEquals((long) 1523468779,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(26861,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineMislacedColonDatestampTimestampTimestamp() {
         String logLine = ": 2017-01-21T04:11:12.565-0500: 1530859.438: 1530859.438: Total time for which application "
                 + "threads were stopped: 0.0292690 seconds, Stopping threads took: 0.0000440 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1530859438, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 29269, event.getDuration());
+        assertEquals((long) 1530859438,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(29269,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -185,11 +170,10 @@ public class TestApplicationStoppedTimeEvent {
         String logLine = "2017-01-21T07:44:22.453-05002017-01-21T07:44:22.453-0500: : 1543649.325: Total time for "
                 + "which application threads were stopped: 0.0293060 seconds, Stopping threads took: "
                 + "0.0000460 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1543649325, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 29306, event.getDuration());
+        assertEquals((long) 1543649325,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(29306,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -197,22 +181,20 @@ public class TestApplicationStoppedTimeEvent {
         String logLine = "2017-01-21T10:23:10.795-05002017-01-21T10:23:10.795-0500: : 1553177.667: 1553177.667: Total "
                 + "time for which application threads were stopped: 0.0416440 seconds, Stopping threads took: "
                 + "0.0000540 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1553177667, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 41644, event.getDuration());
+        assertEquals((long) 1553177667,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(41644,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTruncated() {
         String logLine = "2017-02-01T05:58:45.570-0500: 5062.814: Total time for which application threads were "
                 + "stopped: 0.0001140 seconds, Stopping thread";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 5062814, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 114, event.getDuration());
+        assertEquals((long) 5062814,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(114,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -220,10 +202,9 @@ public class TestApplicationStoppedTimeEvent {
         String logLine = "2017-02-20T20:15:54.487-0500: 2017-02-20T20:15:54.487-0500: 40371.69140371.691: : "
                 + "Total time for which application threads were stopped: 0.0099233 seconds, Stopping threads took: "
                 + "0.0000402 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 40371691, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 9923, event.getDuration());
+        assertEquals((long) 40371691,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(9923,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationStoppedTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestApplicationStoppedTimeEvent.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestApplicationStoppedTimeEvent {
+class TestApplicationStoppedTimeEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "1,065: Total time for which application threads were stopped: 0,0001610 seconds";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "Total time for which application threads were stopped: 0.0968457 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
@@ -41,13 +41,13 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineWithSpacesAtEnd() {
+    void testLogLineWithSpacesAtEnd() {
         String logLine = "Total time for which application threads were stopped: 0.0968457 seconds  ";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "1.977: Total time for which application threads were stopped: 0.0002054 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
@@ -56,7 +56,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineJdk8Update40() {
+    void testLogLineJdk8Update40() {
         String logLine = "4.483: Total time for which application threads were stopped: 0.0018237 seconds, Stopping "
                 + "threads took: 0.0017499 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -66,7 +66,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineWithCommas() {
+    void testLogLineWithCommas() {
         String logLine = "1,065: Total time for which application threads were stopped: 0,0001610 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
         ApplicationStoppedTimeEvent event = new ApplicationStoppedTimeEvent(logLine);
@@ -75,7 +75,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineWithNegativeTime() {
+    void testLogLineWithNegativeTime() {
         String logLine = "51185.692: Total time for which application threads were stopped: -0.0005950 seconds, "
                 + "Stopping threads took: 0.0003310 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -85,7 +85,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2015-05-04T18:08:00.244+0000: 0.964: Total time for which application threads were stopped: "
                 + "0.0001390 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -95,7 +95,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDoubleDatestamp() {
+    void testLogLineDoubleDatestamp() {
         String logLine = "2016-11-08T02:06:23.230-0800: 2016-11-08T02:06:23.230-0800: 8290.973: Total time for which "
                 + "application threads were stopped: 0.2409380 seconds, Stopping threads took: 0.0001210 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -105,7 +105,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestampMisplacedSemicolonTimestamp() {
+    void testLogLineDatestampDatestampTimestampMisplacedSemicolonTimestamp() {
         String logLine = "2016-11-10T06:14:13.216-0500: 2016-11-10T06:14:13.216-0500672303.818: : 672303.818: Total "
                 + "time for which application threads were stopped: 0.2934160 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -115,7 +115,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineTimestampDatestampTimestamp() {
+    void testLogLineTimestampDatestampTimestamp() {
         String logLine = "1514293.426: 2017-01-20T23:35:06.553-0500: 1514293.426: Total time for which application "
                 + "threads were stopped: 0.0233250 seconds, Stopping threads took: 0.0000290 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -125,7 +125,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestampTimestampTimestampNoColon() {
+    void testLogLineDatestampTimestampTimestampNoColon() {
         String logLine = "2017-01-20T23:57:51.722-0500: 1515658.594: 2017-01-20T23:57:51.722-0500Total time for which "
                 + "application threads were stopped: 0.0245350 seconds, Stopping threads took: 0.0000460 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -135,7 +135,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestampTimestampNoColon() {
+    void testLogLineDatestampDatestampTimestampTimestampNoColon() {
         String logLine = "2017-01-21T00:58:08.000-0500: 2017-01-21T00:58:08.000-0500: 1519274.873: 1519274.873Total "
                 + "time for which application threads were stopped: 0.0220410 seconds, Stopping threads took: "
                 + "0.0000290 seconds";
@@ -146,7 +146,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineMislacedColonTimestampDatestampTimestampTimestamp() {
+    void testLogLineMislacedColonTimestampDatestampTimestampTimestamp() {
         String logLine = ": 1523468.7792017-01-21T02:08:01.907-0500: : 1523468.779: Total time for which application "
                 + "threads were stopped: 0.0268610 seconds, Stopping threads took: 0.0000300 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -156,7 +156,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineMislacedColonDatestampTimestampTimestamp() {
+    void testLogLineMislacedColonDatestampTimestampTimestamp() {
         String logLine = ": 2017-01-21T04:11:12.565-0500: 1530859.438: 1530859.438: Total time for which application "
                 + "threads were stopped: 0.0292690 seconds, Stopping threads took: 0.0000440 seconds";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -166,7 +166,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampMisplacedColonTimestamp() {
+    void testLogLineDatestampDatestampMisplacedColonTimestamp() {
         String logLine = "2017-01-21T07:44:22.453-05002017-01-21T07:44:22.453-0500: : 1543649.325: Total time for "
                 + "which application threads were stopped: 0.0293060 seconds, Stopping threads took: "
                 + "0.0000460 seconds";
@@ -177,7 +177,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampMisplacedColonTimestampTimestamp() {
+    void testLogLineDatestampDatestampMisplacedColonTimestampTimestamp() {
         String logLine = "2017-01-21T10:23:10.795-05002017-01-21T10:23:10.795-0500: : 1553177.667: 1553177.667: Total "
                 + "time for which application threads were stopped: 0.0416440 seconds, Stopping threads took: "
                 + "0.0000540 seconds";
@@ -188,7 +188,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineTruncated() {
+    void testLogLineTruncated() {
         String logLine = "2017-02-01T05:58:45.570-0500: 5062.814: Total time for which application threads were "
                 + "stopped: 0.0001140 seconds, Stopping thread";
         assertTrue(ApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
@@ -198,7 +198,7 @@ public class TestApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testLogLineScrambledDateTimeStamps() {
+    void testLogLineScrambledDateTimeStamps() {
         String logLine = "2017-02-20T20:15:54.487-0500: 2017-02-20T20:15:54.487-0500: 40371.69140371.691: : "
                 + "Total time for which application threads were stopped: 0.0099233 seconds, Stopping threads took: "
                 + "0.0000402 seconds";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassHistogramEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassHistogramEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,130 +28,112 @@ public class TestClassHistogramEvent {
     public void testNotBlocking() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
-        assertFalse(JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
-        assertFalse(JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testColumnsNameLine() {
         String logLine = " num     #instances         #bytes  class name";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testHeaderDividerLine() {
         String logLine = "----------------------------------------------";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassDataWithBracketLine() {
         String logLine = "   1:       9249662      876131272  [C";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassDataWithNumberLine() {
         String logLine = "27714:             1             16  sun.reflect.GeneratedMethodAccessor1500";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassDataWithInnerClassLine() {
         String logLine = "27714:             1             16  sun.reflect.GeneratedMethodAccessor1500";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassDataWithUnderscoreLine() {
         String logLine = "27647:             1             16  com.example.Myclass$MyInner_someThing";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassDataWithSemicolonLine() {
         String logLine = "   4:       4149724      232421736  [Ljava.lang.Object;";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testTotalLine() {
         String logLine = "Total      16227637     1059670840";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void test5SpacesBeforeTenDigitBytesLine() {
         String logLine = "   1:       3786335     1564600208  [Ljava.lang.Object;";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void test6DigitLineNumberLine() {
         String logLine = "100000:             1             16  com.msh.rules.regimensearch.Rule_regimen"
                 + "SearchRule_841_a1deb60c00004d67b538438881011c7aDefaultConsequenceInvoker";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void test6SpacesBeforeInstancesLine() {
         String logLine = "   1:      98460990     7018731456  [I";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testTotal11DigitBytesLine() {
         String logLine = "Total     159091427    12666890520";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testG1PreprocessedLine() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testJdk6PreprocessedLine() {
         String logLine = "471478.440: [Class Histogram, 15.6352805 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testClassWithForwardSlash() {
         String logLine = " 116:           318           7632  "
                 + "io.micrometer.prometheus.PrometheusMeterRegistry$$Lambda$53/635371680";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
     public void testTotal8SpacesBeforeInstances() {
         String logLine = "Total        271481       20043160";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                ClassHistogramEvent.match(logLine));
+        assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassHistogramEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassHistogramEvent.java
@@ -22,117 +22,117 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestClassHistogramEvent {
+class TestClassHistogramEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testColumnsNameLine() {
+    void testColumnsNameLine() {
         String logLine = " num     #instances         #bytes  class name";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testHeaderDividerLine() {
+    void testHeaderDividerLine() {
         String logLine = "----------------------------------------------";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassDataWithBracketLine() {
+    void testClassDataWithBracketLine() {
         String logLine = "   1:       9249662      876131272  [C";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassDataWithNumberLine() {
+    void testClassDataWithNumberLine() {
         String logLine = "27714:             1             16  sun.reflect.GeneratedMethodAccessor1500";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassDataWithInnerClassLine() {
+    void testClassDataWithInnerClassLine() {
         String logLine = "27714:             1             16  sun.reflect.GeneratedMethodAccessor1500";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassDataWithUnderscoreLine() {
+    void testClassDataWithUnderscoreLine() {
         String logLine = "27647:             1             16  com.example.Myclass$MyInner_someThing";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassDataWithSemicolonLine() {
+    void testClassDataWithSemicolonLine() {
         String logLine = "   4:       4149724      232421736  [Ljava.lang.Object;";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testTotalLine() {
+    void testTotalLine() {
         String logLine = "Total      16227637     1059670840";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void test5SpacesBeforeTenDigitBytesLine() {
+    void test5SpacesBeforeTenDigitBytesLine() {
         String logLine = "   1:       3786335     1564600208  [Ljava.lang.Object;";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void test6DigitLineNumberLine() {
+    void test6DigitLineNumberLine() {
         String logLine = "100000:             1             16  com.msh.rules.regimensearch.Rule_regimen"
                 + "SearchRule_841_a1deb60c00004d67b538438881011c7aDefaultConsequenceInvoker";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void test6SpacesBeforeInstancesLine() {
+    void test6SpacesBeforeInstancesLine() {
         String logLine = "   1:      98460990     7018731456  [I";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testTotal11DigitBytesLine() {
+    void testTotal11DigitBytesLine() {
         String logLine = "Total     159091427    12666890520";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testG1PreprocessedLine() {
+    void testG1PreprocessedLine() {
         String logLine = "49709.036: [Class Histogram (after full gc):, 2.4232900 secs] "
                 + "[Times: user=29.91 sys=0.08, real=22.24 secs]";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testJdk6PreprocessedLine() {
+    void testJdk6PreprocessedLine() {
         String logLine = "471478.440: [Class Histogram, 15.6352805 secs]";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testClassWithForwardSlash() {
+    void testClassWithForwardSlash() {
         String logLine = " 116:           318           7632  "
                 + "io.micrometer.prometheus.PrometheusMeterRegistry$$Lambda$53/635371680";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }
 
     @Test
-    public void testTotal8SpacesBeforeInstances() {
+    void testTotal8SpacesBeforeInstances() {
         String logLine = "Total        271481       20043160";
         assertTrue(ClassHistogramEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassUnloadingEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassUnloadingEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -26,7 +26,7 @@ import org.eclipselabs.garbagecat.util.jdk.Analysis;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -37,36 +37,31 @@ public class TestClassUnloadingEvent {
     @Test
     public void testNotBlocking() {
         String logLine = " [Unloading class $Proxy225]";
-        assertFalse(JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = " [Unloading class $Proxy225]";
-        assertFalse(JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testLine() {
         String logLine = "[Unloading class $Proxy61]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".",
-                ClassUnloadingEvent.match(logLine));
+        assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
 
     @Test
     public void testLineWithUnderline() {
         String logLine = "[Unloading class MyClass_1234153487841_717989]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".",
-                ClassUnloadingEvent.match(logLine));
+        assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
 
     @Test
     public void testLogLineWithBeginningSpace() {
         String logLine = " [Unloading class $Proxy225]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".",
-                ClassUnloadingEvent.match(logLine));
+        assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
 
     /**
@@ -80,12 +75,9 @@ public class TestClassUnloadingEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD));
-        assertTrue(Analysis.WARN_TRACE_CLASS_UNLOADING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_TRACE_CLASS_UNLOADING));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PARALLEL_SERIAL_OLD), JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_TRACE_CLASS_UNLOADING), Analysis.WARN_TRACE_CLASS_UNLOADING + " analysis not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassUnloadingEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestClassUnloadingEvent.java
@@ -32,34 +32,34 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestClassUnloadingEvent {
+class TestClassUnloadingEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = " [Unloading class $Proxy225]";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = " [Unloading class $Proxy225]";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CLASS_UNLOADING.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[Unloading class $Proxy61]";
         assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
 
     @Test
-    public void testLineWithUnderline() {
+    void testLineWithUnderline() {
         String logLine = "[Unloading class MyClass_1234153487841_717989]";
         assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
 
     @Test
-    public void testLogLineWithBeginningSpace() {
+    void testLogLineWithBeginningSpace() {
         String logLine = " [Unloading class $Proxy225]";
         assertTrue(ClassUnloadingEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_UNLOADING.toString() + ".");
     }
@@ -69,7 +69,7 @@ public class TestClassUnloadingEvent {
      * 
      */
     @Test
-    public void testTraceClassUnloadingPreprocessing() {
+    void testTraceClassUnloadingPreprocessing() {
         File testFile = TestUtil.getFile("dataset84.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsConcurrentEvent.java
@@ -22,193 +22,193 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestCmsConcurrentEvent {
+class TestCmsConcurrentEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "572289.495: [CMS572304.683: [CMS-concurrent-sweep: 17.692/44.143 secs] "
                 + "[Times: user=97.86 sys=1.85, real=44.14 secs]";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testMarkStart() {
+    void testMarkStart() {
         String logLine = "251.781: [CMS-concurrent-mark-start]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkStartWithOtherLoggingAppended() {
+    void testMarkStartWithOtherLoggingAppended() {
         String logLine = "251.781: [CMS-concurrent-mark-start]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMark() {
+    void testMark() {
         String logLine = "252.707: [CMS-concurrent-mark: 0.796/0.926 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkWithOtherLoggingAppended() {
+    void testMarkWithOtherLoggingAppended() {
         String logLine = "252.707: [CMS-concurrent-mark: 0.796/0.926 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkWithTimesData() {
+    void testMarkWithTimesData() {
         String logLine = "242107.737: [CMS-concurrent-mark: 0.443/10.257 secs] "
                 + "[Times: user=6.00 sys=0.28, real=10.26 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkWithTimesData5Digits() {
+    void testMarkWithTimesData5Digits() {
         String logLine = "2017-06-23T08:12:13.943-0400: 39034.532: [CMS-concurrent-mark: 4.583/35144.874 secs] "
                 + "[Times: user=29858.25 sys=2074.63, real=35140.48 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkWithTimesDataWithOtherLoggingAppended() {
+    void testMarkWithTimesDataWithOtherLoggingAppended() {
         String logLine = "242107.737: [CMS-concurrent-mark: 0.443/10.257 secs] "
                 + "[Times: user=6.00 sys=0.28, real=10.26 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanStart() {
+    void testPrecleanStart() {
         String logLine = "252.707: [CMS-concurrent-preclean-start]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanStartWithOtherLoggingAppended() {
+    void testPrecleanStartWithOtherLoggingAppended() {
         String logLine = "252.707: [CMS-concurrent-preclean-start]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPreclean() {
+    void testPreclean() {
         String logLine = "252.888: [CMS-concurrent-preclean: 0.141/0.182 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanWithOtherLoggingAppended() {
+    void testPrecleanWithOtherLoggingAppended() {
         String logLine = "252.888: [CMS-concurrent-preclean: 0.141/0.182 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortablePrecleanStart() {
+    void testAbortablePrecleanStart() {
         String logLine = "252.889: [CMS-concurrent-abortable-preclean-start]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortablePrecleanStartWithOtherLoggingAppended() {
+    void testAbortablePrecleanStartWithOtherLoggingAppended() {
         String logLine = "252.889: [CMS-concurrent-abortable-preclean-start]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortablePreclean() {
+    void testAbortablePreclean() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortablePrecleanWithOtherLoggingAppended() {
+    void testAbortablePrecleanWithOtherLoggingAppended() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortPrecleanDueToTime() {
+    void testAbortPrecleanDueToTime() {
         String logLine = " CMS: abort preclean due to time 32633.935: "
                 + "[CMS-concurrent-abortable-preclean: 0.622/5.054 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testAbortPrecleanDueToTimeWithOtherLoggingAppended() {
+    void testAbortPrecleanDueToTimeWithOtherLoggingAppended() {
         String logLine = " CMS: abort preclean due to time 32633.935: "
                 + "[CMS-concurrent-abortable-preclean: 0.622/5.054 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testSweepStart() {
+    void testSweepStart() {
         String logLine = "253.189: [CMS-concurrent-sweep-start]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testSweepStartWithOtherLoggingAppended() {
+    void testSweepStartWithOtherLoggingAppended() {
         String logLine = "253.189: [CMS-concurrent-sweep-start]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testSweep() {
+    void testSweep() {
         String logLine = "258.265: [CMS-concurrent-sweep: 4.134/5.076 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testSweepWithOtherLoggingAppended() {
+    void testSweepWithOtherLoggingAppended() {
         String logLine = "258.265: [CMS-concurrent-sweep: 4.134/5.076 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testResetStart() {
+    void testResetStart() {
         String logLine = "258.265: [CMS-concurrent-reset-start]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testResetStartWithOtherLoggingAppended() {
+    void testResetStartWithOtherLoggingAppended() {
         String logLine = "258.265: [CMS-concurrent-reset-start]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testReset() {
+    void testReset() {
         String logLine = "258.344: [CMS-concurrent-reset: 0.079/0.079 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testResetWithOtherLoggingAppended() {
+    void testResetWithOtherLoggingAppended() {
         String logLine = "258.344: [CMS-concurrent-reset: 0.079/0.079 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanConcurrentModeFailure() {
+    void testPrecleanConcurrentModeFailure() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs] "
                 + "[Times: user=1.23 sys=0.02, real=0.21 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanConcurrentModeFailureWithOtherLoggingAppended() {
+    void testPrecleanConcurrentModeFailureWithOtherLoggingAppended() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs] "
                 + "[Times: user=1.23 sys=0.02, real=0.21 secs]x";
         assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanConcurrentMarkSweepWithCms() {
+    void testPrecleanConcurrentMarkSweepWithCms() {
         String logLine = "572289.495: [CMS572304.683: [CMS-concurrent-sweep: 17.692/44.143 secs] "
                 + "[Times: user=97.86 sys=1.85, real=44.14 secs]";
         assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentPrefixWithOtherLoggingAppended() {
+    void testConcurrentPrefixWithOtherLoggingAppended() {
         String logLine = "2017-04-24T21:08:04.965+0100: 669960.868: [CMS-concurrent-sweep: 13.324/39.970 secs] "
                 + "[Times: user=124.31 sys=2.44, real=39.97 secs] 6200850K->1243921K(7848704K), "
                 + "[CMS Perm : 481132K->454310K(785120K)], 100.5538981 secs] "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsConcurrentEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,212 +28,183 @@ public class TestCmsConcurrentEvent {
     public void testNotBlocking() {
         String logLine = "572289.495: [CMS572304.683: [CMS-concurrent-sweep: 17.692/44.143 secs] "
                 + "[Times: user=97.86 sys=1.85, real=44.14 secs]";
-        assertFalse(JdkUtil.LogEventType.CMS_CONCURRENT.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testMarkStart() {
         String logLine = "251.781: [CMS-concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkStartWithOtherLoggingAppended() {
         String logLine = "251.781: [CMS-concurrent-mark-start]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMark() {
         String logLine = "252.707: [CMS-concurrent-mark: 0.796/0.926 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkWithOtherLoggingAppended() {
         String logLine = "252.707: [CMS-concurrent-mark: 0.796/0.926 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkWithTimesData() {
         String logLine = "242107.737: [CMS-concurrent-mark: 0.443/10.257 secs] "
                 + "[Times: user=6.00 sys=0.28, real=10.26 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkWithTimesData5Digits() {
         String logLine = "2017-06-23T08:12:13.943-0400: 39034.532: [CMS-concurrent-mark: 4.583/35144.874 secs] "
                 + "[Times: user=29858.25 sys=2074.63, real=35140.48 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkWithTimesDataWithOtherLoggingAppended() {
         String logLine = "242107.737: [CMS-concurrent-mark: 0.443/10.257 secs] "
                 + "[Times: user=6.00 sys=0.28, real=10.26 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanStart() {
         String logLine = "252.707: [CMS-concurrent-preclean-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanStartWithOtherLoggingAppended() {
         String logLine = "252.707: [CMS-concurrent-preclean-start]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPreclean() {
         String logLine = "252.888: [CMS-concurrent-preclean: 0.141/0.182 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanWithOtherLoggingAppended() {
         String logLine = "252.888: [CMS-concurrent-preclean: 0.141/0.182 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortablePrecleanStart() {
         String logLine = "252.889: [CMS-concurrent-abortable-preclean-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortablePrecleanStartWithOtherLoggingAppended() {
         String logLine = "252.889: [CMS-concurrent-abortable-preclean-start]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortablePreclean() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortablePrecleanWithOtherLoggingAppended() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortPrecleanDueToTime() {
         String logLine = " CMS: abort preclean due to time 32633.935: "
                 + "[CMS-concurrent-abortable-preclean: 0.622/5.054 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testAbortPrecleanDueToTimeWithOtherLoggingAppended() {
         String logLine = " CMS: abort preclean due to time 32633.935: "
                 + "[CMS-concurrent-abortable-preclean: 0.622/5.054 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testSweepStart() {
         String logLine = "253.189: [CMS-concurrent-sweep-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testSweepStartWithOtherLoggingAppended() {
         String logLine = "253.189: [CMS-concurrent-sweep-start]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testSweep() {
         String logLine = "258.265: [CMS-concurrent-sweep: 4.134/5.076 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testSweepWithOtherLoggingAppended() {
         String logLine = "258.265: [CMS-concurrent-sweep: 4.134/5.076 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testResetStart() {
         String logLine = "258.265: [CMS-concurrent-reset-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testResetStartWithOtherLoggingAppended() {
         String logLine = "258.265: [CMS-concurrent-reset-start]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testReset() {
         String logLine = "258.344: [CMS-concurrent-reset: 0.079/0.079 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testResetWithOtherLoggingAppended() {
         String logLine = "258.344: [CMS-concurrent-reset: 0.079/0.079 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanConcurrentModeFailure() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs] "
                 + "[Times: user=1.23 sys=0.02, real=0.21 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanConcurrentModeFailureWithOtherLoggingAppended() {
         String logLine = "253.102: [CMS-concurrent-abortable-preclean: 0.083/0.214 secs] "
                 + "[Times: user=1.23 sys=0.02, real=0.21 secs]x";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanConcurrentMarkSweepWithCms() {
         String logLine = "572289.495: [CMS572304.683: [CMS-concurrent-sweep: 17.692/44.143 secs] "
                 + "[Times: user=97.86 sys=1.85, real=44.14 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertTrue(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     @Test
@@ -242,7 +213,6 @@ public class TestCmsConcurrentEvent {
                 + "[Times: user=124.31 sys=2.44, real=39.97 secs] 6200850K->1243921K(7848704K), "
                 + "[CMS Perm : 481132K->454310K(785120K)], 100.5538981 secs] "
                 + "[Times: user=100.68 sys=0.14, real=100.56 secs]";
-        assertFalse("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                CmsConcurrentEvent.match(logLine));
+        assertFalse(CmsConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsInitialMarkEvent.java
@@ -23,17 +23,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestCmsInitialMarkEvent {
+class TestCmsInitialMarkEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "8.722: [GC (CMS Initial Mark) [1 CMS-initial-mark: 0K(989632K)] 187663K(1986432K), "
                 + "0.0157899 secs] [Times: user=0.06 sys=0.00, real=0.02 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs]";
         assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
@@ -43,14 +43,14 @@ public class TestCmsInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs]         ";
         assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs] " + "[Times: user=0.02 sys=0.00, real=0.02 secs]";
         assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");
@@ -63,7 +63,7 @@ public class TestCmsInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineJdk8WithTrigger() {
+    void testLogLineJdk8WithTrigger() {
         String logLine = "8.722: [GC (CMS Initial Mark) [1 CMS-initial-mark: 0K(989632K)] 187663K(1986432K), "
                 + "0.0157899 secs] [Times: user=0.06 sys=0.00, real=0.02 secs]";
         assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");
@@ -77,7 +77,7 @@ public class TestCmsInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2016-10-10T18:43:50.728-0700: 3.065: [GC (CMS Initial Mark) [1 CMS-initial-mark: "
                 + "6993K(8218240K)] 26689K(8371584K), 0.0091989 secs] [Times: user=0.03 sys=0.00, real=0.01 secs]";
         assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsInitialMarkEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -29,67 +29,64 @@ public class TestCmsInitialMarkEvent {
     public void testIsBlocking() {
         String logLine = "8.722: [GC (CMS Initial Mark) [1 CMS-initial-mark: 0K(989632K)] 187663K(1986432K), "
                 + "0.0157899 secs] [Times: user=0.06 sys=0.00, real=0.02 secs]";
-        assertTrue(JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".",
-                CmsInitialMarkEvent.match(logLine));
+        assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
         CmsInitialMarkEvent event = new CmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 251763, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 17443, event.getDuration());
+        assertEquals((long) 251763,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(17443,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs]         ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".",
-                CmsInitialMarkEvent.match(logLine));
+        assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineWithTimesData() {
         String logLine = "251.763: [GC [1 CMS-initial-mark: 4133273K(8218240K)] "
                 + "4150346K(8367360K), 0.0174433 secs] " + "[Times: user=0.02 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as CMS Initial Mark event.", CmsInitialMarkEvent.match(logLine));
+        assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");
         CmsInitialMarkEvent event = new CmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 251763, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 17443, event.getDuration());
-        assertEquals("User time not parsed correctly.", 2, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 251763,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(17443,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(2,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineJdk8WithTrigger() {
         String logLine = "8.722: [GC (CMS Initial Mark) [1 CMS-initial-mark: 0K(989632K)] 187663K(1986432K), "
                 + "0.0157899 secs] [Times: user=0.06 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as CMS Initial Mark event.", CmsInitialMarkEvent.match(logLine));
+        assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");
         CmsInitialMarkEvent event = new CmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 8722, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK));
-        assertEquals("Duration not parsed correctly.", 15789, event.getDuration());
-        assertEquals("User time not parsed correctly.", 6, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 300, event.getParallelism());
+        assertEquals((long) 8722,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK), "Trigger not parsed correctly.");
+        assertEquals(15789,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(6,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineDatestamp() {
         String logLine = "2016-10-10T18:43:50.728-0700: 3.065: [GC (CMS Initial Mark) [1 CMS-initial-mark: "
                 + "6993K(8218240K)] 26689K(8371584K), 0.0091989 secs] [Times: user=0.03 sys=0.00, real=0.01 secs]";
-        assertTrue("Log line not recognized as CMS Initial Mark event.", CmsInitialMarkEvent.match(logLine));
+        assertTrue(CmsInitialMarkEvent.match(logLine), "Log line not recognized as CMS Initial Mark event.");
         CmsInitialMarkEvent event = new CmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3065, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK));
-        assertEquals("Duration not parsed correctly.", 9198, event.getDuration());
-        assertEquals("User time not parsed correctly.", 3, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 300, event.getParallelism());
+        assertEquals((long) 3065,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK), "Trigger not parsed correctly.");
+        assertEquals(9198,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(3,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsRemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsRemarkEvent.java
@@ -32,10 +32,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestCmsRemarkEvent {
+class TestCmsRemarkEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]";
@@ -43,7 +43,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]";
@@ -56,7 +56,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]  ";
@@ -64,7 +64,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs] "
@@ -82,7 +82,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineJdk8WithTriggerAndDatestamps() {
+    void testLogLineJdk8WithTriggerAndDatestamps() {
         String logLine = "13.749: [GC (CMS Final Remark)[YG occupancy: 149636 K (153600 K)]13.749: "
                 + "[Rescan (parallel) , 0.0216980 secs]13.771: [weak refs processing, 0.0005180 secs]13.772: "
                 + "[scrub string table, 0.0015820 secs] [1 CMS-remark: 217008K(341376K)] "
@@ -101,7 +101,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2016-10-27T19:06:06.651-0400: 6.458: [GC[YG occupancy: 480317 K (5505024 K)]6.458: "
                 + "[Rescan (parallel) , 0.0103480 secs]6.469: [weak refs processing, 0.0000110 secs]6.469: "
                 + "[scrub string table, 0.0001750 secs] [1 CMS-remark: 0K(37748736K)] 480317K(43253760K), "
@@ -119,7 +119,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineAllDatestamps() {
+    void testLogLineAllDatestamps() {
         String logLine = "2017-03-04T05:36:05.691-0500: 214.303: [GC[YG occupancy: 1674105 K (2752512 K)]"
                 + "2017-03-04T05:36:05.691-0500: 214.303: [Rescan (parallel) , 0.2958890 secs]"
                 + "2017-03-04T05:36:05.987-0500: 214.599: [weak refs processing, 0.0046990 secs]"
@@ -139,7 +139,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineSpaceBeforeYgBlockAndNoSpaceBeforeCmsRemarkBlock() {
+    void testLogLineSpaceBeforeYgBlockAndNoSpaceBeforeCmsRemarkBlock() {
         String logLine = "61.013: [GC (CMS Final Remark) [YG occupancy: 237181 K (471872 K)]61.014: [Rescan (parallel)"
                 + " , 0.0335675 secs]61.047: [weak refs processing, 0.0011687 secs][1 CMS-remark: 1137616K(1572864K)] "
                 + "1374798K(2044736K), 0.0351204 secs] [Times: user=0.12 sys=0.00, real=0.04 secs]";
@@ -156,7 +156,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloading() {
+    void testLogLineClassUnloading() {
         String logLine = "76694.727: [GC[YG occupancy: 80143 K (153344 K)]76694.727: "
                 + "[Rescan (parallel) , 0.0574180 secs]76694.785: [weak refs processing, 0.0170540 secs]76694.802: "
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
@@ -169,7 +169,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingWhitespaceAtEnd() {
+    void testLogLineClassUnloadingWhitespaceAtEnd() {
         String logLine = "76694.727: [GC[YG occupancy: 80143 K (153344 K)]76694.727: "
                 + "[Rescan (parallel) , 0.0574180 secs]76694.785: [weak refs processing, 0.0170540 secs]76694.802: "
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
@@ -178,7 +178,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingWithTimesData() {
+    void testLogLineClassUnloadingWithTimesData() {
         String logLine = "76694.727: [GC[YG occupancy: 80143 K (153344 K)]76694.727: "
                 + "[Rescan (parallel) , 0.0574180 secs]76694.785: [weak refs processing, 0.0170540 secs]76694.802: "
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
@@ -195,7 +195,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingJdk7() {
+    void testLogLineClassUnloadingJdk7() {
         String logLine = "75.500: [GC[YG occupancy: 163958 K (306688 K)]75.500: [Rescan (parallel) , 0.0491823 secs]"
                 + "75.549: [weak refs processing, 0.0088472 secs]75.558: [class unloading, 0.0049468 secs]75.563: "
                 + "[scrub symbol table, 0.0034342 secs]75.566: [scrub string table, 0.0005542 secs] [1 CMS-remark: "
@@ -208,7 +208,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingJdk7WithTimesData() {
+    void testLogLineClassUnloadingJdk7WithTimesData() {
         String logLine = "75.500: [GC[YG occupancy: 163958 K (306688 K)]75.500: [Rescan (parallel) , 0.0491823 secs]"
                 + "75.549: [weak refs processing, 0.0088472 secs]75.558: [class unloading, 0.0049468 secs]75.563: "
                 + "[scrub symbol table, 0.0034342 secs]75.566: [scrub string table, 0.0005542 secs] [1 CMS-remark: "
@@ -217,7 +217,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingJdk8WithTrigger() {
+    void testLogLineClassUnloadingJdk8WithTrigger() {
         String logLine = "13.758: [GC (CMS Final Remark) [YG occupancy: 235489 K (996800 K)]13.758: "
                 + "[Rescan (parallel) , 0.0268664 secs]13.785: [weak refs processing, 0.0000365 secs]13.785: "
                 + "[class unloading, 0.0058936 secs]13.791: [scrub symbol table, 0.0081277 secs]13.799: "
@@ -236,7 +236,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingJdk7NonParallelRescan() {
+    void testLogLineClassUnloadingJdk7NonParallelRescan() {
         String logLine = "7.294: [GC[YG occupancy: 42599 K (76672 K)]7.294: [Rescan (non-parallel) 7.294: "
                 + "[grey object rescan, 0.0049340 secs]7.299: [root rescan, 0.0230250 secs], 0.0280700 secs]7.322: "
                 + "[weak refs processing, 0.0001950 secs]7.322: [class unloading, 0.0034660 secs]7.326: "
@@ -255,7 +255,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineJdk8NoGcYgBlockClassUnloading() {
+    void testLogLineJdk8NoGcYgBlockClassUnloading() {
         String logLine = "4.578: [Rescan (parallel) , 0.0185521 secs]4.597: [weak refs processing, 0.0008993 secs]"
                 + "4.598: [class unloading, 0.0046742 secs]4.603: [scrub symbol table, 0.0044444 secs]"
                 + "4.607: [scrub string table, 0.0005670 secs][1 CMS-remark: 6569K(4023936K)] 16685K(4177280K), "
@@ -272,7 +272,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineJdk8NoGcYgBlockNoClassUnloading() {
+    void testLogLineJdk8NoGcYgBlockNoClassUnloading() {
         String logLine = "4237.354: [Rescan (parallel) , 0.1378986 secs]4237.492: [weak refs processing, "
                 + "0.1842394 secs] [1 CMS-remark: 4271964K(8388608K)] 4271964K(12582848K), 0.4124068 secs] "
                 + "[Times: user=2.82 sys=0.04, real=0.41 secs]";
@@ -288,7 +288,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingNoSpaceAfterTrigger() {
+    void testLogLineClassUnloadingNoSpaceAfterTrigger() {
         String logLine = "38.695: [GC (CMS Final Remark)[YG occupancy: 4251867 K (8388608 K)]"
                 + "38.695: [Rescan (parallel) , 0.5678440 secs]39.263: [weak refs processing, 0.0000540 secs]"
                 + "39.263: [class unloading, 0.0065460 secs]39.270: [scrub symbol table, 0.0118150 secs]"
@@ -308,7 +308,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineClassUnloadingDatestamp() {
+    void testLogLineClassUnloadingDatestamp() {
         String logLine = "2016-10-10T18:43:51.337-0700: 3.674: [GC (CMS Final Remark) [YG occupancy: 87907 K "
                 + "(153344 K)]2016-10-10T18:43:51.337-0700: 3.674: [Rescan (parallel) , 0.0590379 secs]"
                 + "2016-10-10T18:43:51.396-0700: 3.733: [weak refs processing, 0.0000785 secs]"
@@ -330,7 +330,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testLogLineTruncated() {
+    void testLogLineTruncated() {
         String logLine = "2017-09-15T09:53:41.262+0200: 19763.069: [GC (CMS Final Remark) "
                 + "[YG occupancy: 425526 K (613440 K)]";
         assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
@@ -342,7 +342,7 @@ public class TestCmsRemarkEvent {
     }
 
     @Test
-    public void testTruncatedPreprocessing() {
+    void testTruncatedPreprocessing() {
         File testFile = TestUtil.getFile("dataset142.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsRemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsRemarkEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -26,7 +26,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,8 +39,7 @@ public class TestCmsRemarkEvent {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]";
-        assertTrue(JdkUtil.LogEventType.CMS_REMARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_REMARK.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -48,13 +47,12 @@ public class TestCmsRemarkEvent {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 253103, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 85701, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
+        assertEquals((long) 253103,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(85701,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
     }
 
     @Test
@@ -62,8 +60,7 @@ public class TestCmsRemarkEvent {
         String logLine = "253.103: [GC[YG occupancy: 16172 K (149120 K)]253.103: "
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs]  ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
     }
 
     @Test
@@ -72,17 +69,16 @@ public class TestCmsRemarkEvent {
                 + "[Rescan (parallel) , 0.0226730 secs]253.126: [weak refs processing, 0.0624566 secs] "
                 + "[1 CMS-remark: 4173470K(8218240K)] 4189643K(8367360K), 0.0857010 secs] "
                 + "[Times: user=0.15 sys=0.01, real=0.09 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 253103, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 85701, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 15, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 9, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 178, event.getParallelism());
+        assertEquals((long) 253103,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(85701,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(15,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(9,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(178,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -91,18 +87,17 @@ public class TestCmsRemarkEvent {
                 + "[Rescan (parallel) , 0.0216980 secs]13.771: [weak refs processing, 0.0005180 secs]13.772: "
                 + "[scrub string table, 0.0015820 secs] [1 CMS-remark: 217008K(341376K)] "
                 + "366644K(494976K), 0.0239510 secs] [Times: user=0.18 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 13749, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Duration not parsed correctly.", 23951, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 18, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 900, event.getParallelism());
+        assertEquals((long) 13749,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(23951,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(18,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(900,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -111,17 +106,16 @@ public class TestCmsRemarkEvent {
                 + "[Rescan (parallel) , 0.0103480 secs]6.469: [weak refs processing, 0.0000110 secs]6.469: "
                 + "[scrub string table, 0.0001750 secs] [1 CMS-remark: 0K(37748736K)] 480317K(43253760K), "
                 + "0.0106300 secs] [Times: user=0.23 sys=0.01, real=0.01 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6458, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 10630, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 23, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 2400, event.getParallelism());
+        assertEquals((long) 6458,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(10630,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(23,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(2400,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -132,17 +126,16 @@ public class TestCmsRemarkEvent {
                 + "2017-03-04T05:36:05.992-0500: 214.604: [scrub string table, 0.0023080 secs] "
                 + "[1 CMS-remark: 6775345K(7340032K)] 8449451K(10092544K), 0.3035200 secs] "
                 + "[Times: user=0.98 sys=0.01, real=0.31 secs] ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 214303, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 303520, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 98, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 31, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 320, event.getParallelism());
+        assertEquals((long) 214303,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(303520,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(98,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(31,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(320,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -150,17 +143,16 @@ public class TestCmsRemarkEvent {
         String logLine = "61.013: [GC (CMS Final Remark) [YG occupancy: 237181 K (471872 K)]61.014: [Rescan (parallel)"
                 + " , 0.0335675 secs]61.047: [weak refs processing, 0.0011687 secs][1 CMS-remark: 1137616K(1572864K)] "
                 + "1374798K(2044736K), 0.0351204 secs] [Times: user=0.12 sys=0.00, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 61013, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 35120, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 12, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 300, event.getParallelism());
+        assertEquals((long) 61013,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(35120,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(12,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -169,12 +161,11 @@ public class TestCmsRemarkEvent {
                 + "[Rescan (parallel) , 0.0574180 secs]76694.785: [weak refs processing, 0.0170540 secs]76694.802: "
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
                 + "[1 CMS-remark: 443542K(4023936K)] 523686K(4177280K), 0.1446880 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 76694727, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 144688, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
+        assertEquals((long) 76694727,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(144688,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
     }
 
     @Test
@@ -183,8 +174,7 @@ public class TestCmsRemarkEvent {
                 + "[Rescan (parallel) , 0.0574180 secs]76694.785: [weak refs processing, 0.0170540 secs]76694.802: "
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
                 + "[1 CMS-remark: 443542K(4023936K)] 523686K(4177280K), 0.1446880 secs]     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
     }
 
     @Test
@@ -194,15 +184,14 @@ public class TestCmsRemarkEvent {
                 + "[class unloading, 0.0363010 secs]76694.838: [scrub symbol & string tables, 0.0276600 secs] "
                 + "[1 CMS-remark: 443542K(4023936K)] 523686K(4177280K), 0.1446880 secs] "
                 + "[Times: user=0.13 sys=0.00, real=0.07 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 76694727, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 144688, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 13, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 7, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 186, event.getParallelism());
+        assertEquals((long) 76694727,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(144688,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(13,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(7,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(186,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -211,12 +200,11 @@ public class TestCmsRemarkEvent {
                 + "75.549: [weak refs processing, 0.0088472 secs]75.558: [class unloading, 0.0049468 secs]75.563: "
                 + "[scrub symbol table, 0.0034342 secs]75.566: [scrub string table, 0.0005542 secs] [1 CMS-remark: "
                 + "378031K(707840K)] 541989K(1014528K), 0.0687411 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 75500, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 68741, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
+        assertEquals((long) 75500,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(68741,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
     }
 
     @Test
@@ -225,8 +213,7 @@ public class TestCmsRemarkEvent {
                 + "75.549: [weak refs processing, 0.0088472 secs]75.558: [class unloading, 0.0049468 secs]75.563: "
                 + "[scrub symbol table, 0.0034342 secs]75.566: [scrub string table, 0.0005542 secs] [1 CMS-remark: "
                 + "378031K(707840K)] 541989K(1014528K), 0.0687411 secs] [Times: user=0.13 sys=0.00, real=0.07 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
     }
 
     @Test
@@ -236,17 +223,16 @@ public class TestCmsRemarkEvent {
                 + "[class unloading, 0.0058936 secs]13.791: [scrub symbol table, 0.0081277 secs]13.799: "
                 + "[scrub string table, 0.0007018 secs][1 CMS-remark: 0K(989632K)] 235489K(1986432K), 0.0430349 secs] "
                 + "[Times: user=0.36 sys=0.00, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 13758, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Duration not parsed correctly.", 43034, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 36, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 900, event.getParallelism());
+        assertEquals((long) 13758,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(43034,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(36,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(900,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -257,16 +243,15 @@ public class TestCmsRemarkEvent {
                 + "[scrub symbol table, 0.0047330 secs]7.330: [scrub string table, 0.0006570 secs] "
                 + "[1 CMS-remark: 7720K(1249088K)] 50319K(1325760K), 0.0375310 secs] "
                 + "[Times: user=0.03 sys=0.01, real=0.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7294, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 37531, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 3, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 3, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 134, event.getParallelism());
+        assertEquals((long) 7294,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(37531,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(3,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(3,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(134,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -275,16 +260,15 @@ public class TestCmsRemarkEvent {
                 + "4.598: [class unloading, 0.0046742 secs]4.603: [scrub symbol table, 0.0044444 secs]"
                 + "4.607: [scrub string table, 0.0005670 secs][1 CMS-remark: 6569K(4023936K)] 16685K(4177280K), "
                 + "0.1025102 secs] [Times: user=0.17 sys=0.01, real=0.10 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4578, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 102510, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 17, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 10, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 180, event.getParallelism());
+        assertEquals((long) 4578,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(102510,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(17,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(10,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(180,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -292,16 +276,15 @@ public class TestCmsRemarkEvent {
         String logLine = "4237.354: [Rescan (parallel) , 0.1378986 secs]4237.492: [weak refs processing, "
                 + "0.1842394 secs] [1 CMS-remark: 4271964K(8388608K)] 4271964K(12582848K), 0.4124068 secs] "
                 + "[Times: user=2.82 sys=0.04, real=0.41 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4237354, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 412406, event.getDuration());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 282, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 4, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 41, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 698, event.getParallelism());
+        assertEquals((long) 4237354,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(412406,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(282,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(4,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(41,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(698,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -312,17 +295,16 @@ public class TestCmsRemarkEvent {
                 + "39.282: [scrub string table, 0.0020090 secs] "
                 + "[1 CMS-remark: 0K(13631488K)] 4251867K(22020096K), 0.5893800 secs] "
                 + "[Times: user=3.92 sys=0.04, real=0.59 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 38695, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Duration not parsed correctly.", 589380, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 392, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 4, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 59, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 672, event.getParallelism());
+        assertEquals((long) 38695,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(589380,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(392,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(4,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(59,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(672,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -335,30 +317,28 @@ public class TestCmsRemarkEvent {
                 + "2016-10-10T18:43:51.428-0700: 3.765: [scrub string table, 0.0013969 secs]"
                 + "[1 CMS-remark: 6993K(8218240K)] 94901K(8371584K), 0.0935737 secs] "
                 + "[Times: user=0.26 sys=0.01, real=0.09 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3674, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Duration not parsed correctly.", 93573, event.getDuration());
-        assertTrue("Class unloading not parsed correctly.", event.isClassUnloading());
-        assertEquals("User time not parsed correctly.", 26, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 9, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 300, event.getParallelism());
+        assertEquals((long) 3674,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(93573,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isClassUnloading(), "Class unloading not parsed correctly.");
+        assertEquals(26,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(9,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineTruncated() {
         String logLine = "2017-09-15T09:53:41.262+0200: 19763.069: [GC (CMS Final Remark) "
                 + "[YG occupancy: 425526 K (613440 K)]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                CmsRemarkEvent.match(logLine));
+        assertTrue(CmsRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
         CmsRemarkEvent event = new CmsRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 19763069, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Duration not parsed correctly.", 0, event.getDuration());
-        assertFalse("Class unloading not parsed correctly.", event.isClassUnloading());
+        assertEquals((long) 19763069,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(0,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isClassUnloading(), "Class unloading not parsed correctly.");
     }
 
     @Test
@@ -368,18 +348,12 @@ public class TestCmsRemarkEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 5, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS));
-        assertTrue(JdkUtil.LogEventType.HEADER_MEMORY.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY));
-        assertTrue(JdkUtil.LogEventType.HEADER_VERSION.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION));
-        assertTrue(JdkUtil.LogEventType.PAR_NEW.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue(JdkUtil.LogEventType.CMS_REMARK.toString() + " not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(5,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS), JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY), JdkUtil.LogEventType.HEADER_MEMORY.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION), JdkUtil.LogEventType.HEADER_VERSION.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), JdkUtil.LogEventType.PAR_NEW.toString() + " not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK), JdkUtil.LogEventType.CMS_REMARK.toString() + " not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsSerialOldEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,8 +42,7 @@ public class TestCmsSerialOldEvent {
                 + "(concurrent mode interrupted): 49392K->48780K(1756416K), 0.2620228 secs] "
                 + "49392K->48780K(2063104K), [Metaspace: 256552K->256552K(1230848K)], 0.2624794 secs] "
                 + "[Times: user=0.26 sys=0.00, real=0.27 secs]";
-        assertTrue(JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -51,21 +50,20 @@ public class TestCmsSerialOldEvent {
         String logLine = "5.980: [Full GC 5.980: "
                 + "[CMS: 5589K->5796K(122880K), 0.0889610 secs] 11695K->5796K(131072K), "
                 + "[CMS Perm : 13140K->13124K(131072K)], 0.0891270 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 5980, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(6106), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(8192), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(5589), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(5796), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(122880), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(13140), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(13124), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 89127, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertEquals((long) 5980,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(6106),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(8192),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(5589),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(5796),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(122880),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(13140),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(13124),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(89127,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -73,8 +71,7 @@ public class TestCmsSerialOldEvent {
         String logLine = "5.980: [Full GC 5.980: "
                 + "[CMS: 5589K->5796K(122880K), 0.0889610 secs] 11695K->5796K(131072K), "
                 + "[CMS Perm : 13140K->13124K(131072K)], 0.0891270 secs] ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -82,45 +79,41 @@ public class TestCmsSerialOldEvent {
         String logLine = "2.425: [Full GC (System) 2.425: "
                 + "[CMS: 1231K->2846K(114688K), 0.0827010 secs] 8793K->2846K(129472K), "
                 + "[CMS Perm : 8602K->8593K(131072K)], 0.0828090 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Time stamp not parsed correctly.", 2425, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(7562), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(14784), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1231), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2846), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(114688), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(8602), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(8593), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 82809, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 2425,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(7562),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(14784),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1231),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2846),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(114688),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(8602),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(8593),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(82809,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
     public void testLogLineIcmsDcData() {
         String logLine = "165.805: [Full GC 165.805: [CMS: 101481K->97352K(1572864K), 1.1183800 secs] "
                 + "287075K->97352K(2080768K), [CMS Perm : 68021K->67965K(262144K)] icms_dc=10 , 1.1186020 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 165805, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes((287075 - 101481)),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((97352 - 97352)), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((2080768 - 1572864)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(101481), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(97352), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1572864), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(68021), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(67965), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1118602, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertEquals((long) 165805,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes((287075 - 101481)),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((97352 - 97352)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((2080768 - 1572864)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(101481),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(97352),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1572864),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(68021),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(67965),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1118602,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -128,11 +121,10 @@ public class TestCmsSerialOldEvent {
         String logLine = "1504.625: [Full GC1504.625: [CMS: 1172695K->840574K(1549164K), 3.7572507 secs] "
                 + "1301420K->840574K(1855852K), [CMS Perm : 226817K->226813K(376168K)], "
                 + "3.7574584 secs] [Times: user=3.74 sys=0.00, real=3.76 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1504625L, event.getTimestamp());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertEquals(1504625L,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -140,24 +132,21 @@ public class TestCmsSerialOldEvent {
         String logLine = "44.684: [Full GC44.684: [CMS (concurrent mode failure): 1218548K->413373K(1465840K), "
                 + "1.3656970 secs] 1229657K->413373K(1581168K), [CMS Perm : 83805K->80520K(83968K)], 1.3659420 secs] "
                 + "[Times: user=1.33 sys=0.01, real=1.37 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 44684, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1229657 - 1218548),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(413373 - 413373), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1581168 - 1465840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1218548), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(413373), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1465840), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(83805), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(80520), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(83968), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1365942, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 44684,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1229657 - 1218548),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(413373 - 413373),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1581168 - 1465840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1218548),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(413373),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1465840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(83805),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(80520),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(83968),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1365942,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -166,24 +155,21 @@ public class TestCmsSerialOldEvent {
                 + "861863K->904027K(1797568K), 42.9053262 secs] 1045947K->904027K(2047232K), "
                 + "[CMS Perm : 252246K->252202K(262144K)], 42.9070278 secs] "
                 + "[Times: user=43.11 sys=0.18, real=42.91 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_INTERRUPTED));
-        assertEquals("Time stamp not parsed correctly.", 85030389, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1045947 - 861863),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(904027 - 904027), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(2047232 - 1797568), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(861863), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(904027), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1797568), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(252246), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(252202), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 42907027, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_INTERRUPTED), "Trigger not parsed correctly.");
+        assertEquals((long) 85030389,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1045947 - 861863),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(904027 - 904027),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(2047232 - 1797568),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(861863),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(904027),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1797568),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(252246),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(252202),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(42907027,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -192,24 +178,21 @@ public class TestCmsSerialOldEvent {
                 + "[CMS: 945496K->961540K(4755456K), 0.8503670 secs] 1432148K->961540K(6137856K), "
                 + "[Metaspace: 73362K->73362K(1118208K)], 0.8553350 secs] "
                 + "[Times: user=0.83 sys=0.03, real=0.86 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC));
-        assertEquals("Time stamp not parsed correctly.", 2854464, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1432148 - 945496),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(961540 - 961540), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(6137856 - 4755456), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(945496), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(961540), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4755456), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(73362), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(73362), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1118208), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 855335, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 2854464,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1432148 - 945496),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(961540 - 961540),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(6137856 - 4755456),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(945496),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(961540),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4755456),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(73362),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(73362),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1118208),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(855335,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -217,25 +200,21 @@ public class TestCmsSerialOldEvent {
         String logLine = "4300.825: [Full GC 4300.825: [CMSbailing out to foreground collection (concurrent mode "
                 + "failure): 6014591K->6014592K(6014592K), 79.9352305 secs] 6256895K->6147510K(6256896K), [CMS Perm "
                 + ": 206989K->206977K(262144K)], 79.9356622 secs] [Times: user=101.02 sys=3.09, real=79.94 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 4300825, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(6256895 - 6014591),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(6147510 - 6014592),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(6256896 - 6014592), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(6014591), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(6014592), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6014592), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(206989), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(206977), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 79935662, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 4300825,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(6256895 - 6014591),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(6147510 - 6014592),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(6256896 - 6014592),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(6014591),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(6014592),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6014592),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(206989),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(206977),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(79935662,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -245,25 +224,21 @@ public class TestCmsSerialOldEvent {
                 + "[Metaspace: 72496K->72496K(1118208K)] icms_dc=77 , 11.6770830 secs] "
                 + "[Times: user=14.05 sys=0.02, real=11.68 secs]";
 
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 706707, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(3973407 - 2655937),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(2373842 - 2373842),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(4040704 - 2658304), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2655937), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2373842), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2658304), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(72496), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(72496), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1118208), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 11677083, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 706707,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(3973407 - 2655937),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(2373842 - 2373842),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(4040704 - 2658304),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2655937),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2373842),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2658304),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(72496),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(72496),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1118208),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(11677083,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -273,23 +248,21 @@ public class TestCmsSerialOldEvent {
                 + "3198859K->635365K(7848704K), [CMS Perm : 851635K->408849K(1048576K)], 94.9116214 secs] "
                 + "[Times: user=94.88 sys=0.24, real=94.91 secs]";
 
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CLASS_HISTOGRAM));
-        assertEquals("Time stamp not parsed correctly.", 11662232, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(3198859 - 2844387),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(635365 - 635365), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(7848704 - 7331840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2844387), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(635365), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(851635), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(408849), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1048576), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 94911621, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CLASS_HISTOGRAM), "Trigger not parsed correctly.");
+        assertEquals((long) 11662232,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(3198859 - 2844387),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(635365 - 635365),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(7848704 - 7331840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2844387),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(635365),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(851635),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(408849),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(94911621,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -301,24 +274,21 @@ public class TestCmsSerialOldEvent {
                 + "457349K->457254K(4177280K), [CMS Perm : 260428K->260406K(262144K)], 0.5167600 secs] "
                 + "[Times: user=0.55 sys=0.01, real=0.52 secs]";
 
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 85217903, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(457349 - 423728),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(457254 - 423633), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(4177280 - 4023936), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(423728), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(423633), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4023936), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(260428), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(260406), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 516760, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 85217903,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(457349 - 423728),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(457254 - 423633),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(4177280 - 4023936),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(423728),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(423633),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4023936),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(260428),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(260406),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(516760,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -328,23 +298,21 @@ public class TestCmsSerialOldEvent {
                 + "3198859K->635365K(7848704K), [CMS Perm : 851635K->408849K(1048576K)], 94.9116214 secs] "
                 + "[Times: user=94.88 sys=0.24, real=94.91 secs]";
 
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CLASS_HISTOGRAM));
-        assertEquals("Time stamp not parsed correctly.", 11662232, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(3198859 - 2844387),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(635365 - 635365), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(7848704 - 7331840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2844387), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(635365), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(851635), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(408849), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1048576), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 94911621, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CLASS_HISTOGRAM), "Trigger not parsed correctly.");
+        assertEquals((long) 11662232,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(3198859 - 2844387),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(635365 - 635365),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(7848704 - 7331840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2844387),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(635365),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(851635),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(408849),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(94911621,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -352,23 +320,21 @@ public class TestCmsSerialOldEvent {
         String logLine = "262371.895: [Full GC (Metadata GC Threshold) 262371.895: [CMS: 42863K->49512K(1756416K), "
                 + "0.2337314 secs] 176820K->49512K(2063104K), [Metaspace: 256586K->256586K(1230848K)], "
                 + "0.2343092 secs] [Times: user=0.23 sys=0.00, real=0.23 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Time stamp not parsed correctly.", 262371895, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(176820 - 42863),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(49512 - 49512), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(2063104 - 1756416), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(42863), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(49512), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1756416), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(256586), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(256586), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1230848), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 234309, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals((long) 262371895,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(176820 - 42863),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(49512 - 49512),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(2063104 - 1756416),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(42863),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(49512),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1756416),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(256586),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(256586),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1230848),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(234309,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -376,22 +342,21 @@ public class TestCmsSerialOldEvent {
         String logLine = "262372.130: [Full GC (Last ditch collection) 262372.130: [CMS: 49512K->49392K(1756416K), "
                 + "0.2102326 secs] 49512K->49392K(2063104K), [Metaspace: 256586K->256586K(1230848K)], 0.2108635 secs] "
                 + "[Times: user=0.20 sys=0.00, real=0.21 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION));
-        assertEquals("Time stamp not parsed correctly.", 262372130, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(49512 - 49512), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(49392 - 49392), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(2063104 - 1756416), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(49512), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(49392), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1756416), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(256586), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(256586), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1230848), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 210863, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION), "Trigger not parsed correctly.");
+        assertEquals((long) 262372130,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(49512 - 49512),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(49392 - 49392),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(2063104 - 1756416),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(49512),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(49392),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1756416),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(256586),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(256586),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1230848),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(210863,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -400,45 +365,42 @@ public class TestCmsSerialOldEvent {
                 + "(concurrent mode interrupted): 49392K->48780K(1756416K), 0.2620228 secs] "
                 + "49392K->48780K(2063104K), [Metaspace: 256552K->256552K(1230848K)], 0.2624794 secs] "
                 + "[Times: user=0.26 sys=0.00, real=0.27 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_INTERRUPTED));
-        assertEquals("Time stamp not parsed correctly.", 262372344, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(49392 - 49392), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(48780 - 48780), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(2063104 - 1756416), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(49392), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(48780), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1756416), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(256552), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(256552), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1230848), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 262479, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_INTERRUPTED), "Trigger not parsed correctly.");
+        assertEquals((long) 262372344,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(49392 - 49392),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(48780 - 48780),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(2063104 - 1756416),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(49392),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(48780),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1756416),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(256552),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(256552),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1230848),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(262479,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
     public void testLogLineParNewPromotionFailed() {
         String logLine = "144501.626: [GC 144501.627: [ParNew (promotion failed): 680066K->680066K(707840K), "
                 + "3.7067346 secs] 1971073K->1981370K(2018560K), 3.7084059 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 144501626, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(680066), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(707840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1971073 - 680066), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(0), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2018560 - 707840), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(0), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(0), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(0), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3708405, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 144501626,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(680066),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(707840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1971073 - 680066),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2018560 - 707840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3708405,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -446,13 +408,12 @@ public class TestCmsSerialOldEvent {
         String logLine = "159275.552: [GC 159275.552: [ParNew (promotion failed): 2007040K->2007040K(2007040K), "
                 + "4.3393411 secs] 5167424K->5187429K(12394496K) icms_dc=7 , 4.3398519 secs] "
                 + "[Times: user=4.96 sys=1.91, real=4.34 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 159275552, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 4339851, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 159275552,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(4339851,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -460,42 +421,39 @@ public class TestCmsSerialOldEvent {
         String logLine = "1181.943: [GC 1181.943: [ParNew (promotion failed): 145542K->142287K(149120K), "
                 + "0.1316193 secs]1182.075: [CMS: 6656483K->548489K(8218240K), 9.1244297 secs] "
                 + "6797120K->548489K(8367360K), 9.2564476 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 1181943, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(145542), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(548489 - 548489), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(149120), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(6656483), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(548489), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(8218240), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(0), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(0), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(0), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 9256447, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 1181943,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(145542),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(548489 - 548489),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(149120),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(6656483),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(548489),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(8218240),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(9256447,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
     public void testParNewPromotionFailedTruncated() {
         String logLine = "5881.424: [GC 5881.424: [ParNew (promotion failed): 153272K->152257K(153344K), "
                 + "0.2143850 secs]5881.639: [CMS";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 5881424, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 214385, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 5881424,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(214385,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
     public void testFirstLineOfMultiLineParallelScavengeEvent() {
         String logLine = "10.392: [GC";
-        assertFalse("Log line incorrectly recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertFalse(CmsSerialOldEvent.match(logLine), "Log line incorrectly recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -503,19 +461,18 @@ public class TestCmsSerialOldEvent {
         String logLine = "3546.690: [GC 3546.691: [ParNew: 532480K->532480K(599040K), 0.0000400 secs]3546.691: "
                 + "[CMS: 887439K->893801K(907264K), 9.6413020 secs] 1419919K->893801K(1506304K), 9.6419180 secs] "
                 + "[Times: user=9.54 sys=0.10, real=9.65 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 3546690, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(532480), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(599040), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(887439), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(893801), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(907264), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 9641918, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 3546690,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(532480),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(599040),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(887439),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(893801),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(907264),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(9641918,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     /**
@@ -526,19 +483,18 @@ public class TestCmsSerialOldEvent {
         String logLine = "289985.117: [GC 289985.117: [ParNew (promotion failed): 144192K->144192K(144192K), "
                 + "0.1347360 secs]289985.252: [Tenured: 1281600K->978341K(1281600K), 3.6577930 secs] "
                 + "1409528K->978341K(1425792K), 3.7930200 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 289985117, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(144192), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(978341 - 978341), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(144192), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1281600), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(978341), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1281600), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 3793020, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 289985117,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(144192),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(978341 - 978341),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(144192),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1281600),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(978341),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1281600),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(3793020,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -547,23 +503,21 @@ public class TestCmsSerialOldEvent {
                 + "53094K->53606K(59008K), 0.0510880 secs]395950.421: "
                 + "[CMS: 664527K->317110K(1507328K), 2.9523520 secs] 697709K->317110K(1566336K), "
                 + "[CMS Perm : 83780K->83711K(131072K)], 3.0039040 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 395950370, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(53094), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((317110 - 317110)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(59008), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(664527), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(317110), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1507328), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(83780), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(83711), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3003904, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 395950370,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(53094),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((317110 - 317110)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(59008),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(664527),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(317110),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1507328),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(83780),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(83711),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3003904,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -572,23 +526,21 @@ public class TestCmsSerialOldEvent {
                 + "1.7740754 secs]4597.425: [CMS: 967034K->684015K(4886528K), 3.2678588 secs] "
                 + "2022731K->684015K(6191104K), [CMS Perm : 201541K->201494K(524288K)] icms_dc=21 , "
                 + "5.0421688 secs] [Times: user=5.54 sys=0.01, real=5.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 4595651, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1304576), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((684015 - 684015)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1304576), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(967034), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(684015), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4886528), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(201541), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(201494), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(524288), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 5042168, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 4595651,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1304576),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((684015 - 684015)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1304576),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(967034),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(684015),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4886528),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(201541),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(201494),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(5042168,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -597,23 +549,21 @@ public class TestCmsSerialOldEvent {
                 + "0.4259330 secs]108537.946: [CMS: 13135135K->4554003K(16914880K), 14.7637760 secs] "
                 + "14542753K->4554003K(18482496K), [CMS Perm : 227503K->226115K(378908K)], 15.1927120 secs] "
                 + "[Times: user=16.31 sys=0.21, real=15.19 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 108537519, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1409215), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((4554003 - 4554003)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1567616), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(13135135), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(4554003), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(16914880), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(227503), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(226115), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(378908), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 15192712, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 108537519,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1409215),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((4554003 - 4554003)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1567616),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(13135135),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(4554003),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(16914880),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(227503),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(226115),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(378908),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(15192712,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -623,23 +573,21 @@ public class TestCmsSerialOldEvent {
                 + "[CMS: 3354568K->756393K(7331840K), 53.1398170 secs]182411.482: [Class Histogram, 11.0299920 secs]"
                 + " 3863904K->756393K(7848704K), [CMS Perm : 682507K->442221K(1048576K)], 107.6553710 secs]"
                 + " [Times: user=112.83 sys=0.28, real=107.66 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 182314858, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(516864), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((756393 - 756393)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(516864), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(3354568), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(756393), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(682507), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(442221), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1048576), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 107655371, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 182314858,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(516864),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((756393 - 756393)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(516864),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(3354568),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(756393),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(682507),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(442221),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(107655371,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -647,23 +595,18 @@ public class TestCmsSerialOldEvent {
         String logLine = "26683.209: [GC 26683.210: [ParNew: 261760K->261760K(261952K), "
                 + "0.0000130 secs]26683.210: [CMS (concurrent mode failure): 1141548K->1078465K(1179648K), "
                 + "7.3835370 secs] 1403308K->1078465K(1441600K), 7.3838390 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 26683209, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes((1403308 - 1141548)),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((1078465 - 1078465)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((1441600 - 1179648)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1141548), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(1078465), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1179648), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 7383839, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 26683209,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes((1403308 - 1141548)),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((1078465 - 1078465)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((1441600 - 1179648)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1141548),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(1078465),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1179648),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(7383839,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -671,21 +614,18 @@ public class TestCmsSerialOldEvent {
         String logLine = "25281.015: [GC 25281.015: [ParNew (promotion failed): 261760K->261760K(261952K), "
                 + "0.1785000 secs]25281.193: [CMS (concurrent mode failure): 1048384K->1015603K(1179648K), "
                 + "7.6767910 secs] 1292923K->1015603K(1441600K), 7.8557660 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 25281015, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(261760), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((1015603 - 1015603)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(261952), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1048384), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(1015603), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1179648), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 7855766, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 25281015,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(261760),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((1015603 - 1015603)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(261952),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1048384),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(1015603),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1179648),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(7855766,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -695,20 +635,18 @@ public class TestCmsSerialOldEvent {
                 + "0.4501923 secs]2017-02-28T00:43:56.037+0000: 36844.234: [CMS: 2818067K->2769354K(5120000K), "
                 + "3.8341757 secs] 5094036K->2769354K(7424000K), [Metaspace: 18583K->18583K(1067008K)], "
                 + "4.2847962 secs] [Times: user=9.11 sys=0.00, real=4.29 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 36843783, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(2304000), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((2769354 - 2769354)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(2304000), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2818067), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2769354), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(5120000), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 4284796, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 36843783,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(2304000),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((2769354 - 2769354)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(2304000),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2818067),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2769354),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(5120000),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(4284796,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -716,19 +654,18 @@ public class TestCmsSerialOldEvent {
         String logLine = "42782.086: [GC 42782.086: [ParNew: 254464K->7680K(254464K), 0.2853553 secs]"
                 + "42782.371: [Tenured: 1082057K->934941K(1082084K), 6.2719770 secs] "
                 + "1310721K->934941K(1336548K), 6.5587770 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 42782086, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(254464), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(254464), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1082057), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(934941), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1082084), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 6558777, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 42782086,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(254464),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(254464),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1082057),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(934941),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1082084),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(6558777,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -736,22 +673,21 @@ public class TestCmsSerialOldEvent {
         String logLine = "6.102: [GC6.102: [ParNew: 19648K->2176K(19648K), 0.0184470 secs]6.121: "
                 + "[Tenured: 44849K->25946K(44864K), 0.2586250 secs] 60100K->25946K(64512K), "
                 + "[Perm : 43759K->43759K(262144K)], 0.2773070 secs] [Times: user=0.16 sys=0.01, real=0.28 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 6102, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(19648), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(25946 - 25946), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(64512 - 44864), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(44849), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(25946), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(44864), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(43759), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(43759), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 277307, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 6102,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(19648),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(25946 - 25946),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(64512 - 44864),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(44849),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(25946),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(44864),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(43759),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(43759),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(277307,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -760,23 +696,21 @@ public class TestCmsSerialOldEvent {
                 + "0.0000530 secs]1817.646: [CMS: 2658303K->2658303K(2658304K), 8.7951430 secs] "
                 + "4040686K->2873414K(4040704K), [Metaspace: 72200K->72200K(1118208K)], 8.7986750 secs] "
                 + "[Times: user=8.79 sys=0.01, real=8.80 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 1817644, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1382383), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(2873414 - 2658303),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(4040704 - 2658304), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2658303), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2658303), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2658304), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(72200), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(72200), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1118208), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 8798675, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 1817644,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1382383),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(2873414 - 2658303),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(4040704 - 2658304),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2658303),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2658303),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2658304),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(72200),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(72200),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1118208),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(8798675,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -785,26 +719,21 @@ public class TestCmsSerialOldEvent {
                 + "[CMS (concurrent mode failure): 6010121K->6014591K(6014592K), 79.0505229 secs] "
                 + "6217865K->6028029K(6256896K), [CMS Perm : 206688K->206662K(262144K)], 79.0509595 secs] "
                 + "[Times: user=104.69 sys=3.63, real=79.05 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 3070289, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes((6217865 - 6010121)),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((6028029 - 6014591)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((6256896 - 6014592)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(6010121), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(6014591), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6014592), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(206688), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(206662), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(262144), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 79050959, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 3070289,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes((6217865 - 6010121)),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((6028029 - 6014591)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((6256896 - 6014592)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(6010121),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(6014591),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6014592),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(206688),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(206662),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(262144),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(79050959,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -813,23 +742,18 @@ public class TestCmsSerialOldEvent {
                 + "[CMSJava HotSpot(TM) Server VM warning: bailing out to foreground collection (concurrent mode "
                 + "failure): 1794415K->909664K(1835008K), 124.5953890 secs] 2056175K->909664K(2096960K) "
                 + "icms_dc=100 , 124.5963320 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 1901217, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes((2056175 - 1794415)),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((909664 - 909664)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((2096960 - 1835008)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1794415), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(909664), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1835008), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 124596332, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 1901217,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes((2056175 - 1794415)),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((909664 - 909664)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((2096960 - 1835008)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1794415),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(909664),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1835008),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(124596332,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -838,25 +762,21 @@ public class TestCmsSerialOldEvent {
                 + "0.0000470 secs] (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 719519, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1382400), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((2702358 - 2658278)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((4040704 - 2658304)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2542828), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2658278), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2658304), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(72175), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(72175), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1118208), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 12348057, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 719519,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1382400),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((2702358 - 2658278)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((4040704 - 2658304)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2542828),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2658278),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2658304),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(72175),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(72175),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1118208),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(12348057,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -865,25 +785,21 @@ public class TestCmsSerialOldEvent {
                 + "0.0000500 secs]1202.528: [CMS (concurrent mode failure): 2656311K->2658289K(2658304K), "
                 + "9.3575580 secs] 4011734K->2725109K(4040704K), [Metaspace: 72111K->72111K(1118208K)], "
                 + "9.3610080 secs] [Times: user=9.35 sys=0.01, real=9.36 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 1202526, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1355422), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((2725109 - 2658289)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((4040704 - 2658304)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2656311), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2658289), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2658304), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(72111), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(72111), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1118208), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 9361008, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 1202526,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1355422),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((2725109 - 2658289)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((4040704 - 2658304)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2656311),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2658289),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2658304),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(72111),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(72111),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1118208),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(9361008,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -894,25 +810,21 @@ public class TestCmsSerialOldEvent {
                 + "572349.355: [Class Histogram, 12.1674045 secs] 5825751K->891234K(7848704K), "
                 + "[CMS Perm : 500357K->443269K(1048576K)], 97.2188825 secs] "
                 + "[Times: user=100.78 sys=0.18, real=97.22 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 572264304, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(516864), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((891234 - 891234)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((7848704 - 7331840)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(5350445), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(891234), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(500357), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(443269), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1048576), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 97218882, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 572264304,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(516864),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((891234 - 891234)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((7848704 - 7331840)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(5350445),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(891234),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(500357),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(443269),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(97218882,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -923,24 +835,21 @@ public class TestCmsSerialOldEvent {
                 + "576531.823: [Class Histogram, 12.2976631 secs] 5566845K->905970K(7848704K), "
                 + "[CMS Perm : 498279K->443366K(1048576K)], 83.6775207 secs] "
                 + "[Times: user=87.62 sys=0.20, real=83.68 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Time stamp not parsed correctly.", 576460444, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(516864), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes((905970 - 905970)),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes((7848704 - 7331840)),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(5074711), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(905970), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(498279), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(443366), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1048576), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 83677520, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals((long) 576460444,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(516864),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes((905970 - 905970)),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes((7848704 - 7331840)),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(5074711),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(905970),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(498279),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(443366),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(83677520,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -949,26 +858,21 @@ public class TestCmsSerialOldEvent {
                 + "13441202K->12005469K(13631488K), 23.1836190 secs] 19349630K->12005469K(22020096K), "
                 + "[CMS Perm : 1257346K->1257346K(2097152K)] icms_dc=100 , 23.1838500 secs] "
                 + "[Times: user=22.77 sys=0.39, real=23.18 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 58626878, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(19349630 - 13441202),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(12005469 - 12005469),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(22020096 - 13631488),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(13441202), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(12005469), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(13631488), event.getOldSpace());
-        assertEquals("Perm begin size not parsed correctly.", kilobytes(1257346), event.getPermOccupancyInit());
-        assertEquals("Perm end size not parsed correctly.", kilobytes(1257346), event.getPermOccupancyEnd());
-        assertEquals("Perm allocation size not parsed correctly.", kilobytes(2097152), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 23183850, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 58626878,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(19349630 - 13441202),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(12005469 - 12005469),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(22020096 - 13631488),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(13441202),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(12005469),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(13631488),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(1257346),event.getPermOccupancyInit(),"Perm begin size not parsed correctly.");
+        assertEquals(kilobytes(1257346),event.getPermOccupancyEnd(),"Perm end size not parsed correctly.");
+        assertEquals(kilobytes(2097152),event.getPermSpace(),"Perm allocation size not parsed correctly.");
+        assertEquals(23183850,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -978,24 +882,21 @@ public class TestCmsSerialOldEvent {
                 + "471419.156: [CMS (concurrent mode failure): 5977264K->1290167K(7331840K), 59.2834068 secs]"
                 + "471478.440: [Class Histogram, 15.6352805 secs] 6449325K->1290167K(7848704K), [CMS Perm : "
                 + "473438K->450663K(771512K)], 102.3357902 secs] [Times: user=106.25 sys=0.21, real=102.34 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 471391741, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(516864), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(1290167 - 1290167),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(7848704 - 7331840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(5977264), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(1290167), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(7331840), event.getOldSpace());
-        assertEquals("Perm begin size not parsed correctly.", kilobytes(473438), event.getPermOccupancyInit());
-        assertEquals("Perm end size not parsed correctly.", kilobytes(450663), event.getPermOccupancyEnd());
-        assertEquals("Perm allocation size not parsed correctly.", kilobytes(771512), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 102335790, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 471391741,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(516864),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(1290167 - 1290167),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(7848704 - 7331840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(5977264),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(1290167),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(7331840),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(473438),event.getPermOccupancyInit(),"Perm begin size not parsed correctly.");
+        assertEquals(kilobytes(450663),event.getPermOccupancyEnd(),"Perm end size not parsed correctly.");
+        assertEquals(kilobytes(771512),event.getPermSpace(),"Perm allocation size not parsed correctly.");
+        assertEquals(102335790,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -1006,26 +907,21 @@ public class TestCmsSerialOldEvent {
                 + "2017-05-03T14:52:48.982-0400: 2133.641: [Class Histogram, 11.9525850 secs] "
                 + "13363199K->9728622K(13363200K), [CMS Perm : 376898K->376894K(524288K)], 88.2785270 secs] "
                 + "[Times: user=86.32 sys=0.39, real=88.27 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                CmsSerialOldEvent.match(logLine));
+        assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
         CmsSerialOldEvent event = new CmsSerialOldEvent(logLine);
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 2057323, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(13363199 - 9216000),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(9728622 - 9215999),
-                event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(13363200 - 9216000),
-                event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(9216000), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(9215999), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(9216000), event.getOldSpace());
-        assertEquals("Perm begin size not parsed correctly.", kilobytes(376898), event.getPermOccupancyInit());
-        assertEquals("Perm end size not parsed correctly.", kilobytes(376894), event.getPermOccupancyEnd());
-        assertEquals("Perm allocation size not parsed correctly.", kilobytes(524288), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 88278527, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CONCURRENT_MODE_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 2057323,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(13363199 - 9216000),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(9728622 - 9215999),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(13363200 - 9216000),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(9216000),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(9215999),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(9216000),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(376898),event.getPermOccupancyInit(),"Perm begin size not parsed correctly.");
+        assertEquals(kilobytes(376894),event.getPermOccupancyEnd(),"Perm end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getPermSpace(),"Perm allocation size not parsed correctly.");
+        assertEquals(88278527,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -1035,19 +931,13 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_INITIAL_MARK));
-        assertTrue(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED), Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     /**
@@ -1060,17 +950,12 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC), Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     @Test
@@ -1080,15 +965,11 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     @Test
@@ -1098,13 +979,10 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     @Test
@@ -1114,15 +992,11 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     /**
@@ -1136,15 +1010,11 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE), Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.");
     }
 
     @Test
@@ -1154,17 +1024,12 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(LogEventType.CMS_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
-        assertTrue(Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), LogEventType.CMS_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE), Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.");
     }
 
     /**
@@ -1178,15 +1043,11 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.WARN_HEAP_INSPECTION_INITIATED_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_INSPECTION_INITIATED_GC));
-        assertFalse(Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_INSPECTION_INITIATED_GC), Analysis.WARN_HEAP_INSPECTION_INITIATED_GC + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.");
     }
 
     /**
@@ -1200,15 +1061,11 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis not identified.");
     }
 
     /**
@@ -1222,14 +1079,10 @@ public class TestCmsSerialOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.WARN_HEAP_DUMP_INITIATED_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_INITIATED_GC));
-        assertFalse(Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_INITIATED_GC), Analysis.WARN_HEAP_DUMP_INITIATED_GC + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestCmsSerialOldEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestCmsSerialOldEvent {
+class TestCmsSerialOldEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "262372.344: [Full GC (JvmtiEnv ForceGarbageCollection) 262372.344: [CMS "
                 + "(concurrent mode interrupted): 49392K->48780K(1756416K), 0.2620228 secs] "
                 + "49392K->48780K(2063104K), [Metaspace: 256552K->256552K(1230848K)], 0.2624794 secs] "
@@ -46,7 +46,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "5.980: [Full GC 5.980: "
                 + "[CMS: 5589K->5796K(122880K), 0.0889610 secs] 11695K->5796K(131072K), "
                 + "[CMS Perm : 13140K->13124K(131072K)], 0.0891270 secs]";
@@ -67,7 +67,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "5.980: [Full GC 5.980: "
                 + "[CMS: 5589K->5796K(122880K), 0.0889610 secs] 11695K->5796K(131072K), "
                 + "[CMS Perm : 13140K->13124K(131072K)], 0.0891270 secs] ";
@@ -75,7 +75,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineJdk16WithTrigger() {
+    void testLogLineJdk16WithTrigger() {
         String logLine = "2.425: [Full GC (System) 2.425: "
                 + "[CMS: 1231K->2846K(114688K), 0.0827010 secs] 8793K->2846K(129472K), "
                 + "[CMS Perm : 8602K->8593K(131072K)], 0.0828090 secs]";
@@ -97,7 +97,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineIcmsDcData() {
+    void testLogLineIcmsDcData() {
         String logLine = "165.805: [Full GC 165.805: [CMS: 101481K->97352K(1572864K), 1.1183800 secs] "
                 + "287075K->97352K(2080768K), [CMS Perm : 68021K->67965K(262144K)] icms_dc=10 , 1.1186020 secs]";
         assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
@@ -117,7 +117,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineAfterPreprocessingNoSpaceAfterFullGC() {
+    void testLogLineAfterPreprocessingNoSpaceAfterFullGC() {
         String logLine = "1504.625: [Full GC1504.625: [CMS: 1172695K->840574K(1549164K), 3.7572507 secs] "
                 + "1301420K->840574K(1855852K), [CMS Perm : 226817K->226813K(376168K)], "
                 + "3.7574584 secs] [Times: user=3.74 sys=0.00, real=3.76 secs]";
@@ -128,7 +128,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerConcurrentModeFailure() {
+    void testLogLineTriggerConcurrentModeFailure() {
         String logLine = "44.684: [Full GC44.684: [CMS (concurrent mode failure): 1218548K->413373K(1465840K), "
                 + "1.3656970 secs] 1229657K->413373K(1581168K), [CMS Perm : 83805K->80520K(83968K)], 1.3659420 secs] "
                 + "[Times: user=1.33 sys=0.01, real=1.37 secs]";
@@ -150,7 +150,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerConcurrentModeInterrupted() {
+    void testLogLineTriggerConcurrentModeInterrupted() {
         String logLine = "85030.389: [Full GC 85030.390: [CMS (concurrent mode interrupted): "
                 + "861863K->904027K(1797568K), 42.9053262 secs] 1045947K->904027K(2047232K), "
                 + "[CMS Perm : 252246K->252202K(262144K)], 42.9070278 secs] "
@@ -173,7 +173,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerHeapInspectionInitiatedGc() {
+    void testLogLineTriggerHeapInspectionInitiatedGc() {
         String logLine = "2854.464: [Full GC (Heap Inspection Initiated GC) 2854.465: "
                 + "[CMS: 945496K->961540K(4755456K), 0.8503670 secs] 1432148K->961540K(6137856K), "
                 + "[Metaspace: 73362K->73362K(1118208K)], 0.8553350 secs] "
@@ -196,7 +196,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testFullGcBailing() {
+    void testFullGcBailing() {
         String logLine = "4300.825: [Full GC 4300.825: [CMSbailing out to foreground collection (concurrent mode "
                 + "failure): 6014591K->6014592K(6014592K), 79.9352305 secs] 6256895K->6147510K(6256896K), [CMS Perm "
                 + ": 206989K->206977K(262144K)], 79.9356622 secs] [Times: user=101.02 sys=3.09, real=79.94 secs]";
@@ -218,7 +218,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineIncrementalModeMetaspace() {
+    void testLogLineIncrementalModeMetaspace() {
         String logLine = "706.707: [Full GC (Allocation Failure) 706.708: [CMS (concurrent mode failure): "
                 + "2655937K->2373842K(2658304K), 11.6746550 secs] 3973407K->2373842K(4040704K), "
                 + "[Metaspace: 72496K->72496K(1118208K)] icms_dc=77 , 11.6770830 secs] "
@@ -242,7 +242,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedClassHistogram() {
+    void testLogLinePreprocessedClassHistogram() {
         String logLine = "11662.232: [Full GC 11662.233: [Class Histogram:, 38.6969442 secs]11700.930: "
                 + "[CMS: 2844387K->635365K(7331840K), 46.4488813 secs]11747.379: [Class Histogram, 9.7637786 secs] "
                 + "3198859K->635365K(7848704K), [CMS Perm : 851635K->408849K(1048576K)], 94.9116214 secs] "
@@ -266,7 +266,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedConcurrentModeFailureRemarkBlock() {
+    void testLogLinePreprocessedConcurrentModeFailureRemarkBlock() {
         String logLine = "85217.903: [Full GC 85217.903: [CMS (concurrent mode failure) (concurrent mode failure)"
                 + "[YG occupancy: 33620K (153344K)]85217.919: [Rescan (parallel) , 0.0116680 secs]85217.931: "
                 + "[weak refs processing, 0.0167100 secs]85217.948: [class unloading, 0.0571300 secs]85218.005: "
@@ -292,7 +292,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedClassHistogramWithOldData() {
+    void testLogLinePreprocessedClassHistogramWithOldData() {
         String logLine = "11662.232: [Full GC 11662.233: [Class Histogram:, 38.6969442 secs]11700.930: "
                 + "[CMS: 2844387K->635365K(7331840K), 46.4488813 secs]11747.379: [Class Histogram, 9.7637786 secs] "
                 + "3198859K->635365K(7848704K), [CMS Perm : 851635K->408849K(1048576K)], 94.9116214 secs] "
@@ -316,7 +316,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerMetadataGcThreshold() {
+    void testLogLineTriggerMetadataGcThreshold() {
         String logLine = "262371.895: [Full GC (Metadata GC Threshold) 262371.895: [CMS: 42863K->49512K(1756416K), "
                 + "0.2337314 secs] 176820K->49512K(2063104K), [Metaspace: 256586K->256586K(1230848K)], "
                 + "0.2343092 secs] [Times: user=0.23 sys=0.00, real=0.23 secs]";
@@ -338,7 +338,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerLastDitchCollection() {
+    void testLogLineTriggerLastDitchCollection() {
         String logLine = "262372.130: [Full GC (Last ditch collection) 262372.130: [CMS: 49512K->49392K(1756416K), "
                 + "0.2102326 secs] 49512K->49392K(2063104K), [Metaspace: 256586K->256586K(1230848K)], 0.2108635 secs] "
                 + "[Times: user=0.20 sys=0.00, real=0.21 secs]";
@@ -360,7 +360,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerJvmtiEnvForceGarbageCollectionWithConcurrentModeInterrupted() {
+    void testLogLineTriggerJvmtiEnvForceGarbageCollectionWithConcurrentModeInterrupted() {
         String logLine = "262372.344: [Full GC (JvmtiEnv ForceGarbageCollection) 262372.344: [CMS "
                 + "(concurrent mode interrupted): 49392K->48780K(1756416K), 0.2620228 secs] "
                 + "49392K->48780K(2063104K), [Metaspace: 256552K->256552K(1230848K)], 0.2624794 secs] "
@@ -383,7 +383,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineParNewPromotionFailed() {
+    void testLogLineParNewPromotionFailed() {
         String logLine = "144501.626: [GC 144501.627: [ParNew (promotion failed): 680066K->680066K(707840K), "
                 + "3.7067346 secs] 1971073K->1981370K(2018560K), 3.7084059 secs]";
         assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
@@ -404,7 +404,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedIncrementalMode() {
+    void testParNewPromotionFailedIncrementalMode() {
         String logLine = "159275.552: [GC 159275.552: [ParNew (promotion failed): 2007040K->2007040K(2007040K), "
                 + "4.3393411 secs] 5167424K->5187429K(12394496K) icms_dc=7 , 4.3398519 secs] "
                 + "[Times: user=4.96 sys=1.91, real=4.34 secs]";
@@ -417,7 +417,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testLogLineParNewPromotionFailedWithCmsBlock() {
+    void testLogLineParNewPromotionFailedWithCmsBlock() {
         String logLine = "1181.943: [GC 1181.943: [ParNew (promotion failed): 145542K->142287K(149120K), "
                 + "0.1316193 secs]1182.075: [CMS: 6656483K->548489K(8218240K), 9.1244297 secs] "
                 + "6797120K->548489K(8367360K), 9.2564476 secs]";
@@ -439,7 +439,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedTruncated() {
+    void testParNewPromotionFailedTruncated() {
         String logLine = "5881.424: [GC 5881.424: [ParNew (promotion failed): 153272K->152257K(153344K), "
                 + "0.2143850 secs]5881.639: [CMS";
         assertTrue(CmsSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
@@ -451,13 +451,13 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testFirstLineOfMultiLineParallelScavengeEvent() {
+    void testFirstLineOfMultiLineParallelScavengeEvent() {
         String logLine = "10.392: [GC";
         assertFalse(CmsSerialOldEvent.match(logLine), "Log line incorrectly recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
     }
 
     @Test
-    public void testLogLineParNewPromotionFailedMissingTrigger() {
+    void testLogLineParNewPromotionFailedMissingTrigger() {
         String logLine = "3546.690: [GC 3546.691: [ParNew: 532480K->532480K(599040K), 0.0000400 secs]3546.691: "
                 + "[CMS: 887439K->893801K(907264K), 9.6413020 secs] 1419919K->893801K(1506304K), 9.6419180 secs] "
                 + "[Times: user=9.54 sys=0.10, real=9.65 secs]";
@@ -479,7 +479,7 @@ public class TestCmsSerialOldEvent {
      * Has "Tenured" instead of "CMS" label in old generation block.
      */
     @Test
-    public void testLogLineParNewPromotionFailedTenuredLabel() {
+    void testLogLineParNewPromotionFailedTenuredLabel() {
         String logLine = "289985.117: [GC 289985.117: [ParNew (promotion failed): 144192K->144192K(144192K), "
                 + "0.1347360 secs]289985.252: [Tenured: 1281600K->978341K(1281600K), 3.6577930 secs] "
                 + "1409528K->978341K(1425792K), 3.7930200 secs]";
@@ -498,7 +498,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedCmsSerialOldPermData() {
+    void testParNewPromotionFailedCmsSerialOldPermData() {
         String logLine = "395950.370: [GC 395950.370: [ParNew (promotion failed): "
                 + "53094K->53606K(59008K), 0.0510880 secs]395950.421: "
                 + "[CMS: 664527K->317110K(1507328K), 2.9523520 secs] 697709K->317110K(1566336K), "
@@ -521,7 +521,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedCmsSerialOldPermDataIncrementalMode() {
+    void testParNewPromotionFailedCmsSerialOldPermDataIncrementalMode() {
         String logLine = "4595.651: [GC 4595.651: [ParNew (promotion failed): 1304576K->1304576K(1304576K), "
                 + "1.7740754 secs]4597.425: [CMS: 967034K->684015K(4886528K), 3.2678588 secs] "
                 + "2022731K->684015K(6191104K), [CMS Perm : 201541K->201494K(524288K)] icms_dc=21 , "
@@ -544,7 +544,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedNoSpaceAfterGc() {
+    void testParNewPromotionFailedNoSpaceAfterGc() {
         String logLine = "108537.519: [GC108537.520: [ParNew (promotion failed): 1409215K->1426861K(1567616K), "
                 + "0.4259330 secs]108537.946: [CMS: 13135135K->4554003K(16914880K), 14.7637760 secs] "
                 + "14542753K->4554003K(18482496K), [CMS Perm : 227503K->226115K(378908K)], 15.1927120 secs] "
@@ -567,7 +567,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedCmsSerialOldPermDataPreprocessedPrintClassHistogram() {
+    void testParNewPromotionFailedCmsSerialOldPermDataPreprocessedPrintClassHistogram() {
         String logLine = "182314.858: [GC 182314.859: [ParNew (promotion failed): 516864K->516864K(516864K), "
                 + "2.0947428 secs]182316.954: [Class Histogram: , 41.3875632 secs]182358.342: "
                 + "[CMS: 3354568K->756393K(7331840K), 53.1398170 secs]182411.482: [Class Histogram, 11.0299920 secs]"
@@ -591,7 +591,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailure() {
+    void testParNewConcurrentModeFailure() {
         String logLine = "26683.209: [GC 26683.210: [ParNew: 261760K->261760K(261952K), "
                 + "0.0000130 secs]26683.210: [CMS (concurrent mode failure): 1141548K->1078465K(1179648K), "
                 + "7.3835370 secs] 1403308K->1078465K(1441600K), 7.3838390 secs]";
@@ -610,7 +610,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedConcurrentModeFailure() {
+    void testParNewPromotionFailedConcurrentModeFailure() {
         String logLine = "25281.015: [GC 25281.015: [ParNew (promotion failed): 261760K->261760K(261952K), "
                 + "0.1785000 secs]25281.193: [CMS (concurrent mode failure): 1048384K->1015603K(1179648K), "
                 + "7.6767910 secs] 1292923K->1015603K(1441600K), 7.8557660 secs]";
@@ -629,7 +629,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedPrintPromotionFailure() {
+    void testParNewPromotionFailedPrintPromotionFailure() {
         String logLine = "2017-02-28T00:43:55.587+0000: 36843.783: [GC (Allocation Failure) "
                 + "2017-02-28T00:43:55.587+0000: 36843.783: [ParNew (promotion failed): 2304000K->2304000K(2304000K), "
                 + "0.4501923 secs]2017-02-28T00:43:56.037+0000: 36844.234: [CMS: 2818067K->2769354K(5120000K), "
@@ -650,7 +650,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewCmsSerialOld() {
+    void testParNewCmsSerialOld() {
         String logLine = "42782.086: [GC 42782.086: [ParNew: 254464K->7680K(254464K), 0.2853553 secs]"
                 + "42782.371: [Tenured: 1082057K->934941K(1082084K), 6.2719770 secs] "
                 + "1310721K->934941K(1336548K), 6.5587770 secs]";
@@ -669,7 +669,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewCmsSerialOldWithPerm() {
+    void testParNewCmsSerialOldWithPerm() {
         String logLine = "6.102: [GC6.102: [ParNew: 19648K->2176K(19648K), 0.0184470 secs]6.121: "
                 + "[Tenured: 44849K->25946K(44864K), 0.2586250 secs] 60100K->25946K(64512K), "
                 + "[Perm : 43759K->43759K(262144K)], 0.2773070 secs] [Times: user=0.16 sys=0.01, real=0.28 secs]";
@@ -691,7 +691,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewCmsSerialOldJdk8() {
+    void testParNewCmsSerialOldJdk8() {
         String logLine = "1817.644: [GC (Allocation Failure) 1817.646: [ParNew: 1382383K->1382383K(1382400K), "
                 + "0.0000530 secs]1817.646: [CMS: 2658303K->2658303K(2658304K), 8.7951430 secs] "
                 + "4040686K->2873414K(4040704K), [Metaspace: 72200K->72200K(1118208K)], 8.7986750 secs] "
@@ -714,7 +714,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailurePermData() {
+    void testParNewConcurrentModeFailurePermData() {
         String logLine = "3070.289: [GC 3070.289: [ParNew: 207744K->207744K(242304K), 0.0000682 secs]3070.289: "
                 + "[CMS (concurrent mode failure): 6010121K->6014591K(6014592K), 79.0505229 secs] "
                 + "6217865K->6028029K(6256896K), [CMS Perm : 206688K->206662K(262144K)], 79.0509595 secs] "
@@ -737,7 +737,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testGcBailing() {
+    void testGcBailing() {
         String logLine = "1901.217: [GC 1901.217: [ParNew: 261760K->261760K(261952K), 0.0000570 secs]1901.217: "
                 + "[CMSJava HotSpot(TM) Server VM warning: bailing out to foreground collection (concurrent mode "
                 + "failure): 1794415K->909664K(1835008K), 124.5953890 secs] 2056175K->909664K(2096960K) "
@@ -757,7 +757,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailurePermDataMetaspaceIcrementalMode() {
+    void testParNewConcurrentModeFailurePermDataMetaspaceIcrementalMode() {
         String logLine = "719.519: [GC (Allocation Failure) 719.521: [ParNew: 1382400K->1382400K(1382400K), "
                 + "0.0000470 secs] (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
@@ -780,7 +780,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailurePermDataMetaspaceNotIcrementalMode() {
+    void testParNewConcurrentModeFailurePermDataMetaspaceNotIcrementalMode() {
         String logLine = "1202.526: [GC (Allocation Failure) 1202.528: [ParNew: 1355422K->1355422K(1382400K), "
                 + "0.0000500 secs]1202.528: [CMS (concurrent mode failure): 2656311K->2658289K(2658304K), "
                 + "9.3575580 secs] 4011734K->2725109K(4040704K), [Metaspace: 72111K->72111K(1118208K)], "
@@ -803,7 +803,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailurePermDataPreProcessedClassHistogram() {
+    void testParNewConcurrentModeFailurePermDataPreProcessedClassHistogram() {
         String logLine = "572264.304: [GC 572264.306: [ParNew (promotion failed): 516864K->516864K(516864K), "
                 + "1.4978605 secs]572265.804: [Class Histogram:, 23.6901531 secs]"
                 + "572289.495: [CMS (concurrent mode failure): 5350445K->891234K(7331840K), 59.8600601 secs]"
@@ -828,7 +828,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailurePermDataPreProcessedClassHistogramConcurrentModeFailure() {
+    void testParNewConcurrentModeFailurePermDataPreProcessedClassHistogramConcurrentModeFailure() {
         String logLine = "576460.444: [GC 576460.446: [ParNew (promotion failed): 516864K->516864K(516864K), "
                 + "1.9697779 secs]576462.416: [Class Histogram:, 23.3548450 secs]"
                 + "576485.771: [CMS: 5074711K->905970K(7331840K), 46.0517345 secs]"
@@ -853,7 +853,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testTriggerGcLockerInitiatedGc() {
+    void testTriggerGcLockerInitiatedGc() {
         String logLine = "58626.878: [Full GC (GCLocker Initiated GC)58626.878: [CMS (concurrent mode failure): "
                 + "13441202K->12005469K(13631488K), 23.1836190 secs] 19349630K->12005469K(22020096K), "
                 + "[CMS Perm : 1257346K->1257346K(2097152K)] icms_dc=100 , 23.1838500 secs] "
@@ -876,7 +876,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testJdk6ParNewPromotionFailedConcurrentModeFailureWithClassHistogram() {
+    void testJdk6ParNewPromotionFailedConcurrentModeFailureWithClassHistogram() {
         String logLine = "2017-04-22T13:58:35.287+0100: 471391.741: [GC 471391.743: [ParNew (promotion failed): "
                 + "516864K->516864K(516864K), 2.1875738 secs]471393.931: [Class Histogram:, 25.2253758 secs]"
                 + "471419.156: [CMS (concurrent mode failure): 5977264K->1290167K(7331840K), 59.2834068 secs]"
@@ -900,7 +900,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewPromotionFailedConcurrentModeFailureWithClassHistogramDatestamps() {
+    void testParNewPromotionFailedConcurrentModeFailureWithClassHistogramDatestamps() {
         String logLine = "2017-05-03T14:51:32.659-0400: 2057.323: [Full GC 2017-05-03T14:51:32.680-0400: 2057.341: "
                 + "[Class Histogram:, 13.8859570 secs]2017-05-03T14:51:46.579-0400: "
                 + "2071.240: [CMS (concurrent mode failure): 9216000K->9215999K(9216000K), 62.4046040 secs]"
@@ -925,7 +925,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testSplitParNewPromotionFailedCmsConcurrentModeFailure() {
+    void testSplitParNewPromotionFailedCmsConcurrentModeFailure() {
         File testFile = TestUtil.getFile("dataset5.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -944,7 +944,7 @@ public class TestCmsSerialOldEvent {
      * Test preprocessing <code>HeapAtGcEvent</code> with underlying <code>CmsSerialOldEvent</code>.
      */
     @Test
-    public void testSplitPrintHeapAtGcParNewConcurrentModeFailureEventLogging() {
+    void testSplitPrintHeapAtGcParNewConcurrentModeFailureEventLogging() {
         File testFile = TestUtil.getFile("dataset7.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -959,7 +959,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testSplitParNewPromotionFailedCmsConcurrentModeFailurePermData() {
+    void testSplitParNewPromotionFailedCmsConcurrentModeFailurePermData() {
         File testFile = TestUtil.getFile("dataset12.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -973,7 +973,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testSplitParNewCmsConcurrentModeFailurePermData() {
+    void testSplitParNewCmsConcurrentModeFailurePermData() {
         File testFile = TestUtil.getFile("dataset13.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -986,7 +986,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testSplit3LinesParNewPromotionFailedCmsConcurrentModeFailurePermDataEventMarkLogging() {
+    void testSplit3LinesParNewPromotionFailedCmsConcurrentModeFailurePermDataEventMarkLogging() {
         File testFile = TestUtil.getFile("dataset16.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1004,7 +1004,7 @@ public class TestCmsSerialOldEvent {
      * 
      */
     @Test
-    public void testSplit3LinesParNewConcurrentModeFailureEventLogging() {
+    void testSplit3LinesParNewConcurrentModeFailureEventLogging() {
         File testFile = TestUtil.getFile("dataset29.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1018,7 +1018,7 @@ public class TestCmsSerialOldEvent {
     }
 
     @Test
-    public void testParNewConcurrentModeFailureMixedCmsConcurrentJdk8() {
+    void testParNewConcurrentModeFailureMixedCmsConcurrentJdk8() {
         File testFile = TestUtil.getFile("dataset70.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1037,7 +1037,7 @@ public class TestCmsSerialOldEvent {
      * 
      */
     @Test
-    public void testHeapInspectionInitiatedGcAnalysis() {
+    void testHeapInspectionInitiatedGcAnalysis() {
         File testFile = TestUtil.getFile("dataset72.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1055,7 +1055,7 @@ public class TestCmsSerialOldEvent {
      * 
      */
     @Test
-    public void testParNewPromotionFailedCmsSerialOldPermDataPrintClassHistogramTriggerAcross6Lines() {
+    void testParNewPromotionFailedCmsSerialOldPermDataPrintClassHistogramTriggerAcross6Lines() {
         File testFile = TestUtil.getFile("dataset82.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1073,7 +1073,7 @@ public class TestCmsSerialOldEvent {
      * 
      */
     @Test
-    public void testLogLineTriggerHeapDumpedInitiatedGc() {
+    void testLogLineTriggerHeapDumpedInitiatedGc() {
         File testFile = TestUtil.getFile("dataset92.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFlsStaticsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFlsStaticsEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.domain.UnknownEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,229 +28,196 @@ public class TestFlsStaticsEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "Max   Chunk Size: 536870912";
-        assertFalse(JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testNotReportable() {
         String logLine = "Max   Chunk Size: 536870912";
-        assertFalse(JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testJdkUtilParseLogLineDoesNotReturnUnknownEvent() {
         String logLine = "Max   Chunk Size: 536870912";
-        assertFalse("JdkUtil.parseLogLine() returns " + JdkUtil.LogEventType.UNKNOWN.toString() + " event.",
-                JdkUtil.parseLogLine(logLine) instanceof UnknownEvent);
+        assertFalse(JdkUtil.parseLogLine(logLine) instanceof UnknownEvent, "JdkUtil.parseLogLine() returns " + JdkUtil.LogEventType.UNKNOWN.toString() + " event.");
     }
 
     @Test
     public void testJdkUtilParseLogLineReturnsFlsStatisticsEvent() {
         String logLine = "Max   Chunk Size: 536870912";
-        assertTrue(
-                "JdkUtil.parseLogLine() does not return " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + " event.",
-                JdkUtil.parseLogLine(logLine) instanceof FlsStatisticsEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof FlsStatisticsEvent, "JdkUtil.parseLogLine() does not return " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + " event.");
     }
 
     @Test
     public void testLineStatistics() {
         String logLine = "Statistics for BinaryTreeDictionary:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLineDivider() {
         String logLine = "------------------------------------";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineTotalFreeSpace() {
         String logLine = "Total Free Space: 536870912";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineTotalFreeSpaceNegative() {
         String logLine = "Total Free Space: -136285693";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineMaxChunkSize() {
         String logLine = "Max   Chunk Size: 536870912";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineMaxChunkSizeNegative() {
         String logLine = "Max   Chunk Size: -136285693";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks() {
         String logLine = "Number of Blocks: 1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks4Digits() {
         String logLine = "Number of Blocks: 3752";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks5Digits() {
         String logLine = "Number of Blocks: 68082";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks6Digits() {
         String logLine = "Number of Blocks: 218492";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks7Digits() {
         String logLine = "Number of Blocks: 6455862";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineNumberOfBlocks8Digits() {
         String logLine = "Number of Blocks: 64558627";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineAvBlockSize() {
         String logLine = "Av.  Block  Size: 536870912";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineAvBlockSizeNegative() {
         String logLine = "Av.  Block  Size: -328196225";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineTreeHeight() {
         String logLine = "Tree      Height: 1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineTreeHeight2Digits() {
         String logLine = "Tree      Height: 20";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineTreeHeight3Digits() {
         String logLine = "Tree      Height: 130";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineBeforeGC() {
         String logLine = "Before GC:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineAfterGC() {
         String logLine = "After GC:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineLargeBlock() {
         String logLine = "CMS: Large block 0x00002b79ea830000";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineLargeBlockWithProximity() {
         String logLine = "CMS: Large Block: 0x00002b79ea830000; Proximity: 0x0000000000000000 -> 0x00002b79ea82fac8";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineStatisticsForIndexedFreeLists() {
         String logLine = "Statistics for IndexedFreeLists:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineDivider() {
         String logLine = "--------------------------------";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineFrag() {
         String logLine = " free=1161964910 frag=0.8232";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineSweepSize() {
         String logLine = "size[256] : demand: 0, old_rate: 0.000000, current_rate: 0.000000, new_rate: 0.000000, "
                 + "old_desired: 0, new_desired: 0";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineSweepDemand() {
         String logLine = "demand: 1, old_rate: 0.000000, current_rate: 0.000282, new_rate: 0.000282, old_desired: 0, "
                 + "new_desired: 2";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineSweepSizeDemand8DigitsRate3Digits() {
         String logLine = "size[3] : demand: 11798284, old_rate: 717.797668, current_rate: 743.942383, new_rate: "
                 + "742.511902, old_desired: 15402672, new_desired: 13570211";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
     public void testLogLineSweepSizeDemand9DigitsRate4Digits() {
         String logLine = "size[4] : demand: 81603741, old_rate: 5028.634277, current_rate: 5145.535156, new_rate: "
                 + "5146.810547, old_desired: 107905624, new_desired: 94063552";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".",
-                FlsStatisticsEvent.match(logLine));
+        assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFlsStaticsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFlsStaticsEvent.java
@@ -23,199 +23,199 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestFlsStaticsEvent {
+class TestFlsStaticsEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Max   Chunk Size: 536870912";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testNotReportable() {
+    void testNotReportable() {
         String logLine = "Max   Chunk Size: 536870912";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FLS_STATISTICS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testJdkUtilParseLogLineDoesNotReturnUnknownEvent() {
+    void testJdkUtilParseLogLineDoesNotReturnUnknownEvent() {
         String logLine = "Max   Chunk Size: 536870912";
         assertFalse(JdkUtil.parseLogLine(logLine) instanceof UnknownEvent, "JdkUtil.parseLogLine() returns " + JdkUtil.LogEventType.UNKNOWN.toString() + " event.");
     }
 
     @Test
-    public void testJdkUtilParseLogLineReturnsFlsStatisticsEvent() {
+    void testJdkUtilParseLogLineReturnsFlsStatisticsEvent() {
         String logLine = "Max   Chunk Size: 536870912";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof FlsStatisticsEvent, "JdkUtil.parseLogLine() does not return " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + " event.");
     }
 
     @Test
-    public void testLineStatistics() {
+    void testLineStatistics() {
         String logLine = "Statistics for BinaryTreeDictionary:";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLineDivider() {
+    void testLineDivider() {
         String logLine = "------------------------------------";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineTotalFreeSpace() {
+    void testLogLineTotalFreeSpace() {
         String logLine = "Total Free Space: 536870912";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineTotalFreeSpaceNegative() {
+    void testLogLineTotalFreeSpaceNegative() {
         String logLine = "Total Free Space: -136285693";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineMaxChunkSize() {
+    void testLogLineMaxChunkSize() {
         String logLine = "Max   Chunk Size: 536870912";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineMaxChunkSizeNegative() {
+    void testLogLineMaxChunkSizeNegative() {
         String logLine = "Max   Chunk Size: -136285693";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks() {
+    void testLogLineNumberOfBlocks() {
         String logLine = "Number of Blocks: 1";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks4Digits() {
+    void testLogLineNumberOfBlocks4Digits() {
         String logLine = "Number of Blocks: 3752";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks5Digits() {
+    void testLogLineNumberOfBlocks5Digits() {
         String logLine = "Number of Blocks: 68082";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks6Digits() {
+    void testLogLineNumberOfBlocks6Digits() {
         String logLine = "Number of Blocks: 218492";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks7Digits() {
+    void testLogLineNumberOfBlocks7Digits() {
         String logLine = "Number of Blocks: 6455862";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineNumberOfBlocks8Digits() {
+    void testLogLineNumberOfBlocks8Digits() {
         String logLine = "Number of Blocks: 64558627";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineAvBlockSize() {
+    void testLogLineAvBlockSize() {
         String logLine = "Av.  Block  Size: 536870912";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineAvBlockSizeNegative() {
+    void testLogLineAvBlockSizeNegative() {
         String logLine = "Av.  Block  Size: -328196225";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineTreeHeight() {
+    void testLogLineTreeHeight() {
         String logLine = "Tree      Height: 1";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineTreeHeight2Digits() {
+    void testLogLineTreeHeight2Digits() {
         String logLine = "Tree      Height: 20";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineTreeHeight3Digits() {
+    void testLogLineTreeHeight3Digits() {
         String logLine = "Tree      Height: 130";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineBeforeGC() {
+    void testLogLineBeforeGC() {
         String logLine = "Before GC:";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineAfterGC() {
+    void testLogLineAfterGC() {
         String logLine = "After GC:";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineLargeBlock() {
+    void testLogLineLargeBlock() {
         String logLine = "CMS: Large block 0x00002b79ea830000";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineLargeBlockWithProximity() {
+    void testLogLineLargeBlockWithProximity() {
         String logLine = "CMS: Large Block: 0x00002b79ea830000; Proximity: 0x0000000000000000 -> 0x00002b79ea82fac8";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineStatisticsForIndexedFreeLists() {
+    void testLogLineStatisticsForIndexedFreeLists() {
         String logLine = "Statistics for IndexedFreeLists:";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineDivider() {
+    void testLogLineDivider() {
         String logLine = "--------------------------------";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineFrag() {
+    void testLogLineFrag() {
         String logLine = " free=1161964910 frag=0.8232";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineSweepSize() {
+    void testLogLineSweepSize() {
         String logLine = "size[256] : demand: 0, old_rate: 0.000000, current_rate: 0.000000, new_rate: 0.000000, "
                 + "old_desired: 0, new_desired: 0";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineSweepDemand() {
+    void testLogLineSweepDemand() {
         String logLine = "demand: 1, old_rate: 0.000000, current_rate: 0.000282, new_rate: 0.000282, old_desired: 0, "
                 + "new_desired: 2";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineSweepSizeDemand8DigitsRate3Digits() {
+    void testLogLineSweepSizeDemand8DigitsRate3Digits() {
         String logLine = "size[3] : demand: 11798284, old_rate: 717.797668, current_rate: 743.942383, new_rate: "
                 + "742.511902, old_desired: 15402672, new_desired: 13570211";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");
     }
 
     @Test
-    public void testLogLineSweepSizeDemand9DigitsRate4Digits() {
+    void testLogLineSweepSizeDemand9DigitsRate4Digits() {
         String logLine = "size[4] : demand: 81603741, old_rate: 5028.634277, current_rate: 5145.535156, new_rate: "
                 + "5146.810547, old_desired: 107905624, new_desired: 94063552";
         assertTrue(FlsStatisticsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FLS_STATISTICS.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterHeapEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterHeapEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,428 +33,370 @@ public class TestFooterHeapEvent {
     @Test
     public void testLineJdk8Heap() {
         String logLine = "Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedHeap() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedHeapUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedHeap1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ] Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedHeap3SpacesAfterExit() {
         String logLine = "[32.839s][info][gc,heap,exit   ] Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
-        assertEquals(JdkUtil.LogEventType.FOOTER_HEAP + "not identified.", JdkUtil.LogEventType.FOOTER_HEAP,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.FOOTER_HEAP,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.FOOTER_HEAP + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
-        assertTrue(JdkUtil.LogEventType.FOOTER_HEAP.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof FooterHeapEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof FooterHeapEvent, JdkUtil.LogEventType.FOOTER_HEAP.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
-        assertFalse(JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_HEAP));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_HEAP), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.FOOTER_HEAP);
-        assertFalse(JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLineUnifiedGarbageFirst() {
         String logLine = "[25.016s][info][gc,heap,exit  ]  garbage-first heap   total 59392K, used 38015K "
                 + "[0x00000000fc000000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoah() {
         String logLine = "[69.946s][info][gc,heap,exit ] Shenandoah Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoahUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Shenandoah Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8ShenandoahTotalCommittedUsed() {
         String logLine = " 128M total, 128M committed, 102M used";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoahTotalCommittedUsed() {
         String logLine = "[69.946s][info][gc,heap,exit ]  65536K total, 65536K committed, 55031K used";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoahTotalCommittedUsedUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  1334272K total, 107008K committed, 80727K used";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8ShenandoahRegions() {
         String logLine = " 512 x 256K regions";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoahRegions() {
         String logLine = "[69.946s][info][gc,heap,exit ]  256 x 256K regions";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedShenandoahRegionsUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  2606 x 512K regions";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedStatus() {
         String logLine = "[69.946s][info][gc,heap,exit ] Status: cancelled";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedStatusUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Status: cancelled";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8StatusHasForwarded() {
         String logLine = "Status: has forwarded objects, cancelled";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedStatusHasForwarded() {
         String logLine = "[103.682s][info][gc,heap,exit ] Status: has forwarded objects, cancelled";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8ReservedRegion() {
         String logLine = "Reserved region:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedReservedRegion() {
         String logLine = "[69.946s][info][gc,heap,exit ] Reserved region:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedReservedRegionUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Reserved region:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8ReservedRegionAddress() {
         String logLine = " - [0x00000000f8000000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedReservedRegionAddress() {
         String logLine = "[69.946s][info][gc,heap,exit ]  - [0x00000000fc000000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedReservedRegionAddressUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  - [0x00000000ae900000, 0x0000000100000000) ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedRegion() {
         String logLine = "[25.016s][info][gc,heap,exit  ]   region size 1024K, 13 young (13312K), 1 survivors (1024K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedRegion3DigitYoung2DigutSurvivors() {
         String logLine = "[2020-03-12T13:13:49.821-0400][26578ms]   region size 1024K, 260 young (266240K), 26 "
                 + "survivors (26624K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMetaspace() {
         String logLine = "[25.016s][info][gc,heap,exit  ]  Metaspace       used 11079K, capacity 11287K, "
                 + "committed 11520K, reserved 1060864K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMetaspaceUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  Metaspace       used 80841K, capacity 89293K, "
                 + "committed 89600K, reserved 331776K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMetaspace1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ]  Metaspace       used 4066K, capacity 7271K, committed "
                 + "7296K, reserved 1056768K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMetaspace3SpacesAfterExit() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  Metaspace       used 4109K, capacity 7271K, committed "
                 + "7296K, reserved 1056768K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedClass() {
         String logLine = "[25.016s][info][gc,heap,exit  ]   class space    used 909K, capacity 995K, committed 1024K, "
                 + "reserved 1048576K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedClassUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]   class space    used 10193K, capacity 13027K, "
                 + "committed 13056K, reserved 253952K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedClass1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ]   class space    used 299K, capacity 637K, committed 640K, "
                 + "reserved 1048576K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedDefNew() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  def new generation   total 11456K, used 4604K "
                 + "[0x00000000fc000000, 0x00000000fcc60000, 0x00000000fd550000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedEden() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   eden space 10240K,  43% used [0x00000000fc000000, "
                 + "0x00000000fc463ed8, 0x00000000fca00000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedEdenNoSpacesBetweenAddresses() {
         String logLine = "[37.098s][info][gc,heap,exit   ]   eden space 20480K, 33% used [0x00000000feb00000,"
                 + "0x00000000ff1cb940,0x00000000fff00000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFromSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   from space 1216K,   8% used [0x00000000fca00000, "
                 + "0x00000000fca1b280, 0x00000000fcb30000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedToSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   to   space 1216K,   0% used [0x00000000fcb30000, "
                 + "0x00000000fcb30000, 0x00000000fcc60000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTenured() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  tenured generation   total 25240K, used 24218K "
                 + "[0x00000000fd550000, 0x00000000fedf6000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTheSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]    the space 25240K,  95% used [0x00000000fd550000, "
                 + "0x00000000fecf6b58, 0x00000000fecf6c00, 0x00000000fedf6000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPsYoungGen() {
         String logLine = "[37.098s][info][gc,heap,exit   ]  PSYoungGen      total 20992K, used 7054K "
                 + "[0x00000000feb00000, 0x0000000100000000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPsOldGen() {
         String logLine = "[37.098s][info][gc,heap,exit   ]  PSOldGen        total 32768K, used 27239K "
                 + "[0x00000000fc000000, 0x00000000fe000000, 0x00000000feb00000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedParOldGen() {
         String logLine = "[37.742s][info][gc,heap,exit   ]  ParOldGen       total 30720K, used 27745K "
                 + "[0x00000000fc000000, 0x00000000fde00000, 0x00000000feb00000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedObjectSpace() {
         String logLine = "[37.098s][info][gc,heap,exit   ]   object space 32768K, 83% used [0x00000000fc000000,"
                 + "0x00000000fda99f58,0x00000000fe000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedParNewGeneration() {
         String logLine = "[59.713s][info][gc,heap,exit ]  par new generation   total 1152K, used 713K "
                 + "[0x00000000fc000000, 0x00000000fc140000, 0x00000000fd550000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedParCmsGeneration() {
         String logLine = "[59.713s][info][gc,heap,exit ]  concurrent mark-sweep generation total 31228K, used 25431K "
                 + "[0x00000000fd550000, 0x00000000ff3cf000, 0x0000000100000000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8Collection() {
         String logLine = "Collection set:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedCollection() {
         String logLine = "[103.682s][info][gc,heap,exit ] Collection set:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8MapVanilla() {
         String logLine = " - map (vanilla): 0x00007f271b2e5e00";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMapVanilla() {
         String logLine = "[103.683s][info][gc,heap,exit ]  - map (vanilla): 0x00007fa7ea119f00";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineJdk8MapBiased() {
         String logLine = " - map (biased):  0x00007f271b2e2000";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedMapBiased() {
         String logLine = "[103.683s][info][gc,heap,exit ]  - map (biased):  0x00007fa7ea116000";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
     public void testLineShenandoahSoftMax() {
         String logLine = "[2021-01-25T17:44:28.636-0500]  98304K max, 98304K soft max, 98304K committed, 58219K used";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".",
-                FooterHeapEvent.match(logLine));
+        assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterHeapEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterHeapEvent.java
@@ -28,374 +28,374 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestFooterHeapEvent {
+class TestFooterHeapEvent {
 
     @Test
-    public void testLineJdk8Heap() {
+    void testLineJdk8Heap() {
         String logLine = "Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedHeap() {
+    void testLineUnifiedHeap() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedHeapUptimeMillis() {
+    void testLineUnifiedHeapUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedHeap1SpaceAfterExit() {
+    void testLineUnifiedHeap1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ] Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedHeap3SpacesAfterExit() {
+    void testLineUnifiedHeap3SpacesAfterExit() {
         String logLine = "[32.839s][info][gc,heap,exit   ] Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
         assertEquals(JdkUtil.LogEventType.FOOTER_HEAP,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.FOOTER_HEAP + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof FooterHeapEvent, JdkUtil.LogEventType.FOOTER_HEAP.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_HEAP), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.FOOTER_HEAP);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.FOOTER_HEAP.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLineUnifiedGarbageFirst() {
+    void testLineUnifiedGarbageFirst() {
         String logLine = "[25.016s][info][gc,heap,exit  ]  garbage-first heap   total 59392K, used 38015K "
                 + "[0x00000000fc000000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoah() {
+    void testLineUnifiedShenandoah() {
         String logLine = "[69.946s][info][gc,heap,exit ] Shenandoah Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoahUptimeMillis() {
+    void testLineUnifiedShenandoahUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Shenandoah Heap";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8ShenandoahTotalCommittedUsed() {
+    void testLineJdk8ShenandoahTotalCommittedUsed() {
         String logLine = " 128M total, 128M committed, 102M used";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoahTotalCommittedUsed() {
+    void testLineUnifiedShenandoahTotalCommittedUsed() {
         String logLine = "[69.946s][info][gc,heap,exit ]  65536K total, 65536K committed, 55031K used";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoahTotalCommittedUsedUptimeMillis() {
+    void testLineUnifiedShenandoahTotalCommittedUsedUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  1334272K total, 107008K committed, 80727K used";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8ShenandoahRegions() {
+    void testLineJdk8ShenandoahRegions() {
         String logLine = " 512 x 256K regions";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoahRegions() {
+    void testLineUnifiedShenandoahRegions() {
         String logLine = "[69.946s][info][gc,heap,exit ]  256 x 256K regions";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedShenandoahRegionsUptimeMillis() {
+    void testLineUnifiedShenandoahRegionsUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  2606 x 512K regions";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedStatus() {
+    void testLineUnifiedStatus() {
         String logLine = "[69.946s][info][gc,heap,exit ] Status: cancelled";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedStatusUptimeMillis() {
+    void testLineUnifiedStatusUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Status: cancelled";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8StatusHasForwarded() {
+    void testLineJdk8StatusHasForwarded() {
         String logLine = "Status: has forwarded objects, cancelled";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedStatusHasForwarded() {
+    void testLineUnifiedStatusHasForwarded() {
         String logLine = "[103.682s][info][gc,heap,exit ] Status: has forwarded objects, cancelled";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8ReservedRegion() {
+    void testLineJdk8ReservedRegion() {
         String logLine = "Reserved region:";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedReservedRegion() {
+    void testLineUnifiedReservedRegion() {
         String logLine = "[69.946s][info][gc,heap,exit ] Reserved region:";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedReservedRegionUptimeMillis() {
+    void testLineUnifiedReservedRegionUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] Reserved region:";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8ReservedRegionAddress() {
+    void testLineJdk8ReservedRegionAddress() {
         String logLine = " - [0x00000000f8000000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedReservedRegionAddress() {
+    void testLineUnifiedReservedRegionAddress() {
         String logLine = "[69.946s][info][gc,heap,exit ]  - [0x00000000fc000000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedReservedRegionAddressUptimeMillis() {
+    void testLineUnifiedReservedRegionAddressUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  - [0x00000000ae900000, 0x0000000100000000) ";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedRegion() {
+    void testLineUnifiedRegion() {
         String logLine = "[25.016s][info][gc,heap,exit  ]   region size 1024K, 13 young (13312K), 1 survivors (1024K)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedRegion3DigitYoung2DigutSurvivors() {
+    void testLineUnifiedRegion3DigitYoung2DigutSurvivors() {
         String logLine = "[2020-03-12T13:13:49.821-0400][26578ms]   region size 1024K, 260 young (266240K), 26 "
                 + "survivors (26624K)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMetaspace() {
+    void testLineUnifiedMetaspace() {
         String logLine = "[25.016s][info][gc,heap,exit  ]  Metaspace       used 11079K, capacity 11287K, "
                 + "committed 11520K, reserved 1060864K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMetaspaceUptimeMillis() {
+    void testLineUnifiedMetaspaceUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]  Metaspace       used 80841K, capacity 89293K, "
                 + "committed 89600K, reserved 331776K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMetaspace1SpaceAfterExit() {
+    void testLineUnifiedMetaspace1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ]  Metaspace       used 4066K, capacity 7271K, committed "
                 + "7296K, reserved 1056768K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMetaspace3SpacesAfterExit() {
+    void testLineUnifiedMetaspace3SpacesAfterExit() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  Metaspace       used 4109K, capacity 7271K, committed "
                 + "7296K, reserved 1056768K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedClass() {
+    void testLineUnifiedClass() {
         String logLine = "[25.016s][info][gc,heap,exit  ]   class space    used 909K, capacity 995K, committed 1024K, "
                 + "reserved 1048576K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedClassUptimeMillis() {
+    void testLineUnifiedClassUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]   class space    used 10193K, capacity 13027K, "
                 + "committed 13056K, reserved 253952K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedClass1SpaceAfterExit() {
+    void testLineUnifiedClass1SpaceAfterExit() {
         String logLine = "[69.946s][info][gc,heap,exit ]   class space    used 299K, capacity 637K, committed 640K, "
                 + "reserved 1048576K";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedDefNew() {
+    void testLineUnifiedDefNew() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  def new generation   total 11456K, used 4604K "
                 + "[0x00000000fc000000, 0x00000000fcc60000, 0x00000000fd550000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedEden() {
+    void testLineUnifiedEden() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   eden space 10240K,  43% used [0x00000000fc000000, "
                 + "0x00000000fc463ed8, 0x00000000fca00000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedEdenNoSpacesBetweenAddresses() {
+    void testLineUnifiedEdenNoSpacesBetweenAddresses() {
         String logLine = "[37.098s][info][gc,heap,exit   ]   eden space 20480K, 33% used [0x00000000feb00000,"
                 + "0x00000000ff1cb940,0x00000000fff00000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFromSpace() {
+    void testLineUnifiedFromSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   from space 1216K,   8% used [0x00000000fca00000, "
                 + "0x00000000fca1b280, 0x00000000fcb30000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedToSpace() {
+    void testLineUnifiedToSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]   to   space 1216K,   0% used [0x00000000fcb30000, "
                 + "0x00000000fcb30000, 0x00000000fcc60000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTenured() {
+    void testLineUnifiedTenured() {
         String logLine = "[32.839s][info][gc,heap,exit   ]  tenured generation   total 25240K, used 24218K "
                 + "[0x00000000fd550000, 0x00000000fedf6000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTheSpace() {
+    void testLineUnifiedTheSpace() {
         String logLine = "[32.839s][info][gc,heap,exit   ]    the space 25240K,  95% used [0x00000000fd550000, "
                 + "0x00000000fecf6b58, 0x00000000fecf6c00, 0x00000000fedf6000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPsYoungGen() {
+    void testLineUnifiedPsYoungGen() {
         String logLine = "[37.098s][info][gc,heap,exit   ]  PSYoungGen      total 20992K, used 7054K "
                 + "[0x00000000feb00000, 0x0000000100000000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPsOldGen() {
+    void testLineUnifiedPsOldGen() {
         String logLine = "[37.098s][info][gc,heap,exit   ]  PSOldGen        total 32768K, used 27239K "
                 + "[0x00000000fc000000, 0x00000000fe000000, 0x00000000feb00000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedParOldGen() {
+    void testLineUnifiedParOldGen() {
         String logLine = "[37.742s][info][gc,heap,exit   ]  ParOldGen       total 30720K, used 27745K "
                 + "[0x00000000fc000000, 0x00000000fde00000, 0x00000000feb00000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedObjectSpace() {
+    void testLineUnifiedObjectSpace() {
         String logLine = "[37.098s][info][gc,heap,exit   ]   object space 32768K, 83% used [0x00000000fc000000,"
                 + "0x00000000fda99f58,0x00000000fe000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedParNewGeneration() {
+    void testLineUnifiedParNewGeneration() {
         String logLine = "[59.713s][info][gc,heap,exit ]  par new generation   total 1152K, used 713K "
                 + "[0x00000000fc000000, 0x00000000fc140000, 0x00000000fd550000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedParCmsGeneration() {
+    void testLineUnifiedParCmsGeneration() {
         String logLine = "[59.713s][info][gc,heap,exit ]  concurrent mark-sweep generation total 31228K, used 25431K "
                 + "[0x00000000fd550000, 0x00000000ff3cf000, 0x0000000100000000)";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8Collection() {
+    void testLineJdk8Collection() {
         String logLine = "Collection set:";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedCollection() {
+    void testLineUnifiedCollection() {
         String logLine = "[103.682s][info][gc,heap,exit ] Collection set:";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8MapVanilla() {
+    void testLineJdk8MapVanilla() {
         String logLine = " - map (vanilla): 0x00007f271b2e5e00";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMapVanilla() {
+    void testLineUnifiedMapVanilla() {
         String logLine = "[103.683s][info][gc,heap,exit ]  - map (vanilla): 0x00007fa7ea119f00";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8MapBiased() {
+    void testLineJdk8MapBiased() {
         String logLine = " - map (biased):  0x00007f271b2e2000";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedMapBiased() {
+    void testLineUnifiedMapBiased() {
         String logLine = "[103.683s][info][gc,heap,exit ]  - map (biased):  0x00007fa7ea116000";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }
 
     @Test
-    public void testLineShenandoahSoftMax() {
+    void testLineShenandoahSoftMax() {
         String logLine = "[2021-01-25T17:44:28.636-0500]  98304K max, 98304K soft max, 98304K committed, 58219K used";
         assertTrue(FooterHeapEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_HEAP.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterStatsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterStatsEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,425 +39,369 @@ public class TestFooterStatsEvent {
     @Test
     public void testLineJdk8() {
         String logLine = "GC STATISTICS:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnified() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
-        assertEquals(JdkUtil.LogEventType.FOOTER_STATS + "not identified.", JdkUtil.LogEventType.FOOTER_STATS,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.FOOTER_STATS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.FOOTER_STATS + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
-        assertTrue(JdkUtil.LogEventType.FOOTER_STATS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof FooterStatsEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof FooterStatsEvent, JdkUtil.LogEventType.FOOTER_STATS.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
-        assertFalse(JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_STATS));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_STATS), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.FOOTER_STATS);
-        assertFalse(JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLineJdk8UThreadRoots() {
         String logLine = "    U: Thread Roots         =     0.03 s (a =       14 us) "
                 + "(n =  2498) (lvls, us =        7,       10,       12,       16,      178)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedUThreadRoots() {
         String logLine = "[103.683s][info][gc,stats     ]     U: Thread Roots         =     0.03 s (a =       14 us) "
                 + "(n =  2498) (lvls, us =        7,       10,       12,       16,      178)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8RetireTLabs() {
         String logLine = "  Retire TLABs              =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        1,        1,        2,       18))";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedRetireTLabs() {
         String logLine = "[103.683s][info][gc,stats     ]   Retire TLABs              =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        1,        1,        2,       18))";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8SyncPinned() {
         String logLine = "  Sync Pinned               =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        2,        2,        2,       19)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedSyncPinned() {
         String logLine = "[103.683s][info][gc,stats     ]   Sync Pinned               =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        2,        2,        2,       19)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8TrashCSet() {
         String logLine = "  Trash CSet                =     0.00 s (a =        1 us) "
                 + "(n =  3151) (lvls, us =        0,        1,        1,        1,       21)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTrashCSet() {
         String logLine = "[103.683s][info][gc,stats     ]   Trash CSet                =     0.00 s (a =        1 us) "
                 + "(n =  3151) (lvls, us =        0,        1,        1,        1,       21)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8PauseFinalEvacG() {
         String logLine = "Pause Final Evac (G)        =     0.42 s (a =      170 us) "
                 + "(n =  2499) (lvls, us =       44,       82,      107,      146,     4911)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPauseFinalEvacG() {
         String logLine = "[103.683s][info][gc,stats     ] Pause Final Evac (G)        =     0.42 s (a =      170 us) "
                 + "(n =  2499) (lvls, us =       44,       82,      107,      146,     4911)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8PauseFinalEvacN() {
         String logLine = "Pause Final Evac (N)        =     0.05 s (a =       21 us) "
                 + "(n =  2499) (lvls, us =       12,       15,       18,       23,      139)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPauseFinalEvacN() {
         String logLine = "[103.683s][info][gc,stats     ] Pause Final Evac (N)        =     0.05 s (a =       21 us) "
                 + "(n =  2499) (lvls, us =       12,       15,       18,       23,      139)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8RetireGcLabs() {
         String logLine = "  Retire GCLABs             =     0.00 s (a =        1 us) "
                 + "(n =  2499) (lvls, us =        0,        1,        1,        1,       20)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedRetireGcLabs() {
         String logLine = "[103.683s][info][gc,stats     ]   Retire GCLABs             =     0.00 s (a =        1 us) "
                 + "(n =  2499) (lvls, us =        0,        1,        1,        1,       20)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8Prepare() {
         String logLine = "  Prepare                   =     0.00 s (a =        3 us) "
                 + "(n =   652) (lvls, us =        1,        2,        3,        4,       20)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPrepare() {
         String logLine = "[103.683s][info][gc,stats     ]   Prepare                   =     0.00 s (a =        3 us) "
                 + "(n =   652) (lvls, us =        1,        2,        3,        4,       20)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8SuccessfulConcurrentGCs() {
         String logLine = " 3151 successful concurrent GCs";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedSuccessfulConcurrentGCs() {
         String logLine = "[103.683s][info][gc,stats     ]  3151 successful concurrent GCs";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8InvokedImplicitly() {
         String logLine = "      0 invoked implicitly";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedInvokedImplicitly() {
         String logLine = "[103.683s][info][gc,stats     ]       0 invoked implicitly";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8FromToCountSumData() {
         String logLine = "      1 ms -       2 ms:         1998         999 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFromToCountSumData() {
         String logLine = "[103.684s][info][gc,stats     ]       1 ms -       2 ms:         1998         999 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8FromToCountSumData5DigitSum() {
         String logLine = "      8 ms -      16 ms:         4192       16768 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFromToCountSumData5DigitSum() {
         String logLine = "[103.684s][info][gc,stats     ]       8 ms -      16 ms:         4192       16768 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8FromToCountSumData2DigitSum() {
         String logLine = "     16 ms -      32 ms:          114         912 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFromToCountSumData2DigitSum() {
         String logLine = "[96.867s]      16 ms -      32 ms:            6          48 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8PacingDelays() {
         String logLine = "Pacing delays are measured from entering the pacing code " + "till exiting it. Therefore,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPacingDelays() {
         String logLine = "[103.684s][info][gc,stats     ] Pacing delays are measured from entering the pacing code "
                 + "till exiting it. Therefore,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedPacingDelays3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   Pacing delays are measured from entering the pacing code "
                 + "till exiting it. Therefore,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8ObservedPacing() {
         String logLine = "observed pacing delays may be higher than the threshold " + "when paced thread spent more";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedObservedPacing() {
         String logLine = "[103.684s][info][gc,stats     ] observed pacing delays may be higher than the threshold "
                 + "when paced thread spent more";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedObservedPacing3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   observed pacing delays may be higher than the threshold "
                 + "when paced thread spent more";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8TimeInThePacing() {
         String logLine = "time in the pacing code. It usually happens when thread is " + "de-scheduled while paced,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTimeInThePacing() {
         String logLine = "[103.684s][info][gc,stats     ] time in the pacing code. It usually happens when thread is "
                 + "de-scheduled while paced,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8OsTakesLonger() {
         String logLine = "OS takes longer to unblock the thread, or JVM experiences " + "an STW pause.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedOsTakesLonger() {
         String logLine = "[103.684s][info][gc,stats     ] OS takes longer to unblock the thread, or JVM experiences "
                 + "an STW pause.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedOsTakesLonger3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   OS takes longer to unblock the thread, or JVM experiences "
                 + "an STW pause.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8FromToCount5Sum5() {
         String logLine = "      8 ms -      16 ms:        11145       44580 ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8SFlatProfilerRoots() {
         String logLine = "    S: FlatProfiler Roots   =     0.00 s (a =        0 us) (n =  7119) (lvls, us =        "
                 + "0,        0,        0,        0,       20)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8Enqueue() {
         String logLine = "    Enqueue                 =     0.12 s (a =       81 us) (n =  1424) (lvls, us =       "
                 + "14,       20,       75,       99,      929)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8EFlatProfilerRoots() {
         String logLine = "    E: FlatProfiler Roots   =     0.00 s (a =        0 us) (n =  7118) (lvls, us =        "
                 + "0,        0,        0,        0,       16)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineJdk8URFlatProfilerRoots() {
         String logLine = "    UR: FlatProfiler Roots  =     0.00 s (a =        1 us) (n =  1117) (lvls, us =        "
                 + "0,        0,        0,        0,       13)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSystemPurge() {
         String logLine = "[57.108s][info][gc,stats     ]   System Purge              =     0.10 s (a =       73 us) "
                 + "(n =  1378) (lvls, us =       29,       45,       69,       85,      349)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSystemParallelCleanup() {
         String logLine = "[57.108s][info][gc,stats     ]     Parallel Cleanup        =     0.10 s (a =       72 us) "
                 + "(n =  1378) (lvls, us =       28,       45,       69,       85,      348)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineHigherDelay() {
         String logLine = "[66.558s][info][gc,stats      ]   Higher delay would prevent application outpacing the GC, "
                 + "but it will hide the GC latencies";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineFromTheStw() {
         String logLine = "[66.558s][info][gc,stats      ]   from the STW pause times. Pacing affects the individual "
                 + "threads, and so it would also be";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineInvisible() {
         String logLine = "[66.558s][info][gc,stats      ]   invisible to the usual profiling tools, but would add up "
                 + "to end-to-end application latency.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineRaiseMax() {
         String logLine = "[66.558s][info][gc,stats      ]   Raise max pacing delay with care.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
     public void testLineHappenedAtOutsideOfCycle() {
         String logLine = "[74.874s]         1 happened at Outside of Cycle";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".",
-                FooterStatsEvent.match(logLine));
+        assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     /**
@@ -470,9 +414,8 @@ public class TestFooterStatsEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
+        assertEquals(0,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
     }
 
     @Test
@@ -484,18 +427,14 @@ public class TestFooterStatsEvent {
         File preprocessedFile = gcManager1.preprocess(testFile, null);
         gcManager2.store(preprocessedFile, false);
         JvmRun jvmRun1 = gcManager1.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun1.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.FOOTER_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.FOOTER_STATS));
+        assertEquals(3,jvmRun1.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.FOOTER_STATS), JdkUtil.LogEventType.FOOTER_STATS.toString() + " collector not identified.");
         // Some logging patterns are exactly the same as SHENANDOAH_STATS. No easy way to distinguish them.
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE));
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.");
         JvmRun jvmRun2 = gcManager2.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun2.getEventTypes().size());
+        assertEquals(0,jvmRun2.getEventTypes().size(),"Event type count not correct.");
     }
 
     @Test
@@ -507,17 +446,13 @@ public class TestFooterStatsEvent {
         File preprocessedFile = gcManager1.preprocess(testFile, null);
         gcManager2.store(preprocessedFile, false);
         JvmRun jvmRun1 = gcManager1.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun1.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.FOOTER_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.FOOTER_STATS));
+        assertEquals(3,jvmRun1.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.FOOTER_STATS), JdkUtil.LogEventType.FOOTER_STATS.toString() + " collector not identified.");
         // Some logging patterns are exactly the same as SHENANDOAH_STATS. No easy way to distinguish them.
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS));
-        assertTrue(JdkUtil.LogEventType.BLANK_LINE.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.BLANK_LINE));
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.BLANK_LINE), JdkUtil.LogEventType.BLANK_LINE.toString() + " collector not identified.");
         JvmRun jvmRun2 = gcManager2.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun2.getEventTypes().size());
+        assertEquals(0,jvmRun2.getEventTypes().size(),"Event type count not correct.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterStatsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestFooterStatsEvent.java
@@ -34,372 +34,372 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestFooterStatsEvent {
+class TestFooterStatsEvent {
 
     @Test
-    public void testLineJdk8() {
+    void testLineJdk8() {
         String logLine = "GC STATISTICS:";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnified() {
+    void testLineUnified() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
         assertEquals(JdkUtil.LogEventType.FOOTER_STATS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.FOOTER_STATS + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof FooterStatsEvent, JdkUtil.LogEventType.FOOTER_STATS.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms] GC STATISTICS:";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.FOOTER_STATS), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.FOOTER_STATS);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.FOOTER_STATS.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLineJdk8UThreadRoots() {
+    void testLineJdk8UThreadRoots() {
         String logLine = "    U: Thread Roots         =     0.03 s (a =       14 us) "
                 + "(n =  2498) (lvls, us =        7,       10,       12,       16,      178)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedUThreadRoots() {
+    void testLineUnifiedUThreadRoots() {
         String logLine = "[103.683s][info][gc,stats     ]     U: Thread Roots         =     0.03 s (a =       14 us) "
                 + "(n =  2498) (lvls, us =        7,       10,       12,       16,      178)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8RetireTLabs() {
+    void testLineJdk8RetireTLabs() {
         String logLine = "  Retire TLABs              =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        1,        1,        2,       18))";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedRetireTLabs() {
+    void testLineUnifiedRetireTLabs() {
         String logLine = "[103.683s][info][gc,stats     ]   Retire TLABs              =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        1,        1,        2,       18))";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8SyncPinned() {
+    void testLineJdk8SyncPinned() {
         String logLine = "  Sync Pinned               =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        2,        2,        2,       19)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedSyncPinned() {
+    void testLineUnifiedSyncPinned() {
         String logLine = "[103.683s][info][gc,stats     ]   Sync Pinned               =     0.01 s (a =        2 us) "
                 + "(n =  3151) (lvls, us =        1,        2,        2,        2,       19)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8TrashCSet() {
+    void testLineJdk8TrashCSet() {
         String logLine = "  Trash CSet                =     0.00 s (a =        1 us) "
                 + "(n =  3151) (lvls, us =        0,        1,        1,        1,       21)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTrashCSet() {
+    void testLineUnifiedTrashCSet() {
         String logLine = "[103.683s][info][gc,stats     ]   Trash CSet                =     0.00 s (a =        1 us) "
                 + "(n =  3151) (lvls, us =        0,        1,        1,        1,       21)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8PauseFinalEvacG() {
+    void testLineJdk8PauseFinalEvacG() {
         String logLine = "Pause Final Evac (G)        =     0.42 s (a =      170 us) "
                 + "(n =  2499) (lvls, us =       44,       82,      107,      146,     4911)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPauseFinalEvacG() {
+    void testLineUnifiedPauseFinalEvacG() {
         String logLine = "[103.683s][info][gc,stats     ] Pause Final Evac (G)        =     0.42 s (a =      170 us) "
                 + "(n =  2499) (lvls, us =       44,       82,      107,      146,     4911)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8PauseFinalEvacN() {
+    void testLineJdk8PauseFinalEvacN() {
         String logLine = "Pause Final Evac (N)        =     0.05 s (a =       21 us) "
                 + "(n =  2499) (lvls, us =       12,       15,       18,       23,      139)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPauseFinalEvacN() {
+    void testLineUnifiedPauseFinalEvacN() {
         String logLine = "[103.683s][info][gc,stats     ] Pause Final Evac (N)        =     0.05 s (a =       21 us) "
                 + "(n =  2499) (lvls, us =       12,       15,       18,       23,      139)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8RetireGcLabs() {
+    void testLineJdk8RetireGcLabs() {
         String logLine = "  Retire GCLABs             =     0.00 s (a =        1 us) "
                 + "(n =  2499) (lvls, us =        0,        1,        1,        1,       20)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedRetireGcLabs() {
+    void testLineUnifiedRetireGcLabs() {
         String logLine = "[103.683s][info][gc,stats     ]   Retire GCLABs             =     0.00 s (a =        1 us) "
                 + "(n =  2499) (lvls, us =        0,        1,        1,        1,       20)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8Prepare() {
+    void testLineJdk8Prepare() {
         String logLine = "  Prepare                   =     0.00 s (a =        3 us) "
                 + "(n =   652) (lvls, us =        1,        2,        3,        4,       20)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPrepare() {
+    void testLineUnifiedPrepare() {
         String logLine = "[103.683s][info][gc,stats     ]   Prepare                   =     0.00 s (a =        3 us) "
                 + "(n =   652) (lvls, us =        1,        2,        3,        4,       20)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8SuccessfulConcurrentGCs() {
+    void testLineJdk8SuccessfulConcurrentGCs() {
         String logLine = " 3151 successful concurrent GCs";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedSuccessfulConcurrentGCs() {
+    void testLineUnifiedSuccessfulConcurrentGCs() {
         String logLine = "[103.683s][info][gc,stats     ]  3151 successful concurrent GCs";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8InvokedImplicitly() {
+    void testLineJdk8InvokedImplicitly() {
         String logLine = "      0 invoked implicitly";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedInvokedImplicitly() {
+    void testLineUnifiedInvokedImplicitly() {
         String logLine = "[103.683s][info][gc,stats     ]       0 invoked implicitly";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8FromToCountSumData() {
+    void testLineJdk8FromToCountSumData() {
         String logLine = "      1 ms -       2 ms:         1998         999 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFromToCountSumData() {
+    void testLineUnifiedFromToCountSumData() {
         String logLine = "[103.684s][info][gc,stats     ]       1 ms -       2 ms:         1998         999 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8FromToCountSumData5DigitSum() {
+    void testLineJdk8FromToCountSumData5DigitSum() {
         String logLine = "      8 ms -      16 ms:         4192       16768 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFromToCountSumData5DigitSum() {
+    void testLineUnifiedFromToCountSumData5DigitSum() {
         String logLine = "[103.684s][info][gc,stats     ]       8 ms -      16 ms:         4192       16768 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8FromToCountSumData2DigitSum() {
+    void testLineJdk8FromToCountSumData2DigitSum() {
         String logLine = "     16 ms -      32 ms:          114         912 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFromToCountSumData2DigitSum() {
+    void testLineUnifiedFromToCountSumData2DigitSum() {
         String logLine = "[96.867s]      16 ms -      32 ms:            6          48 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8PacingDelays() {
+    void testLineJdk8PacingDelays() {
         String logLine = "Pacing delays are measured from entering the pacing code " + "till exiting it. Therefore,";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPacingDelays() {
+    void testLineUnifiedPacingDelays() {
         String logLine = "[103.684s][info][gc,stats     ] Pacing delays are measured from entering the pacing code "
                 + "till exiting it. Therefore,";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedPacingDelays3Spaces() {
+    void testLineUnifiedPacingDelays3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   Pacing delays are measured from entering the pacing code "
                 + "till exiting it. Therefore,";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8ObservedPacing() {
+    void testLineJdk8ObservedPacing() {
         String logLine = "observed pacing delays may be higher than the threshold " + "when paced thread spent more";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedObservedPacing() {
+    void testLineUnifiedObservedPacing() {
         String logLine = "[103.684s][info][gc,stats     ] observed pacing delays may be higher than the threshold "
                 + "when paced thread spent more";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedObservedPacing3Spaces() {
+    void testLineUnifiedObservedPacing3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   observed pacing delays may be higher than the threshold "
                 + "when paced thread spent more";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8TimeInThePacing() {
+    void testLineJdk8TimeInThePacing() {
         String logLine = "time in the pacing code. It usually happens when thread is " + "de-scheduled while paced,";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTimeInThePacing() {
+    void testLineUnifiedTimeInThePacing() {
         String logLine = "[103.684s][info][gc,stats     ] time in the pacing code. It usually happens when thread is "
                 + "de-scheduled while paced,";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8OsTakesLonger() {
+    void testLineJdk8OsTakesLonger() {
         String logLine = "OS takes longer to unblock the thread, or JVM experiences " + "an STW pause.";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedOsTakesLonger() {
+    void testLineUnifiedOsTakesLonger() {
         String logLine = "[103.684s][info][gc,stats     ] OS takes longer to unblock the thread, or JVM experiences "
                 + "an STW pause.";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedOsTakesLonger3Spaces() {
+    void testLineUnifiedOsTakesLonger3Spaces() {
         String logLine = "[66.558s][info][gc,stats      ]   OS takes longer to unblock the thread, or JVM experiences "
                 + "an STW pause.";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8FromToCount5Sum5() {
+    void testLineJdk8FromToCount5Sum5() {
         String logLine = "      8 ms -      16 ms:        11145       44580 ms";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8SFlatProfilerRoots() {
+    void testLineJdk8SFlatProfilerRoots() {
         String logLine = "    S: FlatProfiler Roots   =     0.00 s (a =        0 us) (n =  7119) (lvls, us =        "
                 + "0,        0,        0,        0,       20)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8Enqueue() {
+    void testLineJdk8Enqueue() {
         String logLine = "    Enqueue                 =     0.12 s (a =       81 us) (n =  1424) (lvls, us =       "
                 + "14,       20,       75,       99,      929)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8EFlatProfilerRoots() {
+    void testLineJdk8EFlatProfilerRoots() {
         String logLine = "    E: FlatProfiler Roots   =     0.00 s (a =        0 us) (n =  7118) (lvls, us =        "
                 + "0,        0,        0,        0,       16)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineJdk8URFlatProfilerRoots() {
+    void testLineJdk8URFlatProfilerRoots() {
         String logLine = "    UR: FlatProfiler Roots  =     0.00 s (a =        1 us) (n =  1117) (lvls, us =        "
                 + "0,        0,        0,        0,       13)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSystemPurge() {
+    void testLineSystemPurge() {
         String logLine = "[57.108s][info][gc,stats     ]   System Purge              =     0.10 s (a =       73 us) "
                 + "(n =  1378) (lvls, us =       29,       45,       69,       85,      349)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSystemParallelCleanup() {
+    void testLineSystemParallelCleanup() {
         String logLine = "[57.108s][info][gc,stats     ]     Parallel Cleanup        =     0.10 s (a =       72 us) "
                 + "(n =  1378) (lvls, us =       28,       45,       69,       85,      348)";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineHigherDelay() {
+    void testLineHigherDelay() {
         String logLine = "[66.558s][info][gc,stats      ]   Higher delay would prevent application outpacing the GC, "
                 + "but it will hide the GC latencies";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineFromTheStw() {
+    void testLineFromTheStw() {
         String logLine = "[66.558s][info][gc,stats      ]   from the STW pause times. Pacing affects the individual "
                 + "threads, and so it would also be";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineInvisible() {
+    void testLineInvisible() {
         String logLine = "[66.558s][info][gc,stats      ]   invisible to the usual profiling tools, but would add up "
                 + "to end-to-end application latency.";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineRaiseMax() {
+    void testLineRaiseMax() {
         String logLine = "[66.558s][info][gc,stats      ]   Raise max pacing delay with care.";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineHappenedAtOutsideOfCycle() {
+    void testLineHappenedAtOutsideOfCycle() {
         String logLine = "[74.874s]         1 happened at Outside of Cycle";
         assertTrue(FooterStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.FOOTER_STATS.toString() + ".");
     }
@@ -408,7 +408,7 @@ public class TestFooterStatsEvent {
      * Test logging.
      */
     @Test
-    public void testUnifiedUptimeMillis() {
+    void testUnifiedUptimeMillis() {
         File testFile = TestUtil.getFile("dataset165.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -419,7 +419,7 @@ public class TestFooterStatsEvent {
     }
 
     @Test
-    public void testJdk11Time() {
+    void testJdk11Time() {
         File testFile = TestUtil.getFile("dataset196.txt");
         GcManager gcManager1 = new GcManager();
         gcManager1.store(testFile, false);
@@ -438,7 +438,7 @@ public class TestFooterStatsEvent {
     }
 
     @Test
-    public void testJdk8() {
+    void testJdk8() {
         File testFile = TestUtil.getFile("dataset198.txt");
         GcManager gcManager1 = new GcManager();
         gcManager1.store(testFile, false);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1CleanupEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1CleanupEvent.java
@@ -13,11 +13,11 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -28,81 +28,71 @@ public class TestG1CleanupEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_CLEANUP.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_CLEANUP.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testCleanup() {
         String logLine = "18.650: [GC cleanup 297M->236M(512M), 0.0014690 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 18650, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(304128), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(241664), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(524288), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1469, event.getDuration());
+        assertEquals((long) 18650,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(304128),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(241664),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(1469,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testCleanupWhiteSpacesAtEnd() {
         String logLine = "18.650: [GC cleanup 297M->236M(512M), 0.0014690 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
     }
 
     @Test
     public void testLogLineGigabytes() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2972698, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(13631488),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12582912), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(31457280), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 35874, event.getDuration());
+        assertEquals((long) 2972698,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(13631488),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12582912),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31457280),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(35874,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithTimesData() {
         String logLine = "2016-11-08T09:36:22.388-0800: 35290.131: [GC cleanup 5252M->3592M(12G), 0.0154490 secs] "
                 + "[Times: user=0.19 sys=0.00, real=0.01 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 35290131, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(5252 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(3592 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(12 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 15449, event.getDuration());
-        assertEquals("User time not parsed correctly.", 19, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 1900, event.getParallelism());
+        assertEquals((long) 35290131,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(5252 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(3592 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(12 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(15449,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(19,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(1900,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineMissingSizes() {
         String logLine = "2017-05-09T00:46:14.766+1000: 288368.997: [GC cleanup, 0.0000910 secs] "
                 + "[Times: user=0.00 sys=0.00, real=0.00 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 288368997, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(0), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(0), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(0), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 91, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 288368997,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(91,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -111,20 +101,16 @@ public class TestG1CleanupEvent {
                 + "(Concurrent Cycles) finish cleanup, occupancy: 22498457048 bytes, capacity: 32212254720 bytes, "
                 + "known garbage: 9291782792 bytes (28.85 %)]21456M->20543M(30720M), 0.0155840 secs] "
                 + "[Times: user=0.07 sys=0.06, real=0.01 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                G1CleanupEvent.match(logLine));
+        assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1745417, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(21456 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(20543 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(30720 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 15584, event.getDuration());
-        assertEquals("User time not parsed correctly.", 7, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 6, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 1300, event.getParallelism());
+        assertEquals((long) 1745417,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(21456 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(20543 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(30720 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(15584,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(7,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(6,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(1300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1CleanupEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1CleanupEvent.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1CleanupEvent {
+class TestG1CleanupEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_CLEANUP.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testCleanup() {
+    void testCleanup() {
         String logLine = "18.650: [GC cleanup 297M->236M(512M), 0.0014690 secs]";
         assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
@@ -44,13 +44,13 @@ public class TestG1CleanupEvent {
     }
 
     @Test
-    public void testCleanupWhiteSpacesAtEnd() {
+    void testCleanupWhiteSpacesAtEnd() {
         String logLine = "18.650: [GC cleanup 297M->236M(512M), 0.0014690 secs]   ";
         assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
     }
 
     @Test
-    public void testLogLineGigabytes() {
+    void testLogLineGigabytes() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
         assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
         G1CleanupEvent event = new G1CleanupEvent(logLine);
@@ -62,7 +62,7 @@ public class TestG1CleanupEvent {
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "2016-11-08T09:36:22.388-0800: 35290.131: [GC cleanup 5252M->3592M(12G), 0.0154490 secs] "
                 + "[Times: user=0.19 sys=0.00, real=0.01 secs]";
         assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
@@ -79,7 +79,7 @@ public class TestG1CleanupEvent {
     }
 
     @Test
-    public void testLogLineMissingSizes() {
+    void testLogLineMissingSizes() {
         String logLine = "2017-05-09T00:46:14.766+1000: 288368.997: [GC cleanup, 0.0000910 secs] "
                 + "[Times: user=0.00 sys=0.00, real=0.00 secs]";
         assertTrue(G1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
@@ -96,7 +96,7 @@ public class TestG1CleanupEvent {
     }
 
     @Test
-    public void testLogLineMixedErgonomics() {
+    void testLogLineMixedErgonomics() {
         String logLine = "2020-04-29T22:05:39.708+0200: 1745.417: [GC cleanup 1745.419: [G1Ergonomics "
                 + "(Concurrent Cycles) finish cleanup, occupancy: 22498457048 bytes, capacity: 32212254720 bytes, "
                 + "known garbage: 9291782792 bytes (28.85 %)]21456M->20543M(30720M), 0.0155840 secs] "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1ConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1ConcurrentEvent.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1ConcurrentEvent {
+class TestG1ConcurrentEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "50.101: [GC concurrent-root-region-scan-start]";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testRootRegionScanStart() {
+    void testRootRegionScanStart() {
         String logLine = "50.101: [GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -40,7 +40,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testRootRegionScanEnd() {
+    void testRootRegionScanEnd() {
         String logLine = "50.136: [GC concurrent-root-region-scan-end, 0.0346620 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -48,7 +48,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testMarkStart() {
+    void testMarkStart() {
         String logLine = "50.136: [GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -56,7 +56,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testMarkEnd() {
+    void testMarkEnd() {
         String logLine = "50.655: [GC concurrent-mark-end, 0.5186330 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -64,7 +64,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testCleanupStart() {
+    void testCleanupStart() {
         String logLine = "50.685: [GC concurrent-cleanup-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -72,7 +72,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testCleanupEnd() {
+    void testCleanupEnd() {
         String logLine = "50.685: [GC concurrent-cleanup-end, 0.0001080 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -80,7 +80,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testDateStamp() {
+    void testDateStamp() {
         String logLine = "2016-02-09T06:22:10.399-0500: 28039.161: [GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -88,7 +88,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "27744.494: [GC concurrent-mark-start], 0.3349320 secs] 10854M->9765M(26624M) "
                 + "[Times: user=0.98 sys=0.00, real=0.33 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -97,7 +97,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineCleanupEndWithDatestamp() {
+    void testLogLineCleanupEndWithDatestamp() {
         String logLine = "2016-02-11T18:15:35.431-0500: 14974.501: [GC concurrent-cleanup-end, 0.0033880 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -105,7 +105,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineStringDeduplication() {
+    void testLogLineStringDeduplication() {
         String logLine = "8.556: [GC concurrent-string-deduplication, 906.5K->410.2K(496.3K), avg 54.8%, "
                 + "0.0162924 secs]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -114,7 +114,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineDoubleTimestamp() {
+    void testLogLineDoubleTimestamp() {
         String logLine = "23743.632: 23743.632: [GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -122,7 +122,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineWithoutTrailingSecs() {
+    void testLogLineWithoutTrailingSecs() {
         String logLine = "449391.280: [GC concurrent-root-region-scan-end, 0.0033660]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -130,7 +130,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineWithTrailingSecNotSecs() {
+    void testLogLineWithTrailingSecNotSecs() {
         String logLine = "449391.442: [GC concurrent-mark-end, 0.1620950 sec]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -138,7 +138,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineConcurrentMarkResetForOverflow() {
+    void testLogLineConcurrentMarkResetForOverflow() {
         String logLine = "1048.227: [GC concurrent-mark-reset-for-overflow]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -146,7 +146,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineWithDatestamp() {
+    void testLogLineWithDatestamp() {
         String logLine = "2016-02-09T06:17:15.377-0500: 27744.139: [GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -154,7 +154,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineWithDoubleDatestamp() {
+    void testLogLineWithDoubleDatestamp() {
         String logLine = "2017-01-20T23:18:29.584-0500: 1513296.456: 2017-01-20T23:18:29.584-0500: "
                 + "[GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -163,7 +163,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineDatestampTimestampDatestampMisplacedColon() {
+    void testLogLineDatestampTimestampDatestampMisplacedColon() {
         String logLine = "2017-01-20T23:20:52.028-0500: 1513438.9002017-01-20T23:20:52.028-0500: : "
                 + "[GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -172,7 +172,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampTimestampMisplacedColon() {
+    void testLogLineDatestampDatestampTimestampMisplacedColon() {
         String logLine = "2017-01-20T23:49:17.968-0500: 2017-01-20T23:49:17.968-05001515144.840: :"
                 + " [GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -181,7 +181,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineDatestampDatestampMisplacedColonTimestamp() {
+    void testLogLineDatestampDatestampMisplacedColonTimestamp() {
         String logLine = "2017-01-21T00:58:45.921-05002017-01-21T00:58:45.921-0500: : 1519312.793: "
                 + "[GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
@@ -190,7 +190,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineTimestampDatestampMisplacedColonTimestamp() {
+    void testLogLineTimestampDatestampMisplacedColonTimestamp() {
         String logLine = "1516186.5322017-01-21T00:06:39.660-0500: : 1516186.532: [GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -198,7 +198,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineMisplacedColonDatestampTimestampTimestampMisplacedColon() {
+    void testLogLineMisplacedColonDatestampTimestampTimestampMisplacedColon() {
         String logLine = ": 2017-01-21T09:59:17.908-0500: 1551744.7801551744.780: : [GC concurrent-mark-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
@@ -206,7 +206,7 @@ public class TestG1ConcurrentEvent {
     }
 
     @Test
-    public void testLogLineNoTimestamp() {
+    void testLogLineNoTimestamp() {
         String logLine = ": [GC concurrent-root-region-scan-start]";
         assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1ConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1ConcurrentEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -28,211 +28,188 @@ public class TestG1ConcurrentEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "50.101: [GC concurrent-root-region-scan-start]";
-        assertFalse(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testRootRegionScanStart() {
         String logLine = "50.101: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50101, event.getTimestamp());
+        assertEquals((long) 50101,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testRootRegionScanEnd() {
         String logLine = "50.136: [GC concurrent-root-region-scan-end, 0.0346620 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50136, event.getTimestamp());
+        assertEquals((long) 50136,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testMarkStart() {
         String logLine = "50.136: [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50136, event.getTimestamp());
+        assertEquals((long) 50136,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testMarkEnd() {
         String logLine = "50.655: [GC concurrent-mark-end, 0.5186330 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50655, event.getTimestamp());
+        assertEquals((long) 50655,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testCleanupStart() {
         String logLine = "50.685: [GC concurrent-cleanup-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50685, event.getTimestamp());
+        assertEquals((long) 50685,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testCleanupEnd() {
         String logLine = "50.685: [GC concurrent-cleanup-end, 0.0001080 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 50685, event.getTimestamp());
+        assertEquals((long) 50685,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testDateStamp() {
         String logLine = "2016-02-09T06:22:10.399-0500: 28039.161: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 28039161, event.getTimestamp());
+        assertEquals((long) 28039161,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testPreprocessed() {
         String logLine = "27744.494: [GC concurrent-mark-start], 0.3349320 secs] 10854M->9765M(26624M) "
                 + "[Times: user=0.98 sys=0.00, real=0.33 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 27744494, event.getTimestamp());
+        assertEquals((long) 27744494,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineCleanupEndWithDatestamp() {
         String logLine = "2016-02-11T18:15:35.431-0500: 14974.501: [GC concurrent-cleanup-end, 0.0033880 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 14974501, event.getTimestamp());
+        assertEquals((long) 14974501,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineStringDeduplication() {
         String logLine = "8.556: [GC concurrent-string-deduplication, 906.5K->410.2K(496.3K), avg 54.8%, "
                 + "0.0162924 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 8556, event.getTimestamp());
+        assertEquals((long) 8556,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineDoubleTimestamp() {
         String logLine = "23743.632: 23743.632: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 23743632, event.getTimestamp());
+        assertEquals((long) 23743632,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithoutTrailingSecs() {
         String logLine = "449391.280: [GC concurrent-root-region-scan-end, 0.0033660]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 449391280, event.getTimestamp());
+        assertEquals((long) 449391280,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithTrailingSecNotSecs() {
         String logLine = "449391.442: [GC concurrent-mark-end, 0.1620950 sec]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 449391442, event.getTimestamp());
+        assertEquals((long) 449391442,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineConcurrentMarkResetForOverflow() {
         String logLine = "1048.227: [GC concurrent-mark-reset-for-overflow]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1048227, event.getTimestamp());
+        assertEquals((long) 1048227,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithDatestamp() {
         String logLine = "2016-02-09T06:17:15.377-0500: 27744.139: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 27744139, event.getTimestamp());
+        assertEquals((long) 27744139,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithDoubleDatestamp() {
         String logLine = "2017-01-20T23:18:29.584-0500: 1513296.456: 2017-01-20T23:18:29.584-0500: "
                 + "[GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1513296456, event.getTimestamp());
+        assertEquals((long) 1513296456,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestampTimestampDatestampMisplacedColon() {
         String logLine = "2017-01-20T23:20:52.028-0500: 1513438.9002017-01-20T23:20:52.028-0500: : "
                 + "[GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1513438900, event.getTimestamp());
+        assertEquals((long) 1513438900,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestampDatestampTimestampMisplacedColon() {
         String logLine = "2017-01-20T23:49:17.968-0500: 2017-01-20T23:49:17.968-05001515144.840: :"
                 + " [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1515144840, event.getTimestamp());
+        assertEquals((long) 1515144840,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestampDatestampMisplacedColonTimestamp() {
         String logLine = "2017-01-21T00:58:45.921-05002017-01-21T00:58:45.921-0500: : 1519312.793: "
                 + "[GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1519312793, event.getTimestamp());
+        assertEquals((long) 1519312793,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineTimestampDatestampMisplacedColonTimestamp() {
         String logLine = "1516186.5322017-01-21T00:06:39.660-0500: : 1516186.532: [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1516186532, event.getTimestamp());
+        assertEquals((long) 1516186532,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineMisplacedColonDatestampTimestampTimestampMisplacedColon() {
         String logLine = ": 2017-01-21T09:59:17.908-0500: 1551744.7801551744.780: : [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1551744780, event.getTimestamp());
+        assertEquals((long) 1551744780,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineNoTimestamp() {
         String logLine = ": [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                G1ConcurrentEvent.match(logLine));
+        assertTrue(G1ConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
         G1ConcurrentEvent event = new G1ConcurrentEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 0, event.getTimestamp());
+        assertEquals((long) 0,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1FullGCEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1FullGCEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -39,52 +39,45 @@ public class TestG1FullGCEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "1302.524: [Full GC (System.gc()) 653M->586M(979M), 1.6364900 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_FULL_GC.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_FULL_GC.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testNotVerboseGcOld() {
         String logLine = "424753.957: [Full GC (Allocation Failure)  8184M->6998M(8192M), 24.1990452 secs]";
-        assertFalse("Log line recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertFalse(G1YoungPauseEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
     }
 
     @Test
     public void testLogLineTriggerSystemGC() {
         String logLine = "1302.524: [Full GC (System.gc()) 653M->586M(979M), 1.6364900 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Time stamp not parsed correctly.", 1302524, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(653 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(586 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(979 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(0), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(0), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(0), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1636490, event.getDuration());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 1302524,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(653 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(586 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(979 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1636490,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testTriggerAllocationFailure() {
         String logLine = "424753.957: [Full GC (Allocation Failure)  8184M->6998M(8192M), 24.1990452 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 424753957, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8184 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(6998 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(0), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(0), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(0), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 24199045, event.getDuration());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 424753957,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(8184 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(6998 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(24199045,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -92,19 +85,17 @@ public class TestG1FullGCEvent {
         String logLine = "105.151: [Full GC (System.gc()) 5820M->1381M(30G), 5.5390169 secs]"
                 + "[Eden: 80.0M(112.0M)->0.0B(128.0M) Survivors: 16.0M->0.0B Heap: 5820.3M(30.0G)->1381.9M(30.0G)]"
                 + " [Times: user=5.76 sys=1.00, real=5.53 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Time stamp not parsed correctly.", 105151, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(5959987), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1415066), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(30 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(0), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(0), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(0), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 5539016, event.getDuration());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 105151,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(5959987),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1415066),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(5539016,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -113,18 +104,17 @@ public class TestG1FullGCEvent {
                 + "[Eden: 143.0M(1624.0M)->0.0B(1843.0M) Survivors: 219.0M->0.0B "
                 + "Heap: 999.5M(3072.0M)->691.1M(3072.0M)], [Perm: 175031K->175031K(175104K)]"
                 + " [Times: user=4.43 sys=0.05, real=3.44 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Time stamp not parsed correctly.", 178892, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1023488), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(707686), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(3072 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(175031), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(175031), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(175104), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3426206, event.getDuration());
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals((long) 178892,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1023488),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(707686),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3072 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(175031),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(175031),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(175104),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3426206,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -133,20 +123,17 @@ public class TestG1FullGCEvent {
                 + "40.6782890 secs][Eden: 0.0B(1040.0M)->0.0B(1120.0M) Survivors: 80.0M->0.0B "
                 + "Heap: 22.0G(22.0G)->20.6G(22.0G)], [Perm: 1252884K->1252884K(2097152K)] "
                 + "[Times: user=56.34 sys=1.78, real=40.67 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 35911404, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(22 * 1024 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(21600666), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(22 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(1252884), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(1252884), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(2097152), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 40678289, event.getDuration());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) 35911404,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(22 * 1024 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(21600666),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(22 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(1252884),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(1252884),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(2097152),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(40678289,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -155,19 +142,17 @@ public class TestG1FullGCEvent {
                 + "[Eden: 0.0B(1522.0M)->0.0B(2758.0M) Survivors: 244.0M->0.0B "
                 + "Heap: 1831.0M(5120.0M)->1213.5M(5120.0M)], [Metaspace: 396834K->324903K(1511424K)]"
                 + " [Times: user=7.15 sys=0.04, real=5.14 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD, event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 188123, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1831 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1242624), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(5120 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(396834), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(324903), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1511424), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 5135387, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 188123,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1831 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1242624),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5120 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(396834),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(324903),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1511424),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(5135387,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -176,18 +161,17 @@ public class TestG1FullGCEvent {
                 + "[Eden: 0.0B(3072.0M)->0.0B(3072.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 1196.3M(5120.0M)->1118.8M(5120.0M)], [Metaspace: 324984K->323866K(1511424K)] "
                 + "[Times: user=6.37 sys=0.00, real=4.46 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION, event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 98150, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1225011), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1145651), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(5120 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(324984), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(323866), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1511424), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 4462862, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 98150,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1225011),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1145651),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5120 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(324984),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(323866),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1511424),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(4462862,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -196,19 +180,17 @@ public class TestG1FullGCEvent {
                 + "[Eden: 6144.0K(3072.0M)->0.0B(3072.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 1124.8M(5120.0M)->1118.9M(5120.0M)], [Metaspace: 323874K->323874K(1511424K)]"
                 + " [Times: user=5.87 sys=0.01, real=3.89 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_JVM_TI_FORCED_GAREBAGE_COLLECTION,
-                event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 102621, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1151795), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1145754), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(5120 * 1024), event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(323874), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(323874), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1511424), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3895477, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_JVM_TI_FORCED_GAREBAGE_COLLECTION,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 102621,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1151795),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1145754),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5120 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(323874),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(323874),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1511424),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3895477,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -216,20 +198,17 @@ public class TestG1FullGCEvent {
         String logLine = "49689.217: [Full GC49689.217: [Class Histogram (before full gc):, 8.8690440 secs]"
                 + "11G->2270M(12G), 19.8185620 secs][Eden: 0.0B(612.0M)->0.0B(7372.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 11.1G(12.0G)->2270.1M(12.0G)], [Perm: 730823K->730823K(2097152K)]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_CLASS_HISTOGRAM, event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 49689217, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(11639194),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2324582), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(12 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(730823), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(730823), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(2097152), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 19818562, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_CLASS_HISTOGRAM,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 49689217,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(11639194),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(2324582),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(12 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(730823),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(730823),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(2097152),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(19818562,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -237,37 +216,31 @@ public class TestG1FullGCEvent {
         String logLine = "56965.451: [Full GC (Allocation Failure)  28G->387M(28G), 1.1821630 secs]"
                 + "[Eden: 0.0B(45.7G)->0.0B(34.4G) Survivors: 0.0B->0.0B Heap: 28.0G(28.0G)->387.6M(28.0G)], "
                 + "[Metaspace: 65867K->65277K(1112064K)] [Times: user=1.43 sys=0.00, real=1.18 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_ALLOCATION_FAILURE, event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 56965451, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(28 * 1024 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(396902), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(28 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(65867), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(65277), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1112064), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1182163, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_ALLOCATION_FAILURE,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 56965451,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(396902),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(kilobytes(65867),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(65277),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1112064),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(1182163,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedNoDetailsNoTrigger() {
         String logLine = "2017-05-25T13:00:52.772+0000: 2412.888: [Full GC 1630M->1281M(3072M), 4.1555250 secs] "
                 + "[Times: user=7.02 sys=0.01, real=4.16 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Time stamp not parsed correctly.", 2412888, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1630 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1281 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(3072 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 4155525, event.getDuration());
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals((long) 2412888,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1630 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1281 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3072 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(4155525,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -276,16 +249,14 @@ public class TestG1FullGCEvent {
                 + "3198M->827M(4096M), 4.1354492 secs][Eden: 1404.0M(1794.0M)->0.0B(2456.0M) Survivors: 102.0M->0.0B "
                 + "Heap: 3198.1M(4096.0M)->827.6M(4096.0M)], [Metaspace: 319076K->318118K(1343488K)] "
                 + "[Times: user=5.01 sys=0.00, real=4.14 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC,
-                event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 21424319, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(3274854), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(847462), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(4096 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 4135449, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 21424319,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(3274854),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(847462),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(4096 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(4135449,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -294,15 +265,14 @@ public class TestG1FullGCEvent {
                 + "277M->16M(1024M), 0.1206075 secs][Eden: 259.0M(614.0M)->0.0B(614.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 277.7M(1024.0M)->16.7M(1024.0M)], [Metaspace: 41053K->41053K(1085440K)] "
                 + "[Times: user=0.14 sys=0.00, real=0.12 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                G1FullGCEvent.match(logLine));
+        assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
-        assertEquals("Trigger not parsed correctly.", JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC, event.getTrigger());
-        assertEquals("Time stamp not parsed correctly.", 5590760, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(284365), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(17101), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(1024 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 120607, event.getDuration());
+        assertEquals(JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals((long) 5590760,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(284365),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(17101),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(120607,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -312,13 +282,10 @@ public class TestG1FullGCEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC));
-        assertFalse(Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC), JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.");
     }
 
     @Test
@@ -328,12 +295,9 @@ public class TestG1FullGCEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC));
-        assertFalse(Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC), JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1FullGCEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1FullGCEvent.java
@@ -34,22 +34,22 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1FullGCEvent {
+class TestG1FullGCEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "1302.524: [Full GC (System.gc()) 653M->586M(979M), 1.6364900 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_FULL_GC.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testNotVerboseGcOld() {
+    void testNotVerboseGcOld() {
         String logLine = "424753.957: [Full GC (Allocation Failure)  8184M->6998M(8192M), 24.1990452 secs]";
         assertFalse(G1YoungPauseEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
     }
 
     @Test
-    public void testLogLineTriggerSystemGC() {
+    void testLogLineTriggerSystemGC() {
         String logLine = "1302.524: [Full GC (System.gc()) 653M->586M(979M), 1.6364900 secs]";
         assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
@@ -65,7 +65,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testTriggerAllocationFailure() {
+    void testTriggerAllocationFailure() {
         String logLine = "424753.957: [Full GC (Allocation Failure)  8184M->6998M(8192M), 24.1990452 secs]";
         assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
         G1FullGCEvent event = new G1FullGCEvent(logLine);
@@ -81,7 +81,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsTriggerToSpaceExhausted() {
+    void testLogLinePreprocessedDetailsTriggerToSpaceExhausted() {
         String logLine = "105.151: [Full GC (System.gc()) 5820M->1381M(30G), 5.5390169 secs]"
                 + "[Eden: 80.0M(112.0M)->0.0B(128.0M) Survivors: 16.0M->0.0B Heap: 5820.3M(30.0G)->1381.9M(30.0G)]"
                 + " [Times: user=5.76 sys=1.00, real=5.53 secs]";
@@ -99,7 +99,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsNoTriggerPerm() {
+    void testLogLinePreprocessedDetailsNoTriggerPerm() {
         String logLine = "178.892: [Full GC 999M->691M(3072M), 3.4262061 secs]"
                 + "[Eden: 143.0M(1624.0M)->0.0B(1843.0M) Survivors: 219.0M->0.0B "
                 + "Heap: 999.5M(3072.0M)->691.1M(3072.0M)], [Perm: 175031K->175031K(175104K)]"
@@ -118,7 +118,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsPermNoSpaceAfterTriggerWithDatestamp() {
+    void testLogLinePreprocessedDetailsPermNoSpaceAfterTriggerWithDatestamp() {
         String logLine = "2017-02-27T02:55:32.523+0300: 35911.404: [Full GC (Allocation Failure)21G->20G(22G), "
                 + "40.6782890 secs][Eden: 0.0B(1040.0M)->0.0B(1120.0M) Survivors: 80.0M->0.0B "
                 + "Heap: 22.0G(22.0G)->20.6G(22.0G)], [Perm: 1252884K->1252884K(2097152K)] "
@@ -137,7 +137,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsTriggerMetadatGcThresholdMetaspace() {
+    void testLogLinePreprocessedDetailsTriggerMetadatGcThresholdMetaspace() {
         String logLine = "188.123: [Full GC (Metadata GC Threshold) 1831M->1213M(5120M), 5.1353878 secs]"
                 + "[Eden: 0.0B(1522.0M)->0.0B(2758.0M) Survivors: 244.0M->0.0B "
                 + "Heap: 1831.0M(5120.0M)->1213.5M(5120.0M)], [Metaspace: 396834K->324903K(1511424K)]"
@@ -156,7 +156,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsTriggerLastDitchCollection2SpacesAfterTrigger() {
+    void testLogLinePreprocessedDetailsTriggerLastDitchCollection2SpacesAfterTrigger() {
         String logLine = "98.150: [Full GC (Last ditch collection)  1196M->1118M(5120M), 4.4628626 secs]"
                 + "[Eden: 0.0B(3072.0M)->0.0B(3072.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 1196.3M(5120.0M)->1118.8M(5120.0M)], [Metaspace: 324984K->323866K(1511424K)] "
@@ -175,7 +175,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsTriggerJvmTi() {
+    void testLogLinePreprocessedDetailsTriggerJvmTi() {
         String logLine = "102.621: [Full GC (JvmtiEnv ForceGarbageCollection)  1124M->1118M(5120M), 3.8954775 secs]"
                 + "[Eden: 6144.0K(3072.0M)->0.0B(3072.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 1124.8M(5120.0M)->1118.9M(5120.0M)], [Metaspace: 323874K->323874K(1511424K)]"
@@ -194,7 +194,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedClassHistogram() {
+    void testLogLinePreprocessedClassHistogram() {
         String logLine = "49689.217: [Full GC49689.217: [Class Histogram (before full gc):, 8.8690440 secs]"
                 + "11G->2270M(12G), 19.8185620 secs][Eden: 0.0B(612.0M)->0.0B(7372.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 11.1G(12.0G)->2270.1M(12.0G)], [Perm: 730823K->730823K(2097152K)]";
@@ -212,7 +212,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDetailsTriggerAllocationFailure() {
+    void testLogLinePreprocessedDetailsTriggerAllocationFailure() {
         String logLine = "56965.451: [Full GC (Allocation Failure)  28G->387M(28G), 1.1821630 secs]"
                 + "[Eden: 0.0B(45.7G)->0.0B(34.4G) Survivors: 0.0B->0.0B Heap: 28.0G(28.0G)->387.6M(28.0G)], "
                 + "[Metaspace: 65867K->65277K(1112064K)] [Times: user=1.43 sys=0.00, real=1.18 secs]";
@@ -230,7 +230,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoDetailsNoTrigger() {
+    void testLogLinePreprocessedNoDetailsNoTrigger() {
         String logLine = "2017-05-25T13:00:52.772+0000: 2412.888: [Full GC 1630M->1281M(3072M), 4.1555250 secs] "
                 + "[Times: user=7.02 sys=0.01, real=4.16 secs]";
         assertTrue(G1FullGCEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
@@ -244,7 +244,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerHeapInspection() {
+    void testLogLinePreprocessedTriggerHeapInspection() {
         String logLine = "2020-06-26T00:00:06.152+0200: 21424.319: [Full GC (Heap Inspection Initiated GC)  "
                 + "3198M->827M(4096M), 4.1354492 secs][Eden: 1404.0M(1794.0M)->0.0B(2456.0M) Survivors: 102.0M->0.0B "
                 + "Heap: 3198.1M(4096.0M)->827.6M(4096.0M)], [Metaspace: 319076K->318118K(1343488K)] "
@@ -260,7 +260,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerHeapDumpInitiatedGc() {
+    void testLogLinePreprocessedTriggerHeapDumpInitiatedGc() {
         String logLine = "2020-07-14T14:51:39.493-0500: 5590.760: [Full GC (Heap Dump Initiated GC)  "
                 + "277M->16M(1024M), 0.1206075 secs][Eden: 259.0M(614.0M)->0.0B(614.0M) Survivors: 0.0B->0.0B "
                 + "Heap: 277.7M(1024.0M)->16.7M(1024.0M)], [Metaspace: 41053K->41053K(1085440K)] "
@@ -276,7 +276,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testHeapInspectionInitiatedGc() {
+    void testHeapInspectionInitiatedGc() {
         File testFile = TestUtil.getFile("dataset188.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -289,7 +289,7 @@ public class TestG1FullGCEvent {
     }
 
     @Test
-    public void testTriggerHeapDumpInitiatedGc() {
+    void testTriggerHeapDumpInitiatedGc() {
         File testFile = TestUtil.getFile("dataset189.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1MixedPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1MixedPauseEvent.java
@@ -34,16 +34,16 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1MixedPauseEvent {
+class TestG1MixedPauseEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs]";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
@@ -55,7 +55,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs] "
                 + "[Times: user=0.22 sys=0.00, real=0.22 secs]";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
@@ -72,7 +72,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLineSpacesAtEnd() {
+    void testLogLineSpacesAtEnd() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs] "
                 + "[Times: user=0.22 sys=0.00, real=0.22 secs]   ";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
@@ -86,7 +86,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testTriggerG1EvacuationPause() {
+    void testTriggerG1EvacuationPause() {
         String logLine = "81.757: [GC pause (G1 Evacuation Pause) (mixed) 1584M->1390M(8192M), 0.1472883 secs]";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
@@ -103,7 +103,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testTriggerG1EvacuationPauseDashDash() {
+    void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424692.063: [GC pause (G1 Evacuation Pause) (mixed)-- 8129M->7812M(8192M), 0.0890849 secs]";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
@@ -120,7 +120,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerBeforeG1EvacuationPause() {
+    void testLogLinePreprocessedTriggerBeforeG1EvacuationPause() {
         String logLine = "2973.338: [GC pause (G1 Evacuation Pause) (mixed), 0.0457502 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 12.9G(30.0G)->11.3G(30.0G)]"
                 + " [Times: user=0.19 sys=0.00, real=0.05 secs]";
@@ -139,7 +139,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoTrigger() {
+    void testLogLinePreprocessedNoTrigger() {
         String logLine = "3082.652: [GC pause (mixed), 0.0762060 secs]"
                 + "[Eden: 1288.0M(1288.0M)->0.0B(1288.0M) Survivors: 40.0M->40.0M Heap: 11.8G(26.0G)->9058.4M(26.0G)]"
                 + " [Times: user=0.30 sys=0.00, real=0.08 secs]";
@@ -157,7 +157,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoTriggerWholeSizes() {
+    void testLogLinePreprocessedNoTriggerWholeSizes() {
         String logLine = "449412.888: [GC pause (mixed), 0.06137400 secs][Eden: 2044M(2044M)->0B(1792M) "
                 + "Survivors: 4096K->256M Heap: 2653M(12288M)->435M(12288M)] "
                 + "[Times: user=0.43 sys=0.00, real=0.06 secs]";
@@ -175,7 +175,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLineWithDatestamp() {
+    void testLogLineWithDatestamp() {
         String logLine = "2018-03-02T07:08:35.683+0000: 47788.145: [GC pause (G1 Evacuation Pause) (mixed) "
                 + "1239M->949M(4096M), 0.0245500 secs]";
         assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
@@ -192,7 +192,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedWithDatestamp() {
+    void testLogLinePreprocessedWithDatestamp() {
         String logLine = "2016-02-09T23:27:04.149-0500: 3082.652: [GC pause (mixed), 0.0762060 secs]"
                 + "[Eden: 1288.0M(1288.0M)->0.0B(1288.0M) Survivors: 40.0M->40.0M Heap: 11.8G(26.0G)->9058.4M(26.0G)] "
                 + "[Times: user=0.30 sys=0.00, real=0.08 secs]";
@@ -210,7 +210,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testNoTriggerToSpaceExhausted() {
+    void testNoTriggerToSpaceExhausted() {
         String logLine = "615375.044: [GC pause (mixed) (to-space exhausted), 1.5026320 secs]"
                 + "[Eden: 3416.0M(3416.0M)->0.0B(3464.0M) Survivors: 264.0M->216.0M Heap: 17.7G(18.0G)->17.8G(18.0G)] "
                 + "[Times: user=11.35 sys=0.00, real=1.50 secs]";
@@ -229,7 +229,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testDoubleTriggerToSpaceExhausted() {
+    void testDoubleTriggerToSpaceExhausted() {
         String logLine = "506146.808: [GC pause (G1 Evacuation Pause) (mixed) (to-space exhausted), 8.6429024 secs]"
                 + "[Eden: 22.9G(24.3G)->0.0B(24.3G) Survivors: 112.0M->0.0B Heap: 27.7G(28.0G)->23.5G(28.0G)] "
                 + "[Times: user=34.39 sys=13.70, real=8.64 secs]";
@@ -248,7 +248,7 @@ public class TestG1MixedPauseEvent {
     }
 
     @Test
-    public void testTriggerGcLockerInitiatedGc() {
+    void testTriggerGcLockerInitiatedGc() {
         String logLine = "55.647: [GC pause (GCLocker Initiated GC) (mixed), 0.0210214 secs][Eden: "
                 + "44.0M(44.0M)->0.0B(248.0M) Survivors: 31.0M->10.0M Heap: 1141.0M(1500.0M)->1064.5M(1500.0M)] "
                 + "[Times: user=0.07 sys=0.00, real=0.02 secs]";
@@ -271,7 +271,7 @@ public class TestG1MixedPauseEvent {
      * 
      */
     @Test
-    public void testPreprocessingTriggerToSpaceExhausted() {
+    void testPreprocessingTriggerToSpaceExhausted() {
         File testFile = TestUtil.getFile("dataset99.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -288,7 +288,7 @@ public class TestG1MixedPauseEvent {
      * 
      */
     @Test
-    public void testPreprocessingDoubleTriggerG1EvacuationPauseToSpaceExhausted() {
+    void testPreprocessingDoubleTriggerG1EvacuationPauseToSpaceExhausted() {
         File testFile = TestUtil.getFile("dataset102.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -305,7 +305,7 @@ public class TestG1MixedPauseEvent {
      * 
      */
     @Test
-    public void testPreprocessingDoubleTriggerHumongousAllocationToSpaceExhausted() {
+    void testPreprocessingDoubleTriggerHumongousAllocationToSpaceExhausted() {
         File testFile = TestUtil.getFile("dataset133.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1MixedPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1MixedPauseEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -39,94 +39,84 @@ public class TestG1MixedPauseEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 72598, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(658432), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(525312), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(741376), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 168665, event.getDuration());
+        assertEquals((long) 72598,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(658432),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(525312),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(741376),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(168665,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithTimesData() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs] "
                 + "[Times: user=0.22 sys=0.00, real=0.22 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 72598, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(658432), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(525312), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(741376), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 168665, event.getDuration());
-        assertEquals("User time not parsed correctly.", 22, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 22, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 72598,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(658432),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(525312),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(741376),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(168665,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(22,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(22,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineSpacesAtEnd() {
         String logLine = "72.598: [GC pause (mixed) 643M->513M(724M), 0.1686650 secs] "
                 + "[Times: user=0.22 sys=0.00, real=0.22 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 72598, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(658432), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(525312), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(741376), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 168665, event.getDuration());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 72598,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(658432),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(525312),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(741376),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(168665,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testTriggerG1EvacuationPause() {
         String logLine = "81.757: [GC pause (G1 Evacuation Pause) (mixed) 1584M->1390M(8192M), 0.1472883 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 81757, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1584 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1390 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 147288, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 81757,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1584 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1390 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(147288,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424692.063: [GC pause (G1 Evacuation Pause) (mixed)-- 8129M->7812M(8192M), 0.0890849 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 424692063, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8129 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(7812 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 89084, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 424692063,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(8129 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(7812 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(89084,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -134,21 +124,18 @@ public class TestG1MixedPauseEvent {
         String logLine = "2973.338: [GC pause (G1 Evacuation Pause) (mixed), 0.0457502 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 12.9G(30.0G)->11.3G(30.0G)]"
                 + " [Times: user=0.19 sys=0.00, real=0.05 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Time stamp not parsed correctly.", 2973338, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(13526630),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(11848909), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(30 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 45750, event.getDuration());
-        assertEquals("User time not parsed correctly.", 19, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 5, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 380, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals((long) 2973338,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(13526630),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(11848909),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(45750,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(19,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(5,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(380,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -156,20 +143,17 @@ public class TestG1MixedPauseEvent {
         String logLine = "3082.652: [GC pause (mixed), 0.0762060 secs]"
                 + "[Eden: 1288.0M(1288.0M)->0.0B(1288.0M) Survivors: 40.0M->40.0M Heap: 11.8G(26.0G)->9058.4M(26.0G)]"
                 + " [Times: user=0.30 sys=0.00, real=0.08 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3082652, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(12373197),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(9275802), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 76206, event.getDuration());
-        assertEquals("User time not parsed correctly.", 30, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 8, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 375, event.getParallelism());
+        assertEquals((long) 3082652,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(12373197),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(9275802),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(76206,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(30,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(8,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(375,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -177,39 +161,34 @@ public class TestG1MixedPauseEvent {
         String logLine = "449412.888: [GC pause (mixed), 0.06137400 secs][Eden: 2044M(2044M)->0B(1792M) "
                 + "Survivors: 4096K->256M Heap: 2653M(12288M)->435M(12288M)] "
                 + "[Times: user=0.43 sys=0.00, real=0.06 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 449412888, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(2653 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(435 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(12288 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 61374, event.getDuration());
-        assertEquals("User time not parsed correctly.", 43, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 6, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 717, event.getParallelism());
+        assertEquals((long) 449412888,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(2653 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(435 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(12288 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(61374,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(43,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(6,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(717,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineWithDatestamp() {
         String logLine = "2018-03-02T07:08:35.683+0000: 47788.145: [GC pause (G1 Evacuation Pause) (mixed) "
                 + "1239M->949M(4096M), 0.0245500 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 47788145, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1239 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(949 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(4096 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 24550, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 47788145,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1239 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(949 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(4096 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(24550,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -217,20 +196,17 @@ public class TestG1MixedPauseEvent {
         String logLine = "2016-02-09T23:27:04.149-0500: 3082.652: [GC pause (mixed), 0.0762060 secs]"
                 + "[Eden: 1288.0M(1288.0M)->0.0B(1288.0M) Survivors: 40.0M->40.0M Heap: 11.8G(26.0G)->9058.4M(26.0G)] "
                 + "[Times: user=0.30 sys=0.00, real=0.08 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3082652, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(12373197),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(9275802), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 76206, event.getDuration());
-        assertEquals("User time not parsed correctly.", 30, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 8, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 375, event.getParallelism());
+        assertEquals((long) 3082652,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(12373197),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(9275802),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(76206,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(30,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(8,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(375,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -238,21 +214,18 @@ public class TestG1MixedPauseEvent {
         String logLine = "615375.044: [GC pause (mixed) (to-space exhausted), 1.5026320 secs]"
                 + "[Eden: 3416.0M(3416.0M)->0.0B(3464.0M) Survivors: 264.0M->216.0M Heap: 17.7G(18.0G)->17.8G(18.0G)] "
                 + "[Times: user=11.35 sys=0.00, real=1.50 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Time stamp not parsed correctly.", 615375044, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(18559795),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(18664653), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(18 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1502632, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1135, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 150, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 757, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals((long) 615375044,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(18559795),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(18664653),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(18 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(1502632,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1135,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(150,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(757,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -260,21 +233,18 @@ public class TestG1MixedPauseEvent {
         String logLine = "506146.808: [GC pause (G1 Evacuation Pause) (mixed) (to-space exhausted), 8.6429024 secs]"
                 + "[Eden: 22.9G(24.3G)->0.0B(24.3G) Survivors: 112.0M->0.0B Heap: 27.7G(28.0G)->23.5G(28.0G)] "
                 + "[Times: user=34.39 sys=13.70, real=8.64 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Time stamp not parsed correctly.", 506146808, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(29045555),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(24641536), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(28 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 8642902, event.getDuration());
-        assertEquals("User time not parsed correctly.", 3439, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1370, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 864, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 557, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals((long) 506146808,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(29045555),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(24641536),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(8642902,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(3439,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1370,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(864,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(557,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -282,20 +252,18 @@ public class TestG1MixedPauseEvent {
         String logLine = "55.647: [GC pause (GCLocker Initiated GC) (mixed), 0.0210214 secs][Eden: "
                 + "44.0M(44.0M)->0.0B(248.0M) Survivors: 31.0M->10.0M Heap: 1141.0M(1500.0M)->1064.5M(1500.0M)] "
                 + "[Times: user=0.07 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                G1MixedPauseEvent.match(logLine));
+        assertTrue(G1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
         G1MixedPauseEvent event = new G1MixedPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Time stamp not parsed correctly.", 55647, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1141 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1090048), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(1500 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 21021, event.getDuration());
-        assertEquals("User time not parsed correctly.", 7, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 350, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 55647,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1141 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1090048),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1500 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(21021,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(7,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(350,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     /**
@@ -309,13 +277,10 @@ public class TestG1MixedPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE), JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -329,13 +294,10 @@ public class TestG1MixedPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE), JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -349,12 +311,9 @@ public class TestG1MixedPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_MIXED_PAUSE), JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1RemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1RemarkEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -27,43 +27,38 @@ public class TestG1RemarkEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "106.129: [GC remark, 0.0450170 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_REMARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_REMARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testRemark() {
         String logLine = "106.129: [GC remark, 0.0450170 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                G1RemarkEvent.match(logLine));
+        assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
         G1RemarkEvent event = new G1RemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 106129, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 45017, event.getDuration());
+        assertEquals((long) 106129,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(45017,event.getDuration(),"Duration not parsed correctly.");
     }
 
     public void TestG1RemarkPreprocessedEvent() {
         String logLine = "2971.469: [GC remark, 0.2274544 secs] [Times: user=0.22 sys=0.00, real=0.22 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                G1RemarkEvent.match(logLine));
+        assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
     }
 
     public void TestG1RemarkPreprocessedEventWhiteSpacesAtEnd() {
         String logLine = "2971.469: [GC remark, 0.2274544 secs] [Times: user=0.22 sys=0.00, real=0.22 secs]     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                G1RemarkEvent.match(logLine));
+        assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
     }
 
     @Test
     public void testRemarkWithTimesDate() {
         String logLine = "2016-11-08T09:40:55.346-0800: 35563.088: [GC remark, 0.0827210 secs] "
                 + "[Times: user=0.37 sys=0.00, real=0.08 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                G1RemarkEvent.match(logLine));
+        assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
         G1RemarkEvent event = new G1RemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 35563088, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 82721, event.getDuration());
-        assertEquals("User time not parsed correctly.", 37, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 8, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 463, event.getParallelism());
+        assertEquals((long) 35563088,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(82721,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(37,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(8,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(463,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1RemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1RemarkEvent.java
@@ -22,16 +22,16 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1RemarkEvent {
+class TestG1RemarkEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "106.129: [GC remark, 0.0450170 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_REMARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testRemark() {
+    void testRemark() {
         String logLine = "106.129: [GC remark, 0.0450170 secs]";
         assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
         G1RemarkEvent event = new G1RemarkEvent(logLine);
@@ -50,7 +50,7 @@ public class TestG1RemarkEvent {
     }
 
     @Test
-    public void testRemarkWithTimesDate() {
+    void testRemarkWithTimesDate() {
         String logLine = "2016-11-08T09:40:55.346-0800: 35563.088: [GC remark, 0.0827210 secs] "
                 + "[Times: user=0.37 sys=0.00, real=0.08 secs]";
         assertTrue(G1RemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungInitialMarkEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -39,67 +39,58 @@ public class TestG1YoungInitialMarkEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testInitialMark() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs] "
                 + "[Times: user=0.18 sys=0.02, real=0.06 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1244357, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(867328), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(613376), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(993280), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 56684, event.getDuration());
-        assertEquals("User time not parsed correctly.", 18, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 2, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 6, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 334, event.getParallelism());
+        assertEquals((long) 1244357,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(867328),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(613376),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(993280),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(56684,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(18,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(6,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(334,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testNotYoungPause() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
-        assertFalse("Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertFalse(G1YoungInitialMarkEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineMetadataGCThresholdTrigger() {
         String logLine = "1.471: [GC pause (Metadata GC Threshold) (young) (initial-mark) 992M->22M(110G), "
                 + "0.0210012 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1471, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(992 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(22 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(110 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 21001, event.getDuration());
+        assertEquals((long) 1471,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(992 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(22 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(110 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(21001,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineGCLockerInitiatedGCTriggerBeforeInitialMark() {
         String logLine = "2.443: [GC pause (GCLocker Initiated GC) (young) (initial-mark) 1061M->52M(110G), "
                 + "0.0280096 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2443, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1061 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(52 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(110 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 28009, event.getDuration());
+        assertEquals((long) 2443,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1061 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(52 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(110 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(28009,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -107,21 +98,18 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "60346.050: [GC pause (young) (initial-mark) (to-space exhausted), 1.0224350 secs]"
                 + "[Eden: 14.2G(14.5G)->0.0B(1224.0M) Survivors: 40.0M->104.0M Heap: 22.9G(26.0G)->19.2G(26.0G)]"
                 + " [Times: user=3.03 sys=0.02, real=1.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 60346050, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(24012390),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(20132659), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1022435, event.getDuration());
-        assertEquals("User time not parsed correctly.", 303, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 2, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 102, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 300, event.getParallelism());
+        assertEquals((long) 60346050,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(24012390),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(20132659),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(1022435,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(303,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(102,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(300,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -129,21 +117,18 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "44620.073: [GC pause (young), 0.2752700 secs]"
                 + "[Eden: 11.3G(11.3G)->0.0B(11.3G) Survivors: 192.0M->176.0M Heap: 23.0G(26.0G)->11.7G(26.0G)]"
                 + " [Times: user=1.09 sys=0.00, real=0.27 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 44620073, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(23 * 1024 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12268339), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 275270, event.getDuration());
-        assertEquals("User time not parsed correctly.", 109, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 27, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 404, event.getParallelism());
+        assertEquals((long) 44620073,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals(kilobytes(23 * 1024 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12268339),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(275270,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(109,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(27,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(404,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -151,21 +136,18 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "27474.176: [GC pause (young) (initial-mark), 0.4234530 secs]"
                 + "[Eden: 5376.0M(7680.0M)->0.0B(6944.0M) Survivors: 536.0M->568.0M "
                 + "Heap: 13.8G(26.0G)->8821.4M(26.0G)] [Times: user=1.66 sys=0.02, real=0.43 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 27474176, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(14470349),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(9033114), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 423453, event.getDuration());
-        assertEquals("User time not parsed correctly.", 166, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 2, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 43, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 391, event.getParallelism());
+        assertEquals((long) 27474176,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals(kilobytes(14470349),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(9033114),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(423453,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(166,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(43,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(391,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -173,20 +155,17 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "87.830: [GC pause (Metadata GC Threshold) (young) (initial-mark), 0.2932700 secs]"
                 + "[Eden: 716.0M(1850.0M)->0.0B(1522.0M) Survivors: 96.0M->244.0M "
                 + "Heap: 2260.0M(5120.0M)->1831.0M(5120.0M)] [Times: user=0.56 sys=0.04, real=0.29 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 87830, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(2260 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1831 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(5120 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 293270, event.getDuration());
-        assertEquals("User time not parsed correctly.", 56, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 29, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 207, event.getParallelism());
+        assertEquals((long) 87830,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(2260 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1831 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5120 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(293270,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(56,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(29,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(207,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -194,19 +173,18 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "6896.482: [GC pause (GCLocker Initiated GC) (young) (initial-mark), 0.0525160 secs]"
                 + "[Eden: 16.0M(3072.0M)->0.0B(3070.0M) Survivors: 0.0B->2048.0K "
                 + "Heap: 828.8M(5120.0M)->814.8M(5120.0M)] [Times: user=0.09 sys=0.00, real=0.05 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6896482, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(848691), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(834355), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(5120 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 52516, event.getDuration());
-        assertEquals("User time not parsed correctly.", 9, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 5, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 180, event.getParallelism());
+        assertEquals((long) 6896482,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(848691),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(834355),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5120 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(52516,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(9,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(5,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(180,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -214,21 +192,18 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "182.037: [GC pause (G1 Humongous Allocation) (young) (initial-mark), 0.0233585 secs]"
                 + "[Eden: 424.0M(1352.0M)->0.0B(1360.0M) Survivors: 80.0M->72.0M Heap: 500.9M(28.0G)->72.0M(28.0G)] "
                 + "[Times: user=0.14 sys=0.01, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 182037, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(512922), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(72 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(28 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 23358, event.getDuration());
-        assertEquals("User time not parsed correctly.", 14, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 750, event.getParallelism());
+        assertEquals((long) 182037,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(512922),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(72 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(23358,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(14,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(750,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -236,18 +211,17 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "2020-02-26T17:18:26.505+0000: 130.241: [GC pause (System.gc()) (young) (initial-mark), "
                 + "0.1009346 secs][Eden: 220.0M(241.0M)->0.0B(277.0M) Survivors: 28.0M->34.0M "
                 + "Heap: 924.5M(2362.0M)->713.5M(2362.0M)] [Times: user=0.19 sys=0.00, real=0.10 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 130241, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(946688), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(730624), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(2362 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 100934, event.getDuration());
-        assertEquals("User time not parsed correctly.", 19, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 10, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 190, event.getParallelism());
+        assertEquals((long) 130241,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(946688),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(730624),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(2362 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(100934,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(19,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(10,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(190,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -255,21 +229,17 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "449391.255: [GC pause (young) (initial-mark), 0.02147900 secs]"
                 + "[Eden: 1792M(1792M)->0B(2044M) Survivors: 256M->4096K Heap: 7582M(12288M)->5537M(12288M)] "
                 + "[Times: user=0.13 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 449391255, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(7582 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(5537 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(12288 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 21479, event.getDuration());
-        assertEquals("User time not parsed correctly.", 13, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 650, event.getParallelism());
+        assertEquals((long) 449391255,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(7582 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(5537 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(12288 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(21479,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(13,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(650,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -277,33 +247,29 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "2016-02-09T06:12:45.414-0500: 27474.176: [GC pause (young) (initial-mark), 0.4234530 secs]"
                 + "[Eden: 5376.0M(7680.0M)->0.0B(6944.0M) Survivors: 536.0M->568.0M "
                 + "Heap: 13.8G(26.0G)->8821.4M(26.0G)] [Times: user=1.66 sys=0.02, real=0.43 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 27474176, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(14470349),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(9033114), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 423453, event.getDuration());
-        assertEquals("User time not parsed correctly.", 166, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 43, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 391, event.getParallelism());
+        assertEquals((long) 27474176,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(14470349),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(9033114),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(423453,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(166,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(43,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(391,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedTriggerG1HumongousAllocationNoSizeData() {
         String logLine = "2017-02-20T20:17:04.874-0500: 40442.077: [GC pause (G1 Humongous Allocation) (young) "
                 + "(initial-mark), 0.0142482 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 40442077, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(0), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(0), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(0), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 14248, event.getDuration());
+        assertEquals((long) 40442077,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(14248,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -311,56 +277,49 @@ public class TestG1YoungInitialMarkEvent {
         String logLine = "2017-06-23T10:50:04.403-0400: 9.915: [GC pause (Metadata GC Threshold) (young) "
                 + "(initial-mark)[Eden: 304.0M(1552.0M)->0.0B(1520.0M) Survivors: 0.0B->32.0M Heap: "
                 + "296.0M(30.5G)->23.2M(30.5G)] [Times: user=0.12 sys=0.01, real=0.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 9915, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(296 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(23757), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(31981568), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 10000, event.getDuration());
+        assertEquals((long) 9915,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(296 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(23757),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31981568),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(10000,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testTriggerG1EvacuationPause() {
         String logLine = "7.190: [GC pause (G1 Evacuation Pause) (young) (initial-mark) 407M->100M(8192M), "
                 + "0.0720459 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7190, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(407 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(100 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 72045, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 7190,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(407 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(100 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(72045,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424753.803: [GC pause (G1 Evacuation Pause) (young) (initial-mark)-- 8184M->8184M(8192M), "
                 + "0.1294400 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                G1YoungInitialMarkEvent.match(logLine));
+        assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
         G1YoungInitialMarkEvent event = new G1YoungInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 424753803, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8184 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(8184 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 129440, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 424753803,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(8184 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(8184 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(129440,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -370,15 +329,11 @@ public class TestG1YoungInitialMarkEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertFalse(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_G1_YOUNG_INITIAL_MARK + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_G1_YOUNG_INITIAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1), Analysis.ERROR_EXPLICIT_GC_SERIAL_G1 + " analysis incorrectly identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_G1_YOUNG_INITIAL_MARK), Analysis.WARN_EXPLICIT_GC_G1_YOUNG_INITIAL_MARK + " analysis not identified.");
 
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungInitialMarkEvent.java
@@ -34,16 +34,16 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1YoungInitialMarkEvent {
+class TestG1YoungInitialMarkEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testInitialMark() {
+    void testInitialMark() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs] "
                 + "[Times: user=0.18 sys=0.02, real=0.06 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -60,13 +60,13 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testNotYoungPause() {
+    void testNotYoungPause() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
         assertFalse(G1YoungInitialMarkEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineMetadataGCThresholdTrigger() {
+    void testLogLineMetadataGCThresholdTrigger() {
         String logLine = "1.471: [GC pause (Metadata GC Threshold) (young) (initial-mark) 992M->22M(110G), "
                 + "0.0210012 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -80,7 +80,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineGCLockerInitiatedGCTriggerBeforeInitialMark() {
+    void testLogLineGCLockerInitiatedGCTriggerBeforeInitialMark() {
         String logLine = "2.443: [GC pause (GCLocker Initiated GC) (young) (initial-mark) 1061M->52M(110G), "
                 + "0.0280096 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -94,7 +94,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineToSpaceExhaustedTriggerAfterInitialMark() {
+    void testLogLineToSpaceExhaustedTriggerAfterInitialMark() {
         String logLine = "60346.050: [GC pause (young) (initial-mark) (to-space exhausted), 1.0224350 secs]"
                 + "[Eden: 14.2G(14.5G)->0.0B(1224.0M) Survivors: 40.0M->104.0M Heap: 22.9G(26.0G)->19.2G(26.0G)]"
                 + " [Times: user=3.03 sys=0.02, real=1.02 secs]";
@@ -113,7 +113,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLineNoTriggerNoInitialMark() {
+    void testLogLineNoTriggerNoInitialMark() {
         String logLine = "44620.073: [GC pause (young), 0.2752700 secs]"
                 + "[Eden: 11.3G(11.3G)->0.0B(11.3G) Survivors: 192.0M->176.0M Heap: 23.0G(26.0G)->11.7G(26.0G)]"
                 + " [Times: user=1.09 sys=0.00, real=0.27 secs]";
@@ -132,7 +132,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoTrigger() {
+    void testLogLinePreprocessedNoTrigger() {
         String logLine = "27474.176: [GC pause (young) (initial-mark), 0.4234530 secs]"
                 + "[Eden: 5376.0M(7680.0M)->0.0B(6944.0M) Survivors: 536.0M->568.0M "
                 + "Heap: 13.8G(26.0G)->8821.4M(26.0G)] [Times: user=1.66 sys=0.02, real=0.43 secs]";
@@ -151,7 +151,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerMetadataGcThreshold() {
+    void testLogLinePreprocessedTriggerMetadataGcThreshold() {
         String logLine = "87.830: [GC pause (Metadata GC Threshold) (young) (initial-mark), 0.2932700 secs]"
                 + "[Eden: 716.0M(1850.0M)->0.0B(1522.0M) Survivors: 96.0M->244.0M "
                 + "Heap: 2260.0M(5120.0M)->1831.0M(5120.0M)] [Times: user=0.56 sys=0.04, real=0.29 secs]";
@@ -169,7 +169,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerGcLockerInitiatedGc() {
+    void testLogLinePreprocessedTriggerGcLockerInitiatedGc() {
         String logLine = "6896.482: [GC pause (GCLocker Initiated GC) (young) (initial-mark), 0.0525160 secs]"
                 + "[Eden: 16.0M(3072.0M)->0.0B(3070.0M) Survivors: 0.0B->2048.0K "
                 + "Heap: 828.8M(5120.0M)->814.8M(5120.0M)] [Times: user=0.09 sys=0.00, real=0.05 secs]";
@@ -188,7 +188,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerG1HumongousAllocation() {
+    void testLogLinePreprocessedTriggerG1HumongousAllocation() {
         String logLine = "182.037: [GC pause (G1 Humongous Allocation) (young) (initial-mark), 0.0233585 secs]"
                 + "[Eden: 424.0M(1352.0M)->0.0B(1360.0M) Survivors: 80.0M->72.0M Heap: 500.9M(28.0G)->72.0M(28.0G)] "
                 + "[Times: user=0.14 sys=0.01, real=0.02 secs]";
@@ -207,7 +207,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerSystemGc() {
+    void testLogLinePreprocessedTriggerSystemGc() {
         String logLine = "2020-02-26T17:18:26.505+0000: 130.241: [GC pause (System.gc()) (young) (initial-mark), "
                 + "0.1009346 secs][Eden: 220.0M(241.0M)->0.0B(277.0M) Survivors: 28.0M->34.0M "
                 + "Heap: 924.5M(2362.0M)->713.5M(2362.0M)] [Times: user=0.19 sys=0.00, real=0.10 secs]";
@@ -225,7 +225,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoTriggerWholeNumberSizes() {
+    void testLogLinePreprocessedNoTriggerWholeNumberSizes() {
         String logLine = "449391.255: [GC pause (young) (initial-mark), 0.02147900 secs]"
                 + "[Eden: 1792M(1792M)->0B(2044M) Survivors: 256M->4096K Heap: 7582M(12288M)->5537M(12288M)] "
                 + "[Times: user=0.13 sys=0.00, real=0.02 secs]";
@@ -243,7 +243,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDatestamp() {
+    void testLogLinePreprocessedDatestamp() {
         String logLine = "2016-02-09T06:12:45.414-0500: 27474.176: [GC pause (young) (initial-mark), 0.4234530 secs]"
                 + "[Eden: 5376.0M(7680.0M)->0.0B(6944.0M) Survivors: 536.0M->568.0M "
                 + "Heap: 13.8G(26.0G)->8821.4M(26.0G)] [Times: user=1.66 sys=0.02, real=0.43 secs]";
@@ -260,7 +260,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerG1HumongousAllocationNoSizeData() {
+    void testLogLinePreprocessedTriggerG1HumongousAllocationNoSizeData() {
         String logLine = "2017-02-20T20:17:04.874-0500: 40442.077: [GC pause (G1 Humongous Allocation) (young) "
                 + "(initial-mark), 0.0142482 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -273,7 +273,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoDuration() {
+    void testLogLinePreprocessedNoDuration() {
         String logLine = "2017-06-23T10:50:04.403-0400: 9.915: [GC pause (Metadata GC Threshold) (young) "
                 + "(initial-mark)[Eden: 304.0M(1552.0M)->0.0B(1520.0M) Survivors: 0.0B->32.0M Heap: "
                 + "296.0M(30.5G)->23.2M(30.5G)] [Times: user=0.12 sys=0.01, real=0.03 secs]";
@@ -287,7 +287,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testTriggerG1EvacuationPause() {
+    void testTriggerG1EvacuationPause() {
         String logLine = "7.190: [GC pause (G1 Evacuation Pause) (young) (initial-mark) 407M->100M(8192M), "
                 + "0.0720459 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -305,7 +305,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testTriggerG1EvacuationPauseDashDash() {
+    void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424753.803: [GC pause (G1 Evacuation Pause) (young) (initial-mark)-- 8184M->8184M(8192M), "
                 + "0.1294400 secs]";
         assertTrue(G1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -323,7 +323,7 @@ public class TestG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testAnalysisExplicitGc() {
+    void testAnalysisExplicitGc() {
         File testFile = TestUtil.getFile("dataset179.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungPauseEvent.java
@@ -34,28 +34,28 @@ import org.junit.jupiter.api.Test;
  * @author James Livingston
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestG1YoungPauseEvent {
+class TestG1YoungPauseEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testYoungPause() {
+    void testYoungPause() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
-    public void testNotInitialMark() {
+    void testNotInitialMark() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs]";
         assertFalse(G1YoungPauseEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
-    public void testLogLineKilobytes() {
+    void testLogLineKilobytes() {
         String logLine = "0.308: [GC pause (young) 8192K->2028K(59M), 0.0078140 secs] "
                 + "[Times: user=0.01 sys=0.00, real=0.02 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -72,7 +72,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testTriggerGcLockerInitiatedGc() {
+    void testTriggerGcLockerInitiatedGc() {
         String logLine = "9.466: [GC pause (GCLocker Initiated GC) (young) 523M->198M(8192M), 0.0500110 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
@@ -89,7 +89,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testDatestameTriggerG1EvacuationPause() {
+    void testDatestameTriggerG1EvacuationPause() {
         String logLine = "2018-01-22T12:43:33.359-0700: 17.629: [GC pause (G1 Evacuation Pause) (young) "
                 + "511M->103M(10G), 0.1343977 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -107,7 +107,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testTriggerG1EvacuationPauseDashDash() {
+    void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424751.601: [GC pause (G1 Evacuation Pause) (young)-- 8172M->8168M(8192M), 0.4589730 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
@@ -124,7 +124,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedG1Details() {
+    void testLogLinePreprocessedG1Details() {
         String logLine = "2.847: [GC pause (G1 Evacuation Pause) (young), 0.0414530 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 136.9M(30.0G)->70.9M(30.0G)]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -138,7 +138,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedG1Sizes() {
+    void testLogLinePreprocessedG1Sizes() {
         String logLine = "0.807: [GC pause (young), 0.00290200 secs][ 29M->2589K(59M)]"
                 + " [Times: user=0.01 sys=0.00, real=0.01 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -156,7 +156,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedG1DetailsTriggerGcLockerInitiatedGc() {
+    void testLogLinePreprocessedG1DetailsTriggerGcLockerInitiatedGc() {
         String logLine = "5.293: [GC pause (GCLocker Initiated GC) (young), 0.0176868 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 415.0M(30.0G)->313.0M(30.0G)]"
                 + " [Times: user=0.01 sys=0.00, real=0.02 secs]";
@@ -175,7 +175,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedG1DetailsTriggerAfterYoungToSpaceExhausted() {
+    void testLogLinePreprocessedG1DetailsTriggerAfterYoungToSpaceExhausted() {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]"
                 + "[Eden: 1280.0M(1280.0M)->0.0B(1288.0M) Survivors: 48.0M->40.0M Heap: 18.9G(26.0G)->17.8G(26.0G)]"
                 + " [Times: user=0.41 sys=0.02, real=0.12 secs]";
@@ -194,7 +194,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoTrigger() {
+    void testLogLinePreprocessedNoTrigger() {
         String logLine = "44620.073: [GC pause (young), 0.2752700 secs]"
                 + "[Eden: 11.3G(11.3G)->0.0B(11.3G) Survivors: 192.0M->176.0M Heap: 23.0G(26.0G)->11.7G(26.0G)]"
                 + " [Times: user=1.09 sys=0.00, real=0.27 secs]";
@@ -213,7 +213,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoSizeDetails() {
+    void testLogLinePreprocessedNoSizeDetails() {
         String logLine = "785,047: [GC pause (young), 0,73936800 secs][Eden: 4096M(4096M)->0B(3528M) "
                 + "Survivors: 0B->568M Heap: 4096M(16384M)->567M(16384M)] [Times: user=4,42 sys=0,38, real=0,74 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -227,7 +227,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDoubleTrigger() {
+    void testLogLinePreprocessedDoubleTrigger() {
         String logLine = "6049.175: [GC pause (G1 Evacuation Pause) (young) (to-space exhausted), 3.1713585 secs]"
                 + "[Eden: 27.1G(50.7G)->0.0B(50.7G) Survivors: 112.0M->0.0B Heap: 27.9G(28.0G)->16.1G(28.0G)] "
                 + "[Times: user=17.73 sys=0.00, real=3.18 secs]";
@@ -246,7 +246,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTriggerHumongousAllocatioin() {
+    void testLogLinePreprocessedTriggerHumongousAllocatioin() {
         String logLine = "2020-02-16T23:24:09.668+0000: 880272.698: [GC pause (G1 Humongous Allocation) (young) "
                 + "(to-space exhausted), 0.6167306 secs][Eden: 545.0M(1691.0M)->0.0B(1691.0M) "
                 + "Survivors: 0.0B->1024.0K Heap: 3038.2M(3072.0M)->2748.7M(3072.0M)] "
@@ -265,7 +265,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedDatestamp() {
+    void testLogLinePreprocessedDatestamp() {
         String logLine = "2016-12-21T14:28:11.672-0500: 0.823: [GC pause (G1 Evacuation Pause) (young), "
                 + "0.0124023 secs][Eden: 75.0M(75.0M)->0.0B(66.0M) Survivors: 0.0B->9216.0K "
                 + "Heap: 75.0M(1500.0M)->8749.6K(1500.0M)] [Times: user=0.03 sys=0.00, real=0.02 secs]";
@@ -284,7 +284,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoDuration() {
+    void testLogLinePreprocessedNoDuration() {
         String logLine = "2017-04-05T09:09:00.416-0500: 201626.141: [GC pause (G1 Evacuation Pause) (young)"
                 + "[Eden: 3808.0M(3808.0M)->0.0B(3760.0M) Survivors: 40.0M->64.0M "
                 + "Heap: 7253.9M(8192.0M)->3472.3M(8192.0M)] [Times: user=0.22 sys=0.00, real=0.11 secs]";
@@ -303,7 +303,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedToSpaceOverflow() {
+    void testLogLinePreprocessedToSpaceOverflow() {
         String logLine = "2017-05-25T12:24:06.040+0000: 206.156: [GC pause (young) (to-space overflow), "
                 + "0.77121400 secs][Eden: 1270M(1270M)->0B(723M) Survivors: 124M->175M Heap: "
                 + "2468M(3072M)->1695M(3072M)] [Times: user=1.51 sys=0.14, real=0.77 secs]";
@@ -322,7 +322,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedWithCommas() {
+    void testLogLinePreprocessedWithCommas() {
         String logLine = "2018-09-20T14:57:22.095+0300: 6,350: [GC pause (young), 0,1275790 secs]"
                 + "[Eden: 306,0M(306,0M)->0,0B(266,0M) Survivors: 0,0B->40,0M Heap: 306,0M(6144,0M)->57,7M(6144,0M)] "
                 + "[Times: user=0,25 sys=0,05, real=0,12 secs]";
@@ -340,7 +340,7 @@ public class TestG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedNoSpaceAfterYoung() {
+    void testLogLinePreprocessedNoSpaceAfterYoung() {
         String logLine = "2018-12-07T11:26:56.282-0500: 0.314: [GC pause (G1 Evacuation Pause) "
                 + "(young)3589K->2581K(6144K), 0.0063282 secs]";
         assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
@@ -361,7 +361,7 @@ public class TestG1YoungPauseEvent {
      * 
      */
     @Test
-    public void testPreprocessingTriggerToSpaceOverflow() {
+    void testPreprocessingTriggerToSpaceOverflow() {
         File testFile = TestUtil.getFile("dataset128.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -378,7 +378,7 @@ public class TestG1YoungPauseEvent {
      * 
      */
     @Test
-    public void testPreprocessingNoSpaceAfterYoung() {
+    void testPreprocessingNoSpaceAfterYoung() {
         File testFile = TestUtil.getFile("dataset146.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestG1YoungPauseEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author James Livingston
@@ -39,135 +39,120 @@ public class TestG1YoungPauseEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testYoungPause() {
         String logLine = "1113.145: [GC pause (young) 849M->583M(968M), 0.0392710 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
     public void testNotInitialMark() {
         String logLine = "1244.357: [GC pause (young) (initial-mark) 847M->599M(970M), 0.0566840 secs]";
-        assertFalse("Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertFalse(G1YoungPauseEvent.match(logLine), "Log line recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
     public void testLogLineKilobytes() {
         String logLine = "0.308: [GC pause (young) 8192K->2028K(59M), 0.0078140 secs] "
                 + "[Times: user=0.01 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 308, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8192), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2028), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(60416), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 7814, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 50, event.getParallelism());
+        assertEquals((long) 308,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(8192),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(2028),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(60416),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(7814,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(50,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testTriggerGcLockerInitiatedGc() {
         String logLine = "9.466: [GC pause (GCLocker Initiated GC) (young) 523M->198M(8192M), 0.0500110 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 9466, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(523 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(198 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 50011, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 9466,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(523 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(198 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(50011,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testDatestameTriggerG1EvacuationPause() {
         String logLine = "2018-01-22T12:43:33.359-0700: 17.629: [GC pause (G1 Evacuation Pause) (young) "
                 + "511M->103M(10G), 0.1343977 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 17629, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(511 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(103 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(10 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 134397, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 17629,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(511 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(103 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(10 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(134397,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testTriggerG1EvacuationPauseDashDash() {
         String logLine = "424751.601: [GC pause (G1 Evacuation Pause) (young)-- 8172M->8168M(8192M), 0.4589730 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 424751601, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8172 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(8168 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 458973, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 424751601,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(8172 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(8168 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(458973,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedG1Details() {
         String logLine = "2.847: [GC pause (G1 Evacuation Pause) (young), 0.0414530 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 136.9M(30.0G)->70.9M(30.0G)]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Time stamp not parsed correctly.", 2847, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(140186), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(72602), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(31457280), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 41453, event.getDuration());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals((long) 2847,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(140186),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(72602),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31457280),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(41453,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedG1Sizes() {
         String logLine = "0.807: [GC pause (young), 0.00290200 secs][ 29M->2589K(59M)]"
                 + " [Times: user=0.01 sys=0.00, real=0.01 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Time stamp not parsed correctly.", 807, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(29 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2589), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(59 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 2902, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals((long) 807,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(29 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(2589),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(59 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(2902,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -175,21 +160,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "5.293: [GC pause (GCLocker Initiated GC) (young), 0.0176868 secs]"
                 + "[Eden: 112.0M(112.0M)->0.0B(112.0M) Survivors: 16.0M->16.0M Heap: 415.0M(30.0G)->313.0M(30.0G)]"
                 + " [Times: user=0.01 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Time stamp not parsed correctly.", 5293, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(415 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(313 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(30 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 17686, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 50, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals((long) 5293,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(415 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(313 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(17686,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(50,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -197,21 +179,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]"
                 + "[Eden: 1280.0M(1280.0M)->0.0B(1288.0M) Survivors: 48.0M->40.0M Heap: 18.9G(26.0G)->17.8G(26.0G)]"
                 + " [Times: user=0.41 sys=0.02, real=0.12 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Time stamp not parsed correctly.", 27997968, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(19818086),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(18664653), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 120874, event.getDuration());
-        assertEquals("User time not parsed correctly.", 41, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 2, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 12, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 359, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals((long) 27997968,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(19818086),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(18664653),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(120874,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(41,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(12,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(359,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -219,38 +198,32 @@ public class TestG1YoungPauseEvent {
         String logLine = "44620.073: [GC pause (young), 0.2752700 secs]"
                 + "[Eden: 11.3G(11.3G)->0.0B(11.3G) Survivors: 192.0M->176.0M Heap: 23.0G(26.0G)->11.7G(26.0G)]"
                 + " [Times: user=1.09 sys=0.00, real=0.27 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Time stamp not parsed correctly.", 44620073, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(23 * 1024 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12268339), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(26 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 275270, event.getDuration());
-        assertEquals("User time not parsed correctly.", 109, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 27, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 404, event.getParallelism());
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals((long) 44620073,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(23 * 1024 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12268339),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(26 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(275270,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(109,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(27,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(404,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedNoSizeDetails() {
         String logLine = "785,047: [GC pause (young), 0,73936800 secs][Eden: 4096M(4096M)->0B(3528M) "
                 + "Survivors: 0B->568M Heap: 4096M(16384M)->567M(16384M)] [Times: user=4,42 sys=0,38, real=0,74 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Time stamp not parsed correctly.", 785047, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(4096 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(567 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(16384 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 739368, event.getDuration());
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals((long) 785047,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(4096 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(567 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(16384 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(739368,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -258,21 +231,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "6049.175: [GC pause (G1 Evacuation Pause) (young) (to-space exhausted), 3.1713585 secs]"
                 + "[Eden: 27.1G(50.7G)->0.0B(50.7G) Survivors: 112.0M->0.0B Heap: 27.9G(28.0G)->16.1G(28.0G)] "
                 + "[Times: user=17.73 sys=0.00, real=3.18 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Time stamp not parsed correctly.", 6049175, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(29255270),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(16882074), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(28 * 1024 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 3171358, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1773, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 318, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 558, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals((long) 6049175,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(29255270),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(16882074),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(3171358,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1773,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(318,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(558,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -281,18 +251,17 @@ public class TestG1YoungPauseEvent {
                 + "(to-space exhausted), 0.6167306 secs][Eden: 545.0M(1691.0M)->0.0B(1691.0M) "
                 + "Survivors: 0.0B->1024.0K Heap: 3038.2M(3072.0M)->2748.7M(3072.0M)] "
                 + "[Times: user=1.08 sys=0.01, real=0.62 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED));
-        assertEquals("Time stamp not parsed correctly.", 880272698, event.getTimestamp());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2814669), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(3072 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 616730, event.getDuration());
-        assertEquals("User time not parsed correctly.", 108, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 62, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 176, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED), "Trigger not parsed correctly.");
+        assertEquals((long) 880272698,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(2814669),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3072 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(616730,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(108,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(62,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(176,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -300,20 +269,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "2016-12-21T14:28:11.672-0500: 0.823: [GC pause (G1 Evacuation Pause) (young), "
                 + "0.0124023 secs][Eden: 75.0M(75.0M)->0.0B(66.0M) Survivors: 0.0B->9216.0K "
                 + "Heap: 75.0M(1500.0M)->8749.6K(1500.0M)] [Times: user=0.03 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Time stamp not parsed correctly.", 823, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(75 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(8750), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(1500 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 12402, event.getDuration());
-        assertEquals("User time not parsed correctly.", 3, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 150, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals((long) 823,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(75 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(8750),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1500 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(12402,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(3,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(150,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -321,19 +288,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "2017-04-05T09:09:00.416-0500: 201626.141: [GC pause (G1 Evacuation Pause) (young)"
                 + "[Eden: 3808.0M(3808.0M)->0.0B(3760.0M) Survivors: 40.0M->64.0M "
                 + "Heap: 7253.9M(8192.0M)->3472.3M(8192.0M)] [Times: user=0.22 sys=0.00, real=0.11 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Time stamp not parsed correctly.", 201626141, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(7427994), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(3555635), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(8192 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 110000, event.getDuration());
-        assertEquals("User time not parsed correctly.", 22, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 11, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 200, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals((long) 201626141,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(7427994),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(3555635),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8192 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(110000,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(22,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(11,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(200,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -341,21 +307,18 @@ public class TestG1YoungPauseEvent {
         String logLine = "2017-05-25T12:24:06.040+0000: 206.156: [GC pause (young) (to-space overflow), "
                 + "0.77121400 secs][Eden: 1270M(1270M)->0B(723M) Survivors: 124M->175M Heap: "
                 + "2468M(3072M)->1695M(3072M)] [Times: user=1.51 sys=0.14, real=0.77 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_OVERFLOW));
-        assertEquals("Time stamp not parsed correctly.", 206156, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(2468 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1695 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(3072 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 771214, event.getDuration());
-        assertEquals("User time not parsed correctly.", 151, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 14, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 77, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 215, event.getParallelism());
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_TO_SPACE_OVERFLOW), "Trigger not parsed correctly.");
+        assertEquals((long) 206156,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(2468 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1695 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3072 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(771214,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(151,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(14,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(77,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(215,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -363,37 +326,34 @@ public class TestG1YoungPauseEvent {
         String logLine = "2018-09-20T14:57:22.095+0300: 6,350: [GC pause (young), 0,1275790 secs]"
                 + "[Eden: 306,0M(306,0M)->0,0B(266,0M) Survivors: 0,0B->40,0M Heap: 306,0M(6144,0M)->57,7M(6144,0M)] "
                 + "[Times: user=0,25 sys=0,05, real=0,12 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6350, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(306 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(59085), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(6144 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 127579, event.getDuration());
-        assertEquals("User time not parsed correctly.", 25, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 5, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 12, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 250, event.getParallelism());
+        assertEquals((long) 6350,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(306 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(59085),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(6144 * 1024),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(127579,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(25,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(5,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(12,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(250,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedNoSpaceAfterYoung() {
         String logLine = "2018-12-07T11:26:56.282-0500: 0.314: [GC pause (G1 Evacuation Pause) "
                 + "(young)3589K->2581K(6144K), 0.0063282 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                G1YoungPauseEvent.match(logLine));
+        assertTrue(G1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
         G1YoungPauseEvent event = new G1YoungPauseEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 314, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(3589), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2581), event.getCombinedOccupancyEnd());
-        assertEquals("Combined available size not parsed correctly.", kilobytes(6144), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 6328, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 314,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(3589),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(2581),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(6144),event.getCombinedSpace(),"Combined available size not parsed correctly.");
+        assertEquals(6328,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     /**
@@ -407,13 +367,10 @@ public class TestG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -427,12 +384,9 @@ public class TestG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT));
-        assertTrue(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcInfoEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcInfoEvent.java
@@ -28,201 +28,201 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestGcInfoEvent {
+class TestGcInfoEvent {
 
     @Test
-    public void testUnifiedHumongousObjectThreshold() {
+    void testUnifiedHumongousObjectThreshold() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMaxTlabSize() {
+    void testUnifiedMaxTlabSize() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Max TLAB size: 512K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedGcThreads() {
+    void testUnifiedGcThreads() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] GC threads: 4 parallel, 4 concurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedGcThreadsInfo() {
+    void testUnifiedGcThreadsInfo() {
         String logLine = "[0.006s][info][gc,init] GC threads: 2 parallel, 1 concurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedReferenceProcessing() {
+    void testUnifiedReferenceProcessing() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Reference processing: parallel";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedReferenceProcessingInfo() {
+    void testUnifiedReferenceProcessingInfo() {
         String logLine = "[0.006s][info][gc,init] Reference processing: parallel";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testJdk8HeuristicsExplicitGcInvokesConcurrent() {
+    void testJdk8HeuristicsExplicitGcInvokesConcurrent() {
         String logLine = "Heuristics ergonomically sets -XX:+ExplicitGCInvokesConcurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedHeuristicsExplicitGcInvokesConcurrent() {
+    void testUnifiedHeuristicsExplicitGcInvokesConcurrent() {
         String logLine = "[0.006s][info][gc     ] Heuristics ergonomically sets -XX:+ExplicitGCInvokesConcurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testJdk8HeuristicsShenandoahImplicitGcInvokesConcurrent() {
+    void testJdk8HeuristicsShenandoahImplicitGcInvokesConcurrent() {
         String logLine = "Heuristics ergonomically sets -XX:+ShenandoahImplicitGCInvokesConcurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedHeuristicsShenandoahImplicitGcInvokesConcurrent() {
+    void testUnifiedHeuristicsShenandoahImplicitGcInvokesConcurrent() {
         String logLine = "[0.006s][info][gc     ] Heuristics ergonomically sets "
                 + "-XX:+ShenandoahImplicitGCInvokesConcurrent";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testNonUnifiedShanandoahHeuristics() {
+    void testNonUnifiedShanandoahHeuristics() {
         String logLine = "Shenandoah heuristics: Adaptive";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedShanandoahHeuristics() {
+    void testUnifiedShanandoahHeuristics() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Shenandoah heuristics: adaptive";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedShanandoahHeuristicsInfo() {
+    void testUnifiedShanandoahHeuristicsInfo() {
         String logLine = "[0.006s][info][gc,init] Shenandoah heuristics: adaptive";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedInitializeShenandoahHeap() {
+    void testUnifiedInitializeShenandoahHeap() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Initialize Shenandoah heap with initial size "
                 + "1366294528 bytes";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedInitializeShenandoahHeapInfo() {
+    void testUnifiedInitializeShenandoahHeapInfo() {
         String logLine = "[0.007s][info][gc,init] Initialize Shenandoah heap: 32768K initial, 32768K min, 65536K max";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedPacerForIdle() {
+    void testUnifiedPacerForIdle() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Pacer for Idle. Initial: 26M, Alloc Tax Rate: 1.0x";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedPacerForIdleInfo() {
+    void testUnifiedPacerForIdleInfo() {
         String logLine = "[0.007s][info][gc,ergo] Pacer for Idle. Initial: 1310K, Alloc Tax Rate: 1.0x";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedSafepointingMechanism() {
+    void testUnifiedSafepointingMechanism() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Safepointing mechanism: global-page poll";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedSafepointingMechanismInfo() {
+    void testUnifiedSafepointingMechanismInfo() {
         String logLine = "[0.007s][info][gc,init] Safepointing mechanism: global-page poll";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testNonUnifiedFree() {
+    void testNonUnifiedFree() {
         String logLine = "Free: 12838K, Max: 256K regular, 10752K humongous, Frag: 7% external, 12% internal; "
                 + "Reserve: 6656K, Max: 256K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedFree() {
+    void testUnifiedFree() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Free: 912M (1824 regions), Max regular: 512K, Max "
                 + "humongous: 933376K, External frag: 1%, Internal frag: 0%";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedEvacuationReserve() {
+    void testUnifiedEvacuationReserve() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Evacuation Reserve: 65M (131 regions), Max regular: "
                 + "512K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedRegions() {
+    void testUnifiedRegions() {
         String logLine = "[0.006s][info][gc,init] Regions: 256 x 256K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedHumongous() {
+    void testUnifiedHumongous() {
         String logLine = "[0.006s][info][gc,init] Humongous object threshold: 256K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMaxTlab() {
+    void testUnifiedMaxTlab() {
         String logLine = "[0.006s][info][gc,init] Max TLAB size: 256K";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
         assertEquals(JdkUtil.LogEventType.GC_INFO,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.GC_INFO + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof GcInfoEvent, JdkUtil.LogEventType.GC_INFO.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.GC_INFO), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.GC_INFO);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testShenandoahGcMode() {
+    void testShenandoahGcMode() {
         String logLine = "Shenandoah GC mode: Snapshot-At-The-Beginning (SATB)";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
-    public void testReferenceProcessing() {
+    void testReferenceProcessing() {
         String logLine = "Reference processing: parallel discovery, parallel processing";
         assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcInfoEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcInfoEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,229 +33,197 @@ public class TestGcInfoEvent {
     @Test
     public void testUnifiedHumongousObjectThreshold() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedMaxTlabSize() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Max TLAB size: 512K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedGcThreads() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] GC threads: 4 parallel, 4 concurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedGcThreadsInfo() {
         String logLine = "[0.006s][info][gc,init] GC threads: 2 parallel, 1 concurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedReferenceProcessing() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Reference processing: parallel";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedReferenceProcessingInfo() {
         String logLine = "[0.006s][info][gc,init] Reference processing: parallel";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testJdk8HeuristicsExplicitGcInvokesConcurrent() {
         String logLine = "Heuristics ergonomically sets -XX:+ExplicitGCInvokesConcurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedHeuristicsExplicitGcInvokesConcurrent() {
         String logLine = "[0.006s][info][gc     ] Heuristics ergonomically sets -XX:+ExplicitGCInvokesConcurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testJdk8HeuristicsShenandoahImplicitGcInvokesConcurrent() {
         String logLine = "Heuristics ergonomically sets -XX:+ShenandoahImplicitGCInvokesConcurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedHeuristicsShenandoahImplicitGcInvokesConcurrent() {
         String logLine = "[0.006s][info][gc     ] Heuristics ergonomically sets "
                 + "-XX:+ShenandoahImplicitGCInvokesConcurrent";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testNonUnifiedShanandoahHeuristics() {
         String logLine = "Shenandoah heuristics: Adaptive";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedShanandoahHeuristics() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Shenandoah heuristics: adaptive";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedShanandoahHeuristicsInfo() {
         String logLine = "[0.006s][info][gc,init] Shenandoah heuristics: adaptive";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedInitializeShenandoahHeap() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Initialize Shenandoah heap with initial size "
                 + "1366294528 bytes";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedInitializeShenandoahHeapInfo() {
         String logLine = "[0.007s][info][gc,init] Initialize Shenandoah heap: 32768K initial, 32768K min, 65536K max";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedPacerForIdle() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Pacer for Idle. Initial: 26M, Alloc Tax Rate: 1.0x";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedPacerForIdleInfo() {
         String logLine = "[0.007s][info][gc,ergo] Pacer for Idle. Initial: 1310K, Alloc Tax Rate: 1.0x";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedSafepointingMechanism() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Safepointing mechanism: global-page poll";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedSafepointingMechanismInfo() {
         String logLine = "[0.007s][info][gc,init] Safepointing mechanism: global-page poll";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testNonUnifiedFree() {
         String logLine = "Free: 12838K, Max: 256K regular, 10752K humongous, Frag: 7% external, 12% internal; "
                 + "Reserve: 6656K, Max: 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedFree() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Free: 912M (1824 regions), Max regular: 512K, Max "
                 + "humongous: 933376K, External frag: 1%, Internal frag: 0%";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedEvacuationReserve() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Evacuation Reserve: 65M (131 regions), Max regular: "
                 + "512K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedRegions() {
         String logLine = "[0.006s][info][gc,init] Regions: 256 x 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedHumongous() {
         String logLine = "[0.006s][info][gc,init] Humongous object threshold: 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testUnifiedMaxTlab() {
         String logLine = "[0.006s][info][gc,init] Max TLAB size: 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
-        assertEquals(JdkUtil.LogEventType.GC_INFO + "not identified.", JdkUtil.LogEventType.GC_INFO,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.GC_INFO,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.GC_INFO + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
-        assertTrue(JdkUtil.LogEventType.GC_INFO.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof GcInfoEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof GcInfoEvent, JdkUtil.LogEventType.GC_INFO.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Humongous object threshold: 512K";
-        assertFalse(JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.GC_INFO));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.GC_INFO), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.GC_INFO);
-        assertFalse(JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.GC_INFO.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testShenandoahGcMode() {
         String logLine = "Shenandoah GC mode: Snapshot-At-The-Beginning (SATB)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 
     @Test
     public void testReferenceProcessing() {
         String logLine = "Reference processing: parallel discovery, parallel processing";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".",
-                GcInfoEvent.match(logLine));
+        assertTrue(GcInfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_INFO.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcLockerEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcLockerEvent.java
@@ -12,13 +12,13 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.domain.LogEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -29,38 +29,33 @@ public class TestGcLockerEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
-        assertFalse(JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
-        assertFalse(JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testLine() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_LOCKER.toString() + ".",
-                GcLockerEvent.match(logLine));
+        assertTrue(GcLockerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_LOCKER.toString() + ".");
         GcLockerEvent event = new GcLockerEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 0, event.getTimestamp());
+        assertEquals((long) 0,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         LogEvent event = JdkUtil.parseLogLine(logLine);
-        assertTrue(JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.",
-                event instanceof GcLockerEvent);
+        assertTrue(event instanceof GcLockerEvent, JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.");
     }
 
     @Test
     public void testIdentifyEventType() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
-        assertTrue(JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.",
-                JdkUtil.identifyEventType(logLine) == JdkUtil.LogEventType.GC_LOCKER);
+        assertTrue(JdkUtil.identifyEventType(logLine) == JdkUtil.LogEventType.GC_LOCKER, JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcLockerEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcLockerEvent.java
@@ -24,22 +24,22 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestGcLockerEvent {
+class TestGcLockerEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_LOCKER.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         assertTrue(GcLockerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_LOCKER.toString() + ".");
         GcLockerEvent event = new GcLockerEvent(logLine);
@@ -47,14 +47,14 @@ public class TestGcLockerEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         LogEvent event = JdkUtil.parseLogLine(logLine);
         assertTrue(event instanceof GcLockerEvent, JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.");
     }
 
     @Test
-    public void testIdentifyEventType() {
+    void testIdentifyEventType() {
         String logLine = "GC locker: Trying a full collection because scavenge failed";
         assertTrue(JdkUtil.identifyEventType(logLine) == JdkUtil.LogEventType.GC_LOCKER, JdkUtil.LogEventType.GC_LOCKER.toString() + " event not identified.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcOverheadLimitEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcOverheadLimitEvent.java
@@ -22,28 +22,28 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestGcOverheadLimitEvent {
+class TestGcOverheadLimitEvent {
 
     @Test
-    public void testLineWouldExceed() {
+    void testLineWouldExceed() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
         assertTrue(GcOverheadLimitEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
     }
 
     @Test
-    public void testLineIsExceeding() {
+    void testLineIsExceeding() {
         String logLine = "GC time is exceeding GCTimeLimit of 98%";
         assertTrue(GcOverheadLimitEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as reportable.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcOverheadLimitEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestGcOverheadLimitEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,28 +27,24 @@ public class TestGcOverheadLimitEvent {
     @Test
     public void testLineWouldExceed() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".",
-                GcOverheadLimitEvent.match(logLine));
+        assertTrue(GcOverheadLimitEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
     }
 
     @Test
     public void testLineIsExceeding() {
         String logLine = "GC time is exceeding GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".",
-                GcOverheadLimitEvent.match(logLine));
+        assertTrue(GcOverheadLimitEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
-        assertFalse(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "GC time would exceed GCTimeLimit of 98%";
-        assertFalse(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + " incorrectly indentified as reportable.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderCommandLineFlagsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderCommandLineFlagsEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -34,8 +34,7 @@ public class TestHeaderCommandLineFlagsEvent {
                 + "-XX:OldPLABSize=16 -XX:PermSize=402653184 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails "
                 + "-XX:+PrintGCTimeStamps -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+UseGCLogFileRotation "
                 + "-XX:+UseParNewGC";
-        assertFalse(JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
@@ -47,8 +46,7 @@ public class TestHeaderCommandLineFlagsEvent {
                 + "-XX:OldPLABSize=16 -XX:PermSize=402653184 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails "
                 + "-XX:+PrintGCTimeStamps -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+UseGCLogFileRotation "
                 + "-XX:+UseParNewGC";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + ".",
-                HeaderCommandLineFlagsEvent.match(logLine));
+        assertTrue(HeaderCommandLineFlagsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + ".");
         HeaderCommandLineFlagsEvent event = new HeaderCommandLineFlagsEvent(logLine);
         String jvmOptions = "-XX:+CMSClassUnloadingEnabled -XX:CMSInitiatingOccupancyFraction=75 "
                 + "-XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses "
@@ -57,7 +55,7 @@ public class TestHeaderCommandLineFlagsEvent {
                 + "-XX:OldPLABSize=16 -XX:PermSize=402653184 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails "
                 + "-XX:+PrintGCTimeStamps -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+UseGCLogFileRotation "
                 + "-XX:+UseParNewGC";
-        assertEquals("Flags not parsed correctly.", jvmOptions, event.getJvmOptions());
+        assertEquals(jvmOptions,event.getJvmOptions(),"Flags not parsed correctly.");
     }
 
     @Test
@@ -78,8 +76,7 @@ public class TestHeaderCommandLineFlagsEvent {
                 + "-DconfigurationEngine.configDir=/opt/odigeo/properties/ "
                 + "-Djavax.net.ssl.keyStore=/opt/edreams/keys/java/keyStore "
                 + "-Djavax.net.ssl.keyStorePassword=changeit";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + ".",
-                HeaderCommandLineFlagsEvent.match(logLine));
+        assertTrue(HeaderCommandLineFlagsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + ".");
         HeaderCommandLineFlagsEvent event = new HeaderCommandLineFlagsEvent(logLine);
         String jvmOptions = "-Dprogram.name=run.sh -d64 -server -Xms10000m -Xmx10000m -ss512k "
                 + "-XX:PermSize=512m -XX:MaxPermSize=512m -XX:NewSize=3000m -XX:MaxNewSize=3000m -XX:SurvivorRatio=6 "
@@ -97,6 +94,6 @@ public class TestHeaderCommandLineFlagsEvent {
                 + "-DconfigurationEngine.configDir=/opt/odigeo/properties/ "
                 + "-Djavax.net.ssl.keyStore=/opt/edreams/keys/java/keyStore "
                 + "-Djavax.net.ssl.keyStorePassword=changeit";
-        assertEquals("Flags not parsed correctly.", jvmOptions, event.getJvmOptions());
+        assertEquals(jvmOptions,event.getJvmOptions(),"Flags not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderCommandLineFlagsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderCommandLineFlagsEvent.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeaderCommandLineFlagsEvent {
+class TestHeaderCommandLineFlagsEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "CommandLine flags: -XX:+CMSClassUnloadingEnabled -XX:CMSInitiatingOccupancyFraction=75 "
                 + "-XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses "
                 + "-XX:GCLogFileSize=8388608 -XX:InitialHeapSize=13958643712 -XX:MaxHeapSize=13958643712 "
@@ -38,7 +38,7 @@ public class TestHeaderCommandLineFlagsEvent {
     }
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "CommandLine flags: -XX:+CMSClassUnloadingEnabled -XX:CMSInitiatingOccupancyFraction=75 "
                 + "-XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses "
                 + "-XX:GCLogFileSize=8388608 -XX:InitialHeapSize=13958643712 -XX:MaxHeapSize=13958643712 "
@@ -59,7 +59,7 @@ public class TestHeaderCommandLineFlagsEvent {
     }
 
     @Test
-    public void testJBossHeader() {
+    void testJBossHeader() {
         String logLine = "  JAVA_OPTS: -Dprogram.name=run.sh -d64 -server -Xms10000m -Xmx10000m -ss512k "
                 + "-XX:PermSize=512m -XX:MaxPermSize=512m -XX:NewSize=3000m -XX:MaxNewSize=3000m -XX:SurvivorRatio=6 "
                 + "-XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=5 -verbose:gc -XX:+PrintGC -XX:+PrintGCDetails "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderMemoryEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderMemoryEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,35 +28,32 @@ public class TestHeaderMemoryEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "Memory: 4k page, physical 65806300k(58281908k free), swap 16777212k(16777212k free)";
-        assertFalse(JdkUtil.LogEventType.HEADER_MEMORY.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEADER_MEMORY.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testLine() {
         String logLine = "Memory: 4k page, physical 65806300k(58281908k free), swap 16777212k(16777212k free)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".",
-                HeaderMemoryEvent.match(logLine));
+        assertTrue(HeaderMemoryEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".");
         HeaderMemoryEvent event = new HeaderMemoryEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 0, event.getTimestamp());
-        assertEquals("Physical memory not parsed correctly.", 65806300, event.getPhysicalMemory());
-        assertEquals("Physical memory free not parsed correctly.", 58281908, event.getPhysicalMemoryFree());
-        assertEquals("Swap not parsed correctly.", 16777212, event.getSwap());
-        assertEquals("Swap free not parsed correctly.", 16777212, event.getSwapFree());
+        assertEquals((long) 0,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(65806300,event.getPhysicalMemory(),"Physical memory not parsed correctly.");
+        assertEquals(58281908,event.getPhysicalMemoryFree(),"Physical memory free not parsed correctly.");
+        assertEquals(16777212,event.getSwap(),"Swap not parsed correctly.");
+        assertEquals(16777212,event.getSwapFree(),"Swap free not parsed correctly.");
 
     }
 
     @Test
     public void testLineMemoryPage8kNoSwapData() {
         String logLine = "Memory: 8k page, physical 535035904k(398522432k free)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".",
-                HeaderMemoryEvent.match(logLine));
+        assertTrue(HeaderMemoryEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".");
         HeaderMemoryEvent event = new HeaderMemoryEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 0, event.getTimestamp());
-        assertEquals("Physical memory not parsed correctly.", 535035904, event.getPhysicalMemory());
-        assertEquals("Physical memory free not parsed correctly.", 398522432, event.getPhysicalMemoryFree());
-        assertEquals("Swap not parsed correctly.", 0, event.getSwap());
-        assertEquals("Swap free not parsed correctly.", 0, event.getSwapFree());
+        assertEquals((long) 0,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(535035904,event.getPhysicalMemory(),"Physical memory not parsed correctly.");
+        assertEquals(398522432,event.getPhysicalMemoryFree(),"Physical memory free not parsed correctly.");
+        assertEquals(0,event.getSwap(),"Swap not parsed correctly.");
+        assertEquals(0,event.getSwapFree(),"Swap free not parsed correctly.");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderMemoryEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderMemoryEvent.java
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeaderMemoryEvent {
+class TestHeaderMemoryEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Memory: 4k page, physical 65806300k(58281908k free), swap 16777212k(16777212k free)";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEADER_MEMORY.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "Memory: 4k page, physical 65806300k(58281908k free), swap 16777212k(16777212k free)";
         assertTrue(HeaderMemoryEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".");
         HeaderMemoryEvent event = new HeaderMemoryEvent(logLine);
@@ -45,7 +45,7 @@ public class TestHeaderMemoryEvent {
     }
 
     @Test
-    public void testLineMemoryPage8kNoSwapData() {
+    void testLineMemoryPage8kNoSwapData() {
         String logLine = "Memory: 8k page, physical 535035904k(398522432k free)";
         assertTrue(HeaderMemoryEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_MEMORY.toString() + ".");
         HeaderMemoryEvent event = new HeaderMemoryEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderVersionEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderVersionEvent.java
@@ -22,24 +22,24 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeaderVersionEvent {
+class TestHeaderVersionEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "Java HotSpot(TM) 64-Bit Server VM (24.85-b08) for linux-amd64 JRE (1.7.0_85-b34), built on "
                 + "Sep 29 2015 08:44:21 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         assertTrue(HeaderVersionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".");
     }
 
     @Test
-    public void testLineOpenJdk() {
+    void testLineOpenJdk() {
         String logLine = "OpenJDK 64-Bit Server VM (24.95-b01) for linux-amd64 JRE (1.7.0_95-b00), built on "
                 + "Jan 18 2016 21:57:50 by \"mockbuild\" with gcc 4.8.5 20150623 (Red Hat 4.8.5-4)";
         assertTrue(HeaderVersionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Java HotSpot(TM) 64-Bit Server VM (24.85-b08) for linux-amd64 JRE (1.7.0_85-b34), built on "
                 + "Sep 29 2015 08:44:21 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEADER_VERSION.toString() + " incorrectly indentified as blocking.");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderVersionEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeaderVersionEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,23 +28,20 @@ public class TestHeaderVersionEvent {
     public void testLine() {
         String logLine = "Java HotSpot(TM) 64-Bit Server VM (24.85-b08) for linux-amd64 JRE (1.7.0_85-b34), built on "
                 + "Sep 29 2015 08:44:21 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".",
-                HeaderVersionEvent.match(logLine));
+        assertTrue(HeaderVersionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".");
     }
 
     @Test
     public void testLineOpenJdk() {
         String logLine = "OpenJDK 64-Bit Server VM (24.95-b01) for linux-amd64 JRE (1.7.0_95-b00), built on "
                 + "Jan 18 2016 21:57:50 by \"mockbuild\" with gcc 4.8.5 20150623 (Red Hat 4.8.5-4)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".",
-                HeaderVersionEvent.match(logLine));
+        assertTrue(HeaderVersionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEADER_VERSION.toString() + ".");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "Java HotSpot(TM) 64-Bit Server VM (24.85-b08) for linux-amd64 JRE (1.7.0_85-b34), built on "
                 + "Sep 29 2015 08:44:21 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
-        assertFalse(JdkUtil.LogEventType.HEADER_VERSION.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEADER_VERSION.toString() + " incorrectly indentified as blocking.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeapAtGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeapAtGcEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,52 +27,45 @@ public class TestHeapAtGcEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "{Heap before gc invocations=1:";
-        assertFalse(JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testNotReportable() {
         String logLine = "{Heap before gc invocations=1:";
-        assertFalse(JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testHeapBeforeLowerCaseGcLine() {
         String logLine = "{Heap before gc invocations=1:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testHeapBeforeUpperCaseGcFullLine() {
         String logLine = "{Heap before GC invocations=261 (full 10):";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testHeapAfterLowerCaseGcLine() {
         String logLine = "Heap after gc invocations=362:";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testPsYoungGenLine() {
         String logLine = " PSYoungGen      total 434880K, used 89473K [0x00002b3998b80000, "
                 + "0x00002b39b70d0000, 0x00002b39b70d0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testEdenSpaceLine() {
         String logLine = "  eden space 372800K, 24% used [0x00002b3998b80000,"
                 + "0x00002b399e2e0660,0x00002b39af790000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     /**
@@ -82,8 +75,7 @@ public class TestHeapAtGcEvent {
     public void testEdenSpaceLineOneSpace() {
         String logLine = "  eden space 372800K, 24% used [0x00002b3998b80000,"
                 + "0x00002b399e2e0660,0x00002b39af790000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     /**
@@ -93,196 +85,170 @@ public class TestHeapAtGcEvent {
     public void testEdenSpaceLineTwoSpaces() {
         String logLine = "  eden space 785024K,  39% used [0x00002aabdaab0000, "
                 + "0x00002aabed98be48, 0x00002aac0a950000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testFromSpaceLine() {
         String logLine = "  from space 62080K, 0% used [0x00002b39b3430000," + "0x00002b39b3430000,0x00002b39b70d0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testToSpaceLine() {
         String logLine = "  to   space 62080K, 0% used [0x00002b39af790000," + "0x00002b39af790000,0x00002b39b3430000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testPsOldGenLine() {
         String logLine = " PSOldGen        total 993984K, used 0K [0x00002b395c0d0000, "
                 + "0x00002b3998b80000, 0x00002b3998b80000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testParOldGenLine() {
         String logLine = " ParOldGen       total 1572864K, used 1380722K [0x00002b5dd6bd0000, "
                 + "0x00002b5e36bd0000, 0x00002b5e36bd0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testObjectSpaceLine() {
         String logLine = "  object space 993984K, 0% used [0x00002b395c0d0000,"
                 + "0x00002b395c0d0000,0x00002b3998b80000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testPsPermGenLine() {
         String logLine = " PSPermGen       total 524288K, used 13076K [0x00002b393c0d0000, "
                 + "0x00002b395c0d0000, 0x00002b395c0d0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testBraceLine() {
         String logLine = "}";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testParNewGenerationLine() {
         String logLine = " par new generation   total 785728K, used 310127K [0x00002aabdaab0000, "
                 + "0x00002aac0aab0000, 0x00002aac0aab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testCmsGenerationLine() {
         String logLine = " concurrent mark-sweep generation total 3407872K, used 1640998K "
                 + "[0x00002aac0aab0000, 0x00002aacdaab0000, 0x00002aacdaab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testCmsPermGenLine() {
         String logLine = " concurrent-mark-sweep perm gen total 786432K, used 507386K "
                 + "[0x00002aacdaab0000, 0x00002aad0aab0000, 0x00002aad0aab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testHeapBeforePrintGCDateStampsLine() {
         String logLine = "{Heap before GC invocations=0 (full 0):";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testHeapAfterPrintGCDateStampsLine() {
         String logLine = "Heap after GC invocations=1 (full 0):";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testClassDataSharingLine() {
         String logLine = "No shared spaces configured.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testTenuredGenerationLine() {
         String logLine = " tenured generation   total 704512K, used 17793K [0x00002aab2fab0000, "
                 + "0x00002aab5aab0000, 0x00002aab7aab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testCompactingPermGenLine() {
         String logLine = " compacting perm gen  total 262144K, used 65340K [0x00002aab7aab0000, "
                 + "0x00002aab8aab0000, 0x00002aab8aab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testTheSpaceLine() {
         String logLine = "   the space 704512K,   2% used [0x00002aab2fab0000, 0x00002aab30c107e8, "
                 + "0x00002aab30c10800, 0x00002aab5aab0000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testG1HeapLine() {
         String logLine = "Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testG1GarbageFirstHeapLine() {
         String logLine = " garbage-first heap   total 60416K, used 6685K [0x00007f9128c00000, 0x00007f912c700000, "
                 + "0x00007f9162e00000";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testG1RegionSizeLine() {
         String logLine = "  region size 1024K, 6 young (6144K), 1 survivors (1024K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testG1TheSpaceLine() {
         String logLine = "  the space 20480K,  35% used [0x00007f9162e00000, 0x00007f9163526df0, 0x00007f9163526e00, "
                 + "0x00007f9164200000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testJDK8MetaspaceLine() {
         String logLine = " Metaspace       used 73096K, capacity 79546K, committed 79732K, reserved 1118208K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testMetaspaceLineWithDatestamp() {
         String logLine = "2017-03-21T15:06:10.427+1100:  Metaspace       used 625128K, capacity 943957K, "
                 + "committed 951712K, reserved 1943552K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testJDK8ClassSpaceLine() {
         String logLine = "  class space    used 8643K, capacity 10553K, committed 10632K, reserved 1048576K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testClassSpaceLineWithTimestamp() {
         String logLine = "425018.340:   class space    used 37442K, capacity 57351K, committed 58624K, reserved "
                 + "1048576K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
     public void testDefNewGeneration() {
         String logLine = " def new generation   total 39680K, used 11177K [0x04800000, 0x07300000, 0x19d50000)K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".",
-                HeapAtGcEvent.match(logLine));
+        assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeapAtGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestHeapAtGcEvent.java
@@ -22,47 +22,47 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeapAtGcEvent {
+class TestHeapAtGcEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "{Heap before gc invocations=1:";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testNotReportable() {
+    void testNotReportable() {
         String logLine = "{Heap before gc invocations=1:";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_AT_GC.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testHeapBeforeLowerCaseGcLine() {
+    void testHeapBeforeLowerCaseGcLine() {
         String logLine = "{Heap before gc invocations=1:";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testHeapBeforeUpperCaseGcFullLine() {
+    void testHeapBeforeUpperCaseGcFullLine() {
         String logLine = "{Heap before GC invocations=261 (full 10):";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testHeapAfterLowerCaseGcLine() {
+    void testHeapAfterLowerCaseGcLine() {
         String logLine = "Heap after gc invocations=362:";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testPsYoungGenLine() {
+    void testPsYoungGenLine() {
         String logLine = " PSYoungGen      total 434880K, used 89473K [0x00002b3998b80000, "
                 + "0x00002b39b70d0000, 0x00002b39b70d0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testEdenSpaceLine() {
+    void testEdenSpaceLine() {
         String logLine = "  eden space 372800K, 24% used [0x00002b3998b80000,"
                 + "0x00002b399e2e0660,0x00002b39af790000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
@@ -72,7 +72,7 @@ public class TestHeapAtGcEvent {
      * One space before percent.
      */
     @Test
-    public void testEdenSpaceLineOneSpace() {
+    void testEdenSpaceLineOneSpace() {
         String logLine = "  eden space 372800K, 24% used [0x00002b3998b80000,"
                 + "0x00002b399e2e0660,0x00002b39af790000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
@@ -82,172 +82,172 @@ public class TestHeapAtGcEvent {
      * Two spaces before percent.
      */
     @Test
-    public void testEdenSpaceLineTwoSpaces() {
+    void testEdenSpaceLineTwoSpaces() {
         String logLine = "  eden space 785024K,  39% used [0x00002aabdaab0000, "
                 + "0x00002aabed98be48, 0x00002aac0a950000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testFromSpaceLine() {
+    void testFromSpaceLine() {
         String logLine = "  from space 62080K, 0% used [0x00002b39b3430000," + "0x00002b39b3430000,0x00002b39b70d0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testToSpaceLine() {
+    void testToSpaceLine() {
         String logLine = "  to   space 62080K, 0% used [0x00002b39af790000," + "0x00002b39af790000,0x00002b39b3430000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testPsOldGenLine() {
+    void testPsOldGenLine() {
         String logLine = " PSOldGen        total 993984K, used 0K [0x00002b395c0d0000, "
                 + "0x00002b3998b80000, 0x00002b3998b80000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testParOldGenLine() {
+    void testParOldGenLine() {
         String logLine = " ParOldGen       total 1572864K, used 1380722K [0x00002b5dd6bd0000, "
                 + "0x00002b5e36bd0000, 0x00002b5e36bd0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testObjectSpaceLine() {
+    void testObjectSpaceLine() {
         String logLine = "  object space 993984K, 0% used [0x00002b395c0d0000,"
                 + "0x00002b395c0d0000,0x00002b3998b80000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testPsPermGenLine() {
+    void testPsPermGenLine() {
         String logLine = " PSPermGen       total 524288K, used 13076K [0x00002b393c0d0000, "
                 + "0x00002b395c0d0000, 0x00002b395c0d0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testBraceLine() {
+    void testBraceLine() {
         String logLine = "}";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testParNewGenerationLine() {
+    void testParNewGenerationLine() {
         String logLine = " par new generation   total 785728K, used 310127K [0x00002aabdaab0000, "
                 + "0x00002aac0aab0000, 0x00002aac0aab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testCmsGenerationLine() {
+    void testCmsGenerationLine() {
         String logLine = " concurrent mark-sweep generation total 3407872K, used 1640998K "
                 + "[0x00002aac0aab0000, 0x00002aacdaab0000, 0x00002aacdaab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testCmsPermGenLine() {
+    void testCmsPermGenLine() {
         String logLine = " concurrent-mark-sweep perm gen total 786432K, used 507386K "
                 + "[0x00002aacdaab0000, 0x00002aad0aab0000, 0x00002aad0aab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testHeapBeforePrintGCDateStampsLine() {
+    void testHeapBeforePrintGCDateStampsLine() {
         String logLine = "{Heap before GC invocations=0 (full 0):";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testHeapAfterPrintGCDateStampsLine() {
+    void testHeapAfterPrintGCDateStampsLine() {
         String logLine = "Heap after GC invocations=1 (full 0):";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testClassDataSharingLine() {
+    void testClassDataSharingLine() {
         String logLine = "No shared spaces configured.";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testTenuredGenerationLine() {
+    void testTenuredGenerationLine() {
         String logLine = " tenured generation   total 704512K, used 17793K [0x00002aab2fab0000, "
                 + "0x00002aab5aab0000, 0x00002aab7aab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testCompactingPermGenLine() {
+    void testCompactingPermGenLine() {
         String logLine = " compacting perm gen  total 262144K, used 65340K [0x00002aab7aab0000, "
                 + "0x00002aab8aab0000, 0x00002aab8aab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testTheSpaceLine() {
+    void testTheSpaceLine() {
         String logLine = "   the space 704512K,   2% used [0x00002aab2fab0000, 0x00002aab30c107e8, "
                 + "0x00002aab30c10800, 0x00002aab5aab0000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testG1HeapLine() {
+    void testG1HeapLine() {
         String logLine = "Heap";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testG1GarbageFirstHeapLine() {
+    void testG1GarbageFirstHeapLine() {
         String logLine = " garbage-first heap   total 60416K, used 6685K [0x00007f9128c00000, 0x00007f912c700000, "
                 + "0x00007f9162e00000";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testG1RegionSizeLine() {
+    void testG1RegionSizeLine() {
         String logLine = "  region size 1024K, 6 young (6144K), 1 survivors (1024K)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testG1TheSpaceLine() {
+    void testG1TheSpaceLine() {
         String logLine = "  the space 20480K,  35% used [0x00007f9162e00000, 0x00007f9163526df0, 0x00007f9163526e00, "
                 + "0x00007f9164200000)";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testJDK8MetaspaceLine() {
+    void testJDK8MetaspaceLine() {
         String logLine = " Metaspace       used 73096K, capacity 79546K, committed 79732K, reserved 1118208K";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testMetaspaceLineWithDatestamp() {
+    void testMetaspaceLineWithDatestamp() {
         String logLine = "2017-03-21T15:06:10.427+1100:  Metaspace       used 625128K, capacity 943957K, "
                 + "committed 951712K, reserved 1943552K";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testJDK8ClassSpaceLine() {
+    void testJDK8ClassSpaceLine() {
         String logLine = "  class space    used 8643K, capacity 10553K, committed 10632K, reserved 1048576K";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testClassSpaceLineWithTimestamp() {
+    void testClassSpaceLineWithTimestamp() {
         String logLine = "425018.340:   class space    used 37442K, capacity 57351K, committed 58624K, reserved "
                 + "1048576K";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }
 
     @Test
-    public void testDefNewGeneration() {
+    void testDefNewGeneration() {
         String logLine = " def new generation   total 39680K, used 11177K [0x04800000, 0x07300000, 0x19d50000)K";
         assertTrue(HeapAtGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_AT_GC.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestLogFileEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestLogFileEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -24,7 +24,7 @@ import org.eclipselabs.garbagecat.service.GcManager;
 import org.eclipselabs.garbagecat.util.Constants;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -35,31 +35,27 @@ public class TestLogFileEvent {
     public void testNotBlocking() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
-        assertFalse(JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testNotReportable() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
-        assertFalse(JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testLogLineCreated() {
         String logLine = "2016-10-18 01:50:54 GC log file created /path/to/gc.log";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".",
-                LogFileEvent.match(logLine));
+        assertTrue(LogFileEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".");
     }
 
     @Test
     public void testLogLineRotations() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".",
-                LogFileEvent.match(logLine));
+        assertTrue(LogFileEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".");
     }
 
     /**
@@ -72,6 +68,6 @@ public class TestLogFileEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun.getEventTypes().size());
+        assertEquals(0,jvmRun.getEventTypes().size(),"Event type count not correct.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestLogFileEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestLogFileEvent.java
@@ -29,30 +29,30 @@ import org.junit.jupiter.api.Test;
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestLogFileEvent {
+class TestLogFileEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testNotReportable() {
+    void testNotReportable() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.LOG_FILE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testLogLineCreated() {
+    void testLogLineCreated() {
         String logLine = "2016-10-18 01:50:54 GC log file created /path/to/gc.log";
         assertTrue(LogFileEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".");
     }
 
     @Test
-    public void testLogLineRotations() {
+    void testLogLineRotations() {
         String logLine = "2016-03-24 10:28:33 GC log file has reached the maximum size. "
                 + "Saved as /path/to/gc.log.0";
         assertTrue(LogFileEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.LOG_FILE.toString() + ".");
@@ -62,7 +62,7 @@ public class TestLogFileEvent {
      * Test preparsing throws event away.
      */
     @Test
-    public void testPreparsing() {
+    void testPreparsing() {
         File testFile = TestUtil.getFile("dataset88.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParNewEvent.java
@@ -35,17 +35,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestParNewEvent {
+class TestParNewEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "20.189: [GC 20.190: [ParNew: 86199K->8454K(91712K), 0.0375060 secs] "
                 + "89399K->11655K(907328K), 0.0387074 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PAR_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "20.189: [GC 20.190: [ParNew: 86199K->8454K(91712K), 0.0375060 secs] "
                 + "89399K->11655K(907328K), 0.0387074 secs]";
         assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
@@ -62,7 +62,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "68331.885: [GC 68331.885: [ParNew: 149120K->18211K(149120K), "
                 + "0.0458577 secs] 4057776K->3931241K(8367360K), 0.0461448 secs] "
                 + "[Times: user=0.34 sys=0.01, real=0.05 secs]";
@@ -84,7 +84,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWithIcmsDcData() {
+    void testLogLineWithIcmsDcData() {
         String logLine = "42514.965: [GC 42514.966: [ParNew: 54564K->1006K(59008K), 0.0221640 secs] "
                 + "417639K->364081K(1828480K) icms_dc=0 , 0.0225090 secs] "
                 + "[Times: user=0.05 sys=0.00, real=0.02 secs]";
@@ -106,7 +106,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "68331.885: [GC 68331.885: [ParNew: 149120K->18211K(149120K), "
                 + "0.0458577 secs] 4057776K->3931241K(8367360K), 0.0461448 secs] "
                 + "[Times: user=0.34 sys=0.01, real=0.05 secs]    ";
@@ -114,7 +114,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineHugeTimestamp() {
+    void testLogLineHugeTimestamp() {
         String logLine = "4687597.901: [GC 4687597.901: [ParNew: 342376K->16369K(368640K), "
                 + "0.0865160 secs] 1561683K->1235676K(2056192K), 0.0869060 secs]";
         ParNewEvent event = new ParNewEvent(logLine);
@@ -122,7 +122,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineAfterPreprocessing() {
+    void testLogLineAfterPreprocessing() {
         String logLine = "13.086: [GC13.086: [ParNew: 272640K->33532K(306688K), 0.0381419 secs] "
                 + "272640K->33532K(1014528K), 0.0383306 secs] " + "[Times: user=0.11 sys=0.02, real=0.04 secs]";
         ParNewEvent event = new ParNewEvent(logLine);
@@ -130,7 +130,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineJdk8WithTrigger() {
+    void testLogLineJdk8WithTrigger() {
         String logLine = "6.703: [GC (Allocation Failure) 6.703: [ParNew: 886080K->11485K(996800K), 0.0193349 secs] "
                 + "886080K->11485K(1986432K), 0.0198375 secs] [Times: user=0.09 sys=0.01, real=0.02 secs]";
         assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
@@ -152,7 +152,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineJdk8NoSpaceAfterTrigger() {
+    void testLogLineJdk8NoSpaceAfterTrigger() {
         String logLine = "1.948: [GC (Allocation Failure)1.948: [ParNew: 136576K->17023K(153600K), 0.0303800 secs] "
                 + "136576K->19515K(494976K), 0.0305360 secs] [Times: user=0.10 sys=0.01, real=0.03 secs]";
         assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
@@ -174,7 +174,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineGcLockerTrigger() {
+    void testLogLineGcLockerTrigger() {
         String logLine = "2.480: [GC (GCLocker Initiated GC) 2.480: [ParNew: 1228800K->30695K(1382400K), "
                 + "0.0395910 secs] 1228800K->30695K(8235008K), 0.0397980 secs] "
                 + "[Times: user=0.23 sys=0.01, real=0.04 secs]";
@@ -197,7 +197,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineCmsScavengeBeforeRemark() {
+    void testLogLineCmsScavengeBeforeRemark() {
         String logLine = "7236.341: [GC[YG occupancy: 1388745 K (4128768 K)]7236.341: [GC7236.341: [ParNew: "
                 + "1388745K->458752K(4128768K), 0.5246295 secs] 2977822K->2161212K(13172736K), 0.5248785 secs] "
                 + "[Times: user=0.92 sys=0.03, real=0.51 secs]";
@@ -219,7 +219,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineSystemGcTrigger() {
+    void testLogLineSystemGcTrigger() {
         String logLine = "27880.710: [GC (System.gc()) 27880.710: [ParNew: 925502K->58125K(996800K), 0.0133005 secs] "
                 + "5606646K->4742781K(8277888K), 0.0138294 secs] [Times: user=0.14 sys=0.00, real=0.02 secs]";
         assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
@@ -241,7 +241,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLinePromotionFailed() {
+    void testLogLinePromotionFailed() {
         String logLine = "393747.603: [GC393747.603: [ParNew (promotion failed): 476295K->476295K(4128768K), "
                 + "0.5193071 secs] 7385012K->7555732K(13172736K), 0.5196411 secs] "
                 + "[Times: user=0.92 sys=0.00, real=0.55 secs]";
@@ -263,7 +263,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWithDatestamp() {
+    void testLogLineWithDatestamp() {
         String logLine = "2010-04-16T12:11:18.979+0200: 84.335: [GC 84.336: [ParNew: 273152K->858K(341376K), "
                 + "0.0030008 secs] 273152K->858K(980352K), 0.0031183 secs] "
                 + "[Times: user=0.00 sys=0.00, real=0.00 secs]";
@@ -285,7 +285,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWithDatestampNoTimestamp() {
+    void testLogLineWithDatestampNoTimestamp() {
         String logLine = "2017-02-27T07:23:39.571+0100: [GC [ParNew: 2304000K->35161K(2688000K), 0.0759285 secs] "
                 + "2304000K->35161K(9856000K), 0.0760907 secs] [Times: user=0.21 sys=0.05, real=0.08 secs]";
         // Datestamp only is handled by preparsing.
@@ -293,7 +293,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineWithDoubleDatestamp() {
+    void testLogLineWithDoubleDatestamp() {
         String logLine = "2013-12-09T16:18:17.813+0000: 13.086: [GC2013-12-09T16:18:17.813+0000: 13.086: [ParNew: "
                 + "272640K->33532K(306688K), 0.0381419 secs] 272640K->33532K(1014528K), 0.0383306 secs] "
                 + "[Times: user=0.11 sys=0.02, real=0.04 secs]";
@@ -315,7 +315,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineTriggerCmsFinalRemarkJdk8() {
+    void testLogLineTriggerCmsFinalRemarkJdk8() {
         String logLine = "4.506: [GC (CMS Final Remark) [YG occupancy: 100369 K (153344 K)]"
                 + "4.506: [GC (CMS Final Remark) 4.506: [ParNew: 100369K->10116K(153344K), 0.0724021 secs] "
                 + "100369K->16685K(4177280K), 0.0724907 secs] [Times: user=0.13 sys=0.01, real=0.07 secs]";
@@ -338,7 +338,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineTriggerCmsFinalRemarkJdk8WithTimeStamps() {
+    void testLogLineTriggerCmsFinalRemarkJdk8WithTimeStamps() {
         String logLine = "2017-01-07T22:02:15.504+0300: 66.504: [GC (CMS Final Remark)[YG occupancy: 4266790 K "
                 + "(8388608 K)]2017-01-07T22:02:15.504+0300: 66.504: [GC (CMS Final Remark)"
                 + "2017-01-07T22:02:15.504+0300: 66.504: [ParNew: 4266790K->922990K(8388608K), 0.6540990 secs] "
@@ -363,7 +363,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineNoSpaceAfterTrigger() {
+    void testLogLineNoSpaceAfterTrigger() {
         String logLine = "78.251: [GC (CMS Final Remark)[YG occupancy: 2619547 K (8388608 K)]"
                 + "78.251: [GC (CMS Final Remark)78.251: [ParNew: 2619547K->569438K(8388608K), 0.3405110 secs] "
                 + "6555444K->5043068K(22020096K) icms_dc=100 , 0.3406250 secs] "
@@ -387,7 +387,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineTriggerPromotionFailed() {
+    void testLogLineTriggerPromotionFailed() {
         String logLine = "58427.547: [GC (CMS Final Remark)[YG occupancy: 5117539 K (8388608 K)]"
                 + "58427.548: [GC (CMS Final Remark)58427.548: [ParNew (promotion failed): "
                 + "5117539K->5001473K(8388608K), 27.6557600 secs] 17958061K->18622281K(22020096K) icms_dc=57 , "
@@ -411,7 +411,7 @@ public class TestParNewEvent {
     }
 
     @Test
-    public void testLogLineTriggerScavengeBeforeRemarkNoGcDetailsPreprocessed() {
+    void testLogLineTriggerScavengeBeforeRemarkNoGcDetailsPreprocessed() {
         String logLine = "2017-04-03T03:12:02.133-0500: 30.385: [GC (CMS Final Remark) 2017-04-03T03:12:02.134-0500: "
                 + "30.385: [GC (CMS Final Remark)  890910K->620060K(7992832K), 0.1223879 secs] 620060K(7992832K), "
                 + "0.2328529 secs]";
@@ -433,7 +433,7 @@ public class TestParNewEvent {
      * failure" text.
      */
     @Test
-    public void testSplitParNewCmsConcurrentEventAbortablePrecleanLogging() {
+    void testSplitParNewCmsConcurrentEventAbortablePrecleanLogging() {
         File testFile = TestUtil.getFile("dataset15.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -448,7 +448,7 @@ public class TestParNewEvent {
      * Test identifying <code>ParNewEvent</code> running in incremental mode.
      */
     @Test
-    public void testCmsIncrementalModeAnalysis() {
+    void testCmsIncrementalModeAnalysis() {
         File testFile = TestUtil.getFile("dataset68.txt");
         String jvmOptions = "Xss128k -XX:+CMSIncrementalMode -XX:CMSInitiatingOccupancyFraction=70 -Xms2048M";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -464,7 +464,7 @@ public class TestParNewEvent {
      * Test datestamp only logging without passing in JVM start datetime.
      */
     @Test
-    public void testParNewDatestampNoTimestampNoJvmStartDate() {
+    void testParNewDatestampNoTimestampNoJvmStartDate() {
         File testFile = TestUtil.getFile("dataset113.txt");
         Jvm jvm = new Jvm(null, null);
         GcManager gcManager = new GcManager();
@@ -482,7 +482,7 @@ public class TestParNewEvent {
      * Test datestamp only logging with passing in JVM start datetime.
      */
     @Test
-    public void testParNewDatestampNoTimestampJvmStartDate() {
+    void testParNewDatestampNoTimestampJvmStartDate() {
         File testFile = TestUtil.getFile("dataset113.txt");
         Date jvmStartDate = GcUtil.parseStartDateTime("2017-02-28 11:26:24,135");
         Jvm jvm = new Jvm(null, jvmStartDate);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParNewEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Date;
@@ -29,7 +29,7 @@ import org.eclipselabs.garbagecat.util.jdk.Analysis;
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -41,26 +41,24 @@ public class TestParNewEvent {
     public void testIsBlocking() {
         String logLine = "20.189: [GC 20.190: [ParNew: 86199K->8454K(91712K), 0.0375060 secs] "
                 + "89399K->11655K(907328K), 0.0387074 secs]";
-        assertTrue(JdkUtil.LogEventType.PAR_NEW.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PAR_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "20.189: [GC 20.190: [ParNew: 86199K->8454K(91712K), 0.0375060 secs] "
                 + "89399K->11655K(907328K), 0.0387074 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 20189, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(86199), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(8454), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(91712), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(3200), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(3201), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(815616), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 38707, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
+        assertEquals((long) 20189,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(86199),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(8454),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(91712),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(3200),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(3201),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(815616),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(38707,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
     }
 
     @Test
@@ -68,22 +66,21 @@ public class TestParNewEvent {
         String logLine = "68331.885: [GC 68331.885: [ParNew: 149120K->18211K(149120K), "
                 + "0.0458577 secs] 4057776K->3931241K(8367360K), 0.0461448 secs] "
                 + "[Times: user=0.34 sys=0.01, real=0.05 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 68331885, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(149120), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(18211), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(149120), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(3908656), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(3913030), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(8218240), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 46144, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 34, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 5, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 700, event.getParallelism());
+        assertEquals((long) 68331885,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(149120),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(18211),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(149120),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(3908656),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(3913030),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(8218240),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(46144,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(34,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(5,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(700,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -91,22 +88,21 @@ public class TestParNewEvent {
         String logLine = "42514.965: [GC 42514.966: [ParNew: 54564K->1006K(59008K), 0.0221640 secs] "
                 + "417639K->364081K(1828480K) icms_dc=0 , 0.0225090 secs] "
                 + "[Times: user=0.05 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 42514965, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(54564), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(1006), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(59008), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((417639 - 54564)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((364081 - 1006)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((1828480 - 59008)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 22509, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 5, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 250, event.getParallelism());
+        assertEquals((long) 42514965,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(54564),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(1006),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(59008),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((417639 - 54564)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((364081 - 1006)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((1828480 - 59008)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(22509,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(5,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(250,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -114,8 +110,7 @@ public class TestParNewEvent {
         String logLine = "68331.885: [GC 68331.885: [ParNew: 149120K->18211K(149120K), "
                 + "0.0458577 secs] 4057776K->3931241K(8367360K), 0.0461448 secs] "
                 + "[Times: user=0.34 sys=0.01, real=0.05 secs]    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
     }
 
     @Test
@@ -123,7 +118,7 @@ public class TestParNewEvent {
         String logLine = "4687597.901: [GC 4687597.901: [ParNew: 342376K->16369K(368640K), "
                 + "0.0865160 secs] 1561683K->1235676K(2056192K), 0.0869060 secs]";
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4687597901L, event.getTimestamp());
+        assertEquals(4687597901L,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
@@ -131,53 +126,51 @@ public class TestParNewEvent {
         String logLine = "13.086: [GC13.086: [ParNew: 272640K->33532K(306688K), 0.0381419 secs] "
                 + "272640K->33532K(1014528K), 0.0383306 secs] " + "[Times: user=0.11 sys=0.02, real=0.04 secs]";
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 13086L, event.getTimestamp());
+        assertEquals(13086L,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testLogLineJdk8WithTrigger() {
         String logLine = "6.703: [GC (Allocation Failure) 6.703: [ParNew: 886080K->11485K(996800K), 0.0193349 secs] "
                 + "886080K->11485K(1986432K), 0.0198375 secs] [Times: user=0.09 sys=0.01, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6703, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(886080), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(11485), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(996800), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((886080 - 886080)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((11485 - 11485)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((1986432 - 996800)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 19837, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 9, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 500, event.getParallelism());
+        assertEquals((long) 6703,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(886080),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(11485),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(996800),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((886080 - 886080)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((11485 - 11485)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((1986432 - 996800)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(19837,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(9,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(500,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineJdk8NoSpaceAfterTrigger() {
         String logLine = "1.948: [GC (Allocation Failure)1.948: [ParNew: 136576K->17023K(153600K), 0.0303800 secs] "
                 + "136576K->19515K(494976K), 0.0305360 secs] [Times: user=0.10 sys=0.01, real=0.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1948, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(136576), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(17023), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(153600), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((136576 - 136576)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((19515 - 17023)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((494976 - 153600)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 30536, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 10, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 3, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 367, event.getParallelism());
+        assertEquals((long) 1948,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(136576),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(17023),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(153600),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((136576 - 136576)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((19515 - 17023)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((494976 - 153600)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(30536,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(10,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(3,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(367,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -185,24 +178,22 @@ public class TestParNewEvent {
         String logLine = "2.480: [GC (GCLocker Initiated GC) 2.480: [ParNew: 1228800K->30695K(1382400K), "
                 + "0.0395910 secs] 1228800K->30695K(8235008K), 0.0397980 secs] "
                 + "[Times: user=0.23 sys=0.01, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2480, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1228800), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(30695), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1382400), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((1228800 - 1228800)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((30695 - 30695)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((8235008 - 1382400)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 39798, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 23, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 600, event.getParallelism());
+        assertEquals((long) 2480,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1228800),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(30695),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1382400),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((1228800 - 1228800)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((30695 - 30695)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((8235008 - 1382400)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(39798,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(23,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(600,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -210,47 +201,43 @@ public class TestParNewEvent {
         String logLine = "7236.341: [GC[YG occupancy: 1388745 K (4128768 K)]7236.341: [GC7236.341: [ParNew: "
                 + "1388745K->458752K(4128768K), 0.5246295 secs] 2977822K->2161212K(13172736K), 0.5248785 secs] "
                 + "[Times: user=0.92 sys=0.03, real=0.51 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7236341, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1388745), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(458752), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(4128768), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((2977822 - 1388745)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((2161212 - 458752)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((13172736 - 4128768)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 524878, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 92, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 3, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 51, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 187, event.getParallelism());
+        assertEquals((long) 7236341,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1388745),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(458752),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(4128768),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((2977822 - 1388745)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((2161212 - 458752)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((13172736 - 4128768)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(524878,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(92,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(3,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(51,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(187,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLineSystemGcTrigger() {
         String logLine = "27880.710: [GC (System.gc()) 27880.710: [ParNew: 925502K->58125K(996800K), 0.0133005 secs] "
                 + "5606646K->4742781K(8277888K), 0.0138294 secs] [Times: user=0.14 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 27880710, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(925502), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(58125), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(996800), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((5606646 - 925502)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((4742781 - 58125)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((8277888 - 996800)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 13829, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 14, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 700, event.getParallelism());
+        assertEquals((long) 27880710,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(925502),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(58125),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(996800),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((5606646 - 925502)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((4742781 - 58125)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((8277888 - 996800)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(13829,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(14,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(700,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -258,23 +245,21 @@ public class TestParNewEvent {
         String logLine = "393747.603: [GC393747.603: [ParNew (promotion failed): 476295K->476295K(4128768K), "
                 + "0.5193071 secs] 7385012K->7555732K(13172736K), 0.5196411 secs] "
                 + "[Times: user=0.92 sys=0.00, real=0.55 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 393747603, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(476295), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(476295), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(4128768), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((7385012 - 476295)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((7555732 - 476295)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((13172736 - 4128768)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 519641, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 92, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 55, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 168, event.getParallelism());
+        assertEquals((long) 393747603,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(476295),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(476295),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(4128768),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((7385012 - 476295)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((7555732 - 476295)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((13172736 - 4128768)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(519641,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(92,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(55,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(168,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -282,22 +267,21 @@ public class TestParNewEvent {
         String logLine = "2010-04-16T12:11:18.979+0200: 84.335: [GC 84.336: [ParNew: 273152K->858K(341376K), "
                 + "0.0030008 secs] 273152K->858K(980352K), 0.0031183 secs] "
                 + "[Times: user=0.00 sys=0.00, real=0.00 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 84335, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(273152), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(858), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(341376), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((273152 - 273152)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((858 - 858)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((980352 - 341376)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 3118, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) 84335,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(273152),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(858),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(341376),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((273152 - 273152)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((858 - 858)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((980352 - 341376)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(3118,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -305,8 +289,7 @@ public class TestParNewEvent {
         String logLine = "2017-02-27T07:23:39.571+0100: [GC [ParNew: 2304000K->35161K(2688000K), 0.0759285 secs] "
                 + "2304000K->35161K(9856000K), 0.0760907 secs] [Times: user=0.21 sys=0.05, real=0.08 secs]";
         // Datestamp only is handled by preparsing.
-        assertFalse("Log line incorrectly recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertFalse(ParNewEvent.match(logLine), "Log line incorrectly recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
     }
 
     @Test
@@ -314,22 +297,21 @@ public class TestParNewEvent {
         String logLine = "2013-12-09T16:18:17.813+0000: 13.086: [GC2013-12-09T16:18:17.813+0000: 13.086: [ParNew: "
                 + "272640K->33532K(306688K), 0.0381419 secs] 272640K->33532K(1014528K), 0.0383306 secs] "
                 + "[Times: user=0.11 sys=0.02, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 13086, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(272640), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(33532), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(306688), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((272640 - 272640)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((33532 - 33532)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((1014528 - 306688)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 38330, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 11, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 2, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 325, event.getParallelism());
+        assertEquals((long) 13086,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(272640),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(33532),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(306688),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((272640 - 272640)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((33532 - 33532)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((1014528 - 306688)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(38330,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(11,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(2,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(325,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -337,23 +319,22 @@ public class TestParNewEvent {
         String logLine = "4.506: [GC (CMS Final Remark) [YG occupancy: 100369 K (153344 K)]"
                 + "4.506: [GC (CMS Final Remark) 4.506: [ParNew: 100369K->10116K(153344K), 0.0724021 secs] "
                 + "100369K->16685K(4177280K), 0.0724907 secs] [Times: user=0.13 sys=0.01, real=0.07 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4506, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(100369), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(10116), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(153344), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((100369 - 100369)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((16685 - 10116)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((4177280 - 153344)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 72490, event.getDuration());
-        assertFalse("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 13, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 7, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 200, event.getParallelism());
+        assertEquals((long) 4506,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(100369),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(10116),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(153344),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((100369 - 100369)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((16685 - 10116)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((4177280 - 153344)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(72490,event.getDuration(),"Duration not parsed correctly.");
+        assertFalse(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(13,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(7,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(200,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -363,24 +344,22 @@ public class TestParNewEvent {
                 + "2017-01-07T22:02:15.504+0300: 66.504: [ParNew: 4266790K->922990K(8388608K), 0.6540990 secs] "
                 + "6417140K->3472610K(22020096K) icms_dc=35 , 0.6542370 secs] "
                 + "[Times: user=1.89 sys=0.01, real=0.66 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 66504, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(4266790), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(922990), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(8388608), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((6417140 - 4266790)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((3472610 - 922990)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((22020096 - 8388608)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 654237, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 189, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 66, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 288, event.getParallelism());
+        assertEquals((long) 66504,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(4266790),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(922990),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(8388608),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((6417140 - 4266790)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((3472610 - 922990)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((22020096 - 8388608)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(654237,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(189,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(66,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(288,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -389,24 +368,22 @@ public class TestParNewEvent {
                 + "78.251: [GC (CMS Final Remark)78.251: [ParNew: 2619547K->569438K(8388608K), 0.3405110 secs] "
                 + "6555444K->5043068K(22020096K) icms_dc=100 , 0.3406250 secs] "
                 + "[Times: user=2.12 sys=0.01, real=0.34 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 78251, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(2619547), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(569438), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(8388608), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((6555444 - 2619547)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((5043068 - 569438)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((22020096 - 8388608)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 340625, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 212, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 34, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 627, event.getParallelism());
+        assertEquals((long) 78251,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(2619547),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(569438),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(8388608),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((6555444 - 2619547)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((5043068 - 569438)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((22020096 - 8388608)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(340625,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(212,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(34,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(627,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -415,24 +392,22 @@ public class TestParNewEvent {
                 + "58427.548: [GC (CMS Final Remark)58427.548: [ParNew (promotion failed): "
                 + "5117539K->5001473K(8388608K), 27.6557600 secs] 17958061K->18622281K(22020096K) icms_dc=57 , "
                 + "27.6560550 secs] [Times: user=49.10 sys=6.01, real=27.65 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 58427547, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(5117539), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(5001473), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(8388608), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((17958061 - 5117539)),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((18622281 - 5001473)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((22020096 - 8388608)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 27656055, event.getDuration());
-        assertTrue("Incremental Mode not parsed correctly.", event.isIncrementalMode());
-        assertEquals("User time not parsed correctly.", 4910, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 601, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 2765, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 200, event.getParallelism());
+        assertEquals((long) 58427547,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(5117539),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(5001473),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(8388608),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((17958061 - 5117539)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((18622281 - 5001473)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((22020096 - 8388608)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(27656055,event.getDuration(),"Duration not parsed correctly.");
+        assertTrue(event.isIncrementalMode(), "Incremental Mode not parsed correctly.");
+        assertEquals(4910,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(601,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(2765,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(200,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -440,18 +415,17 @@ public class TestParNewEvent {
         String logLine = "2017-04-03T03:12:02.133-0500: 30.385: [GC (CMS Final Remark) 2017-04-03T03:12:02.134-0500: "
                 + "30.385: [GC (CMS Final Remark)  890910K->620060K(7992832K), 0.1223879 secs] 620060K(7992832K), "
                 + "0.2328529 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                ParNewEvent.match(logLine));
+        assertTrue(ParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
         ParNewEvent event = new ParNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 30385, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(890910), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(620060), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(7992832), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes((620060 - 620060)), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes((620060 - 620060)), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes((7992832 - 7992832)), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 232852, event.getDuration());
+        assertEquals((long) 30385,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(890910),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(620060),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(7992832),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes((620060 - 620060)),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes((620060 - 620060)),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes((7992832 - 7992832)),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(232852,event.getDuration(),"Duration not parsed correctly.");
     }
 
     /**
@@ -465,11 +439,9 @@ public class TestParNewEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -484,10 +456,8 @@ public class TestParNewEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE));
-        assertTrue(Analysis.WARN_CMS_INC_MODE_WITH_INIT_OCCUP_FRACT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INC_MODE_WITH_INIT_OCCUP_FRACT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE), Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INC_MODE_WITH_INIT_OCCUP_FRACT), Analysis.WARN_CMS_INC_MODE_WITH_INIT_OCCUP_FRACT + " analysis not identified.");
     }
 
     /**
@@ -501,15 +471,11 @@ public class TestParNewEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.ERROR_DATESTAMP_NO_TIMESTAMP + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_DATESTAMP_NO_TIMESTAMP));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_DATESTAMP_NO_TIMESTAMP), Analysis.ERROR_DATESTAMP_NO_TIMESTAMP + " analysis not identified.");
         // Don't report datestamp only lines unidentified
-        assertFalse(Analysis.ERROR_UNIDENTIFIED_LOG_LINES_PREPARSE + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_UNIDENTIFIED_LOG_LINES_PREPARSE));
-        assertFalse(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST));
-        assertFalse(Analysis.WARN_UNIDENTIFIED_LOG_LINE_REPORT + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_UNIDENTIFIED_LOG_LINE_REPORT));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_UNIDENTIFIED_LOG_LINES_PREPARSE), Analysis.ERROR_UNIDENTIFIED_LOG_LINES_PREPARSE + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST), Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_UNIDENTIFIED_LOG_LINE_REPORT), Analysis.WARN_UNIDENTIFIED_LOG_LINE_REPORT + " analysis incorrectly identified.");
     }
 
     /**
@@ -524,10 +490,8 @@ public class TestParNewEvent {
         File preprocessedFile = gcManager.preprocess(testFile, jvmStartDate);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertFalse(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED), Analysis.INFO_FIRST_TIMESTAMP_THRESHOLD_EXCEEDED + " analysis incorrectly identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelCompactingOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelCompactingOldEvent.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestParallelCompactingOldEvent {
+class TestParallelCompactingOldEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "2182.541: [Full GC [PSYoungGen: 1940K->0K(98560K)] "
                 + "[ParOldGen: 813929K->422305K(815616K)] 815869K->422305K(914176K) "
                 + "[PSPermGen: 81960K->81783K(164352K)], 2.4749181 secs]";
@@ -47,7 +47,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLineWhiteSpaceAtEnd() {
+    void testLogLineWhiteSpaceAtEnd() {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[ParOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]  ";
@@ -55,7 +55,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLineJdk16() {
+    void testLogLineJdk16() {
         String logLine = "2.417: [Full GC (System) [PSYoungGen: 1788K->0K(12736K)] "
                 + "[ParOldGen: 1084K->2843K(116544K)] 2872K->2843K(129280K) "
                 + "[PSPermGen: 8602K->8593K(131072K)], 0.1028360 secs]";
@@ -76,7 +76,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "1.234: [Full GC (Metadata GC Threshold) [PSYoungGen: 17779K->0K(1835008K)] "
                 + "[ParOldGen: 16K->16894K(4194304K)] 17795K->16894K(6029312K), [Metaspace: 19114K->19114K(1067008K)], "
                 + "0.0352132 secs] [Times: user=0.09 sys=0.00, real=0.04 secs]";
@@ -101,7 +101,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLineLastDitchCollectionTrigger() {
+    void testLogLineLastDitchCollectionTrigger() {
         String logLine = "372405.718: [Full GC (Last ditch collection) [PSYoungGen: 0K->0K(1569280K)] "
                 + "[ParOldGen: 773083K->773083K(4718592K)] 773083K->773083K(6287872K), "
                 + "[Metaspace: 4177368K->4177368K(4194304K)], 1.9708670 secs] "
@@ -127,7 +127,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "2182.541: [Full GC [PSYoungGen: 1940K->0K(98560K)] "
                 + "[ParOldGen: 813929K->422305K(815616K)] 815869K->422305K(914176K) "
                 + "[PSPermGen: 81960K->81783K(164352K)], 2.4749181 secs]";
@@ -135,7 +135,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLineErgonomicsTrigger() {
+    void testLogLineErgonomicsTrigger() {
         String logLine = "21415.385: [Full GC (Ergonomics) [PSYoungGen: 105768K->0K(547840K)] "
                 + "[ParOldGen: 1390311K->861344K(1398272K)] 1496080K->861344K(1946112K), "
                 + "[Metaspace: 136339K->135256K(1177600K)], 3.4522057 secs] "
@@ -161,7 +161,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testHeapInspectionInitiatedGcTrigger() {
+    void testHeapInspectionInitiatedGcTrigger() {
         String logLine = "285197.105: [Full GC (Heap Inspection Initiated GC) [PSYoungGen: 47669K->0K(1514496K)] "
                 + "[ParOldGen: 2934846K->851463K(4718592K)] 2982516K->851463K(6233088K), "
                 + "[Metaspace: 3959933K->3959881K(3977216K)], 2.4308400 secs] "
@@ -187,7 +187,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testAllocationFailureTrigger() {
+    void testAllocationFailureTrigger() {
         String logLine = "3203650.654: [Full GC (Allocation Failure) [PSYoungGen: 393482K->393073K(532992K)] "
                 + "[ParOldGen: 1398224K->1398199K(1398272K)] 1791707K->1791273K(1931264K), "
                 + "[Metaspace: 170955K->170731K(1220608K)], 3.5730395 secs] "
@@ -213,7 +213,7 @@ public class TestParallelCompactingOldEvent {
     }
 
     @Test
-    public void testHeapDumpInitiatedGcTrigger() {
+    void testHeapDumpInitiatedGcTrigger() {
         String logLine = "2017-02-01T17:09:50.180+0000: 1029482.070: [Full GC (Heap Dump Initiated GC) "
                 + "[PSYoungGen: 33192K->0K(397312K)] [ParOldGen: 885002K->812903K(890368K)] "
                 + "918194K->812903K(1287680K), [Metaspace: 142181K->141753K(1185792K)], 2.3728899 secs] "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelCompactingOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelCompactingOldEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -31,20 +31,19 @@ public class TestParallelCompactingOldEvent {
         String logLine = "2182.541: [Full GC [PSYoungGen: 1940K->0K(98560K)] "
                 + "[ParOldGen: 813929K->422305K(815616K)] 815869K->422305K(914176K) "
                 + "[PSPermGen: 81960K->81783K(164352K)], 2.4749181 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2182541, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1940), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(98560), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(813929), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(422305), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(815616), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(81960), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(81783), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(164352), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 2474918, event.getDuration());
+        assertEquals((long) 2182541,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1940),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(98560),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(813929),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(422305),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(815616),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(81960),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(81783),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(164352),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(2474918,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -52,8 +51,7 @@ public class TestParallelCompactingOldEvent {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[ParOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]  ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
     }
 
     @Test
@@ -61,22 +59,20 @@ public class TestParallelCompactingOldEvent {
         String logLine = "2.417: [Full GC (System) [PSYoungGen: 1788K->0K(12736K)] "
                 + "[ParOldGen: 1084K->2843K(116544K)] 2872K->2843K(129280K) "
                 + "[PSPermGen: 8602K->8593K(131072K)], 0.1028360 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2417, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1788), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(12736), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1084), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2843), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(116544), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(8602), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(8593), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 102836, event.getDuration());
+        assertEquals((long) 2417,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".");
+        assertEquals(kilobytes(1788),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(12736),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1084),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2843),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(116544),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(8602),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(8593),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(102836,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -84,26 +80,24 @@ public class TestParallelCompactingOldEvent {
         String logLine = "1.234: [Full GC (Metadata GC Threshold) [PSYoungGen: 17779K->0K(1835008K)] "
                 + "[ParOldGen: 16K->16894K(4194304K)] 17795K->16894K(6029312K), [Metaspace: 19114K->19114K(1067008K)], "
                 + "0.0352132 secs] [Times: user=0.09 sys=0.00, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1234, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.METADATA_GC_THRESHOLD.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(17779), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1835008), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(16), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(16894), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4194304), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(19114), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(19114), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1067008), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 35213, event.getDuration());
-        assertEquals("User time not parsed correctly.", 9, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 225, event.getParallelism());
+        assertEquals((long) 1234,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not recognized as " + JdkUtil.TriggerType.METADATA_GC_THRESHOLD.toString() + ".");
+        assertEquals(kilobytes(17779),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1835008),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(16),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(16894),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4194304),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(19114),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(19114),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1067008),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(35213,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(9,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(225,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -112,26 +106,24 @@ public class TestParallelCompactingOldEvent {
                 + "[ParOldGen: 773083K->773083K(4718592K)] 773083K->773083K(6287872K), "
                 + "[Metaspace: 4177368K->4177368K(4194304K)], 1.9708670 secs] "
                 + "[Times: user=4.41 sys=0.01, real=1.97 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 372405718, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.LAST_DITCH_COLLECTION.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(0), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1569280), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(773083), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(773083), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4718592), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(4177368), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(4177368), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(4194304), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1970867, event.getDuration());
-        assertEquals("User time not parsed correctly.", 441, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 197, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 225, event.getParallelism());
+        assertEquals((long) 372405718,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION), "Trigger not recognized as " + JdkUtil.TriggerType.LAST_DITCH_COLLECTION.toString() + ".");
+        assertEquals(kilobytes(0),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1569280),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(773083),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(773083),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4718592),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(4177368),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(4177368),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(4194304),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1970867,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(441,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(197,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(225,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -139,8 +131,7 @@ public class TestParallelCompactingOldEvent {
         String logLine = "2182.541: [Full GC [PSYoungGen: 1940K->0K(98560K)] "
                 + "[ParOldGen: 813929K->422305K(815616K)] 815869K->422305K(914176K) "
                 + "[PSPermGen: 81960K->81783K(164352K)], 2.4749181 secs]";
-        assertTrue(JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -149,26 +140,24 @@ public class TestParallelCompactingOldEvent {
                 + "[ParOldGen: 1390311K->861344K(1398272K)] 1496080K->861344K(1946112K), "
                 + "[Metaspace: 136339K->135256K(1177600K)], 3.4522057 secs] "
                 + "[Times: user=11.58 sys=0.64, real=3.45 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 21415385, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.ERGONOMICS.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(105768), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(547840), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1390311), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(861344), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1398272), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(136339), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(135256), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1177600), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3452205, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1158, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 64, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 345, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 355, event.getParallelism());
+        assertEquals((long) 21415385,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not recognized as " + JdkUtil.TriggerType.ERGONOMICS.toString() + ".");
+        assertEquals(kilobytes(105768),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(547840),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1390311),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(861344),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1398272),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(136339),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(135256),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1177600),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3452205,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1158,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(64,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(345,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(355,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -177,26 +166,24 @@ public class TestParallelCompactingOldEvent {
                 + "[ParOldGen: 2934846K->851463K(4718592K)] 2982516K->851463K(6233088K), "
                 + "[Metaspace: 3959933K->3959881K(3977216K)], 2.4308400 secs] "
                 + "[Times: user=6.95 sys=0.03, real=2.43 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 285197105, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.HEAP_INSPECTION_INITIATED_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(47669), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1514496), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2934846), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(851463), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4718592), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(3959933), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(3959881), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(3977216), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 2430840, event.getDuration());
-        assertEquals("User time not parsed correctly.", 695, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 3, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 243, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 288, event.getParallelism());
+        assertEquals((long) 285197105,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC), "Trigger not recognized as " + JdkUtil.TriggerType.HEAP_INSPECTION_INITIATED_GC.toString() + ".");
+        assertEquals(kilobytes(47669),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1514496),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2934846),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(851463),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4718592),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(3959933),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(3959881),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(3977216),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(2430840,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(695,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(3,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(243,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(288,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -205,26 +192,24 @@ public class TestParallelCompactingOldEvent {
                 + "[ParOldGen: 1398224K->1398199K(1398272K)] 1791707K->1791273K(1931264K), "
                 + "[Metaspace: 170955K->170731K(1220608K)], 3.5730395 secs] "
                 + "[Times: user=26.24 sys=0.09, real=3.57 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", Long.parseLong("3203650654"), event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.ALLOCATION_FAILURE.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(393482), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(393073), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(532992), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1398224), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(1398199), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1398272), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(170955), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(170731), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1220608), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3573039, event.getDuration());
-        assertEquals("User time not parsed correctly.", 2624, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 9, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 357, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 738, event.getParallelism());
+        assertEquals(Long.parseLong("3203650654"),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not recognized as " + JdkUtil.TriggerType.ALLOCATION_FAILURE.toString() + ".");
+        assertEquals(kilobytes(393482),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(393073),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(532992),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1398224),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(1398199),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1398272),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(170955),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(170731),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1220608),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(3573039,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(2624,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(9,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(357,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(738,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -233,25 +218,23 @@ public class TestParallelCompactingOldEvent {
                 + "[PSYoungGen: 33192K->0K(397312K)] [ParOldGen: 885002K->812903K(890368K)] "
                 + "918194K->812903K(1287680K), [Metaspace: 142181K->141753K(1185792K)], 2.3728899 secs] "
                 + "[Times: user=7.55 sys=0.60, real=2.37 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                ParallelCompactingOldEvent.match(logLine));
+        assertTrue(ParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
         ParallelCompactingOldEvent event = new ParallelCompactingOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", Long.parseLong("1029482070"), event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.HEAP_DUMP_INITIATED_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(33192), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(397312), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(885002), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(812903), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(890368), event.getOldSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(142181), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(141753), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1185792), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 2372889, event.getDuration());
-        assertEquals("User time not parsed correctly.", 755, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 60, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 237, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 344, event.getParallelism());
+        assertEquals(Long.parseLong("1029482070"),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC), "Trigger not recognized as " + JdkUtil.TriggerType.HEAP_DUMP_INITIATED_GC.toString() + ".");
+        assertEquals(kilobytes(33192),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(397312),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(885002),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(812903),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(890368),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(142181),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(141753),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1185792),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(2372889,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(755,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(60,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(237,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(344,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelScavengeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelScavengeEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -30,206 +30,192 @@ public class TestParallelScavengeEvent {
     public void testIsBlocking() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]";
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 19810091, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(27808), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(632), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(28032), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(132375), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(132527), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(557056), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 22521, event.getDuration());
+        assertEquals((long) 19810091,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(27808),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(632),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(28032),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(132375),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(132527),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(557056),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(22521,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
     }
 
     @Test
     public void testStressedJvmLogLine() {
         String logLine = "14112.691: [GC-- [PSYoungGen: 313864K->313864K(326656K)] "
                 + "879670K->1012935K(1025728K), 0.9561947 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 14112691, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(313864), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(313864), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(326656), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(565806), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(699071), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(699072), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 956194, event.getDuration());
+        assertEquals((long) 14112691,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(313864),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(313864),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(326656),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(565806),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(699071),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(699072),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(956194,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testSizeWithNineTensPlacesLogLine() {
         String logLine = "1006.751: [GC [PSYoungGen: 61139904K->20643840K(67413056K)] "
                 + "119561147K->80396669K(129092672K), 3.8993460 secs] [Times: user=66.40 sys=3.73, real=3.89 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1006751, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(61139904), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(20643840), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(67413056), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(119561147 - 61139904),
-                event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(80396669 - 20643840), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(129092672 - 67413056), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 3899346, event.getDuration());
-        assertEquals("User time not parsed correctly.", 6640, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 373, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 389, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 1803, event.getParallelism());
+        assertEquals((long) 1006751,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(61139904),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(20643840),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(67413056),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(119561147 - 61139904),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(80396669 - 20643840),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(129092672 - 67413056),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(3899346,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(6640,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(373,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(389,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(1803,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testJDK8LogLineWithMetatdataGcThreshholdTrigger() {
         String logLine = "1.219: [GC (Metadata GC Threshold) [PSYoungGen: 1226834K->17779K(1835008K)] "
                 + "1226834K->17795K(6029312K), 0.0144911 secs] [Times: user=0.04 sys=0.00, real=0.01 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1219, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1226834), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(17779), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1835008), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1226834 - 1226834), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(17795 - 17779), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6029312 - 1835008), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 14491, event.getDuration());
-        assertEquals("User time not parsed correctly.", 4, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 400, event.getParallelism());
+        assertEquals((long) 1219,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1226834),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(17779),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1835008),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1226834 - 1226834),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(17795 - 17779),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6029312 - 1835008),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(14491,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(4,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(400,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testJDK8LogLineWithGcLockerInitiateGcTrigger() {
         String logLine = "4.172: [GC (GCLocker Initiated GC) [PSYoungGen: 649034K->114285K(1223168K)] "
                 + "673650K->138909K(4019712K), 0.0711412 secs] [Times: user=0.24 sys=0.01, real=0.08 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4172, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(649034), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(114285), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1223168), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(673650 - 649034), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(138909 - 114285), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4019712 - 1223168), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 71141, event.getDuration());
-        assertEquals("User time not parsed correctly.", 24, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 8, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 313, event.getParallelism());
+        assertEquals((long) 4172,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(649034),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(114285),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1223168),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(673650 - 649034),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(138909 - 114285),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4019712 - 1223168),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(71141,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(24,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(8,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(313,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testJDK8LogLineWithAllocationFailureTrigger() {
         String logLine = "7.682: [GC (Allocation Failure) [PSYoungGen: 1048576K->131690K(1223168K)] "
                 + "1118082K->201204K(4019712K), 0.0657426 secs] [Times: user=0.13 sys=0.00, real=0.07 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7682, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1048576), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(131690), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1223168), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1118082 - 1048576), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(201204 - 131690), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(4019712 - 1223168), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 65742, event.getDuration());
-        assertEquals("User time not parsed correctly.", 13, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 7, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 186, event.getParallelism());
+        assertEquals((long) 7682,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1048576),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(131690),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1223168),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1118082 - 1048576),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(201204 - 131690),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(4019712 - 1223168),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(65742,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(13,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(7,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(186,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLastDitchCollectionTrigger() {
         String logLine = "372405.495: [GC (Last ditch collection) [PSYoungGen: 0K->0K(1569280K)] "
                 + "773083K->773083K(6287872K), 0.2217060 secs] [Times: user=0.76 sys=0.00, real=0.22 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 372405495, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(0), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1569280), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(773083 - 0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(773083 - 0), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6287872 - 1569280), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 221706, event.getDuration());
-        assertEquals("User time not parsed correctly.", 76, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 22, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 346, event.getParallelism());
+        assertEquals((long) 372405495,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1569280),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(773083 - 0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(773083 - 0),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6287872 - 1569280),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(221706,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(76,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(22,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(346,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testHeapInspectionInitiatedGcTrigger() {
         String logLine = "285196.842: [GC (Heap Inspection Initiated GC) [PSYoungGen: 1475708K->47669K(1514496K)] "
                 + "4407360K->2982516K(6233088K), 0.2635940 secs] [Times: user=0.86 sys=0.00, real=0.27 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 285196842, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.HEAP_INSPECTION_INITIATED_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1475708), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(47669), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1514496), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(4407360 - 1475708), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2982516 - 47669), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6233088 - 1514496), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 263594, event.getDuration());
-        assertEquals("User time not parsed correctly.", 86, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 27, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 319, event.getParallelism());
+        assertEquals((long) 285196842,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_INSPECTION_INITIATED_GC), "Trigger not recognized as " + JdkUtil.TriggerType.HEAP_INSPECTION_INITIATED_GC.toString() + ".");
+        assertEquals(kilobytes(1475708),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(47669),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1514496),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(4407360 - 1475708),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2982516 - 47669),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6233088 - 1514496),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(263594,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(86,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(27,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(319,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testSystemGcTrigger() {
         String logLine = "180069.616: [GC (System.gc()) [PSYoungGen: 553672K->22188K(1472512K)] "
                 + "2900456K->2372732K(6191104K), 0.1668270 secs] [Times: user=0.58 sys=0.00, real=0.17 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 180069616, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(553672), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(22188), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1472512), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(2900456 - 553672), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2372732 - 22188), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(6191104 - 1472512), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 166827, event.getDuration());
-        assertEquals("User time not parsed correctly.", 58, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 17, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 342, event.getParallelism());
+        assertEquals((long) 180069616,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".");
+        assertEquals(kilobytes(553672),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(22188),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1472512),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(2900456 - 553672),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2372732 - 22188),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(6191104 - 1472512),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(166827,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(58,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(17,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(342,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -237,23 +223,21 @@ public class TestParallelScavengeEvent {
         String logLine = "2017-02-01T17:09:50.155+0000: 1029482.045: [GC (Heap Dump Initiated GC) "
                 + "[PSYoungGen: 335699K->33192K(397312K)] 1220565K->918194K(1287680K), 0.0243428 secs] "
                 + "[Times: user=0.07 sys=0.01, real=0.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1029482045, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.HEAP_DUMP_INITIATED_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(335699), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(33192), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(397312), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1220565 - 335699), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(918194 - 33192), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1287680 - 397312), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 24342, event.getDuration());
-        assertEquals("User time not parsed correctly.", 7, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 3, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 267, event.getParallelism());
+        assertEquals((long) 1029482045,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_HEAP_DUMP_INITIATED_GC), "Trigger not recognized as " + JdkUtil.TriggerType.HEAP_DUMP_INITIATED_GC.toString() + ".");
+        assertEquals(kilobytes(335699),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(33192),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(397312),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1220565 - 335699),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(918194 - 33192),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1287680 - 397312),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(24342,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(7,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(3,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(267,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -261,22 +245,20 @@ public class TestParallelScavengeEvent {
         String logLine = "2017-02-01T15:56:24.437+0000: 1025076.327: [GC (Allocation Failure) "
                 + "--[PSYoungGen: 385537K->385537K(397824K)] 1271095K->1275901K(1288192K), 0.1674611 secs] "
                 + "[Times: user=0.24 sys=0.00, real=0.17 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                ParallelScavengeEvent.match(logLine));
+        assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
         ParallelScavengeEvent event = new ParallelScavengeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1025076327, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.ALLOCATION_FAILURE.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(385537), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(385537), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(397824), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1271095 - 385537), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(1275901 - 385537), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1288192 - 397824), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 167461, event.getDuration());
-        assertEquals("User time not parsed correctly.", 24, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 17, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 142, event.getParallelism());
+        assertEquals((long) 1025076327,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not recognized as " + JdkUtil.TriggerType.ALLOCATION_FAILURE.toString() + ".");
+        assertEquals(kilobytes(385537),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(385537),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(397824),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1271095 - 385537),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(1275901 - 385537),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1288192 - 397824),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(167461,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(24,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(17,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(142,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelScavengeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelScavengeEvent.java
@@ -24,17 +24,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestParallelScavengeEvent {
+class TestParallelScavengeEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -50,14 +50,14 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "19810.091: [GC [PSYoungGen: 27808K->632K(28032K)] "
                 + "160183K->133159K(585088K), 0.0225213 secs]     ";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
     }
 
     @Test
-    public void testStressedJvmLogLine() {
+    void testStressedJvmLogLine() {
         String logLine = "14112.691: [GC-- [PSYoungGen: 313864K->313864K(326656K)] "
                 + "879670K->1012935K(1025728K), 0.9561947 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -73,7 +73,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testSizeWithNineTensPlacesLogLine() {
+    void testSizeWithNineTensPlacesLogLine() {
         String logLine = "1006.751: [GC [PSYoungGen: 61139904K->20643840K(67413056K)] "
                 + "119561147K->80396669K(129092672K), 3.8993460 secs] [Times: user=66.40 sys=3.73, real=3.89 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -93,7 +93,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testJDK8LogLineWithMetatdataGcThreshholdTrigger() {
+    void testJDK8LogLineWithMetatdataGcThreshholdTrigger() {
         String logLine = "1.219: [GC (Metadata GC Threshold) [PSYoungGen: 1226834K->17779K(1835008K)] "
                 + "1226834K->17795K(6029312K), 0.0144911 secs] [Times: user=0.04 sys=0.00, real=0.01 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -114,7 +114,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testJDK8LogLineWithGcLockerInitiateGcTrigger() {
+    void testJDK8LogLineWithGcLockerInitiateGcTrigger() {
         String logLine = "4.172: [GC (GCLocker Initiated GC) [PSYoungGen: 649034K->114285K(1223168K)] "
                 + "673650K->138909K(4019712K), 0.0711412 secs] [Times: user=0.24 sys=0.01, real=0.08 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -135,7 +135,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testJDK8LogLineWithAllocationFailureTrigger() {
+    void testJDK8LogLineWithAllocationFailureTrigger() {
         String logLine = "7.682: [GC (Allocation Failure) [PSYoungGen: 1048576K->131690K(1223168K)] "
                 + "1118082K->201204K(4019712K), 0.0657426 secs] [Times: user=0.13 sys=0.00, real=0.07 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -156,7 +156,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testLastDitchCollectionTrigger() {
+    void testLastDitchCollectionTrigger() {
         String logLine = "372405.495: [GC (Last ditch collection) [PSYoungGen: 0K->0K(1569280K)] "
                 + "773083K->773083K(6287872K), 0.2217060 secs] [Times: user=0.76 sys=0.00, real=0.22 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -177,7 +177,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testHeapInspectionInitiatedGcTrigger() {
+    void testHeapInspectionInitiatedGcTrigger() {
         String logLine = "285196.842: [GC (Heap Inspection Initiated GC) [PSYoungGen: 1475708K->47669K(1514496K)] "
                 + "4407360K->2982516K(6233088K), 0.2635940 secs] [Times: user=0.86 sys=0.00, real=0.27 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -198,7 +198,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testSystemGcTrigger() {
+    void testSystemGcTrigger() {
         String logLine = "180069.616: [GC (System.gc()) [PSYoungGen: 553672K->22188K(1472512K)] "
                 + "2900456K->2372732K(6191104K), 0.1668270 secs] [Times: user=0.58 sys=0.00, real=0.17 secs]";
         assertTrue(ParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
@@ -219,7 +219,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testHeapDumpInitiatedGcTrigger() {
+    void testHeapDumpInitiatedGcTrigger() {
         String logLine = "2017-02-01T17:09:50.155+0000: 1029482.045: [GC (Heap Dump Initiated GC) "
                 + "[PSYoungGen: 335699K->33192K(397312K)] 1220565K->918194K(1287680K), 0.0243428 secs] "
                 + "[Times: user=0.07 sys=0.01, real=0.03 secs]";
@@ -241,7 +241,7 @@ public class TestParallelScavengeEvent {
     }
 
     @Test
-    public void testDoubleDash() {
+    void testDoubleDash() {
         String logLine = "2017-02-01T15:56:24.437+0000: 1025076.327: [GC (Allocation Failure) "
                 + "--[PSYoungGen: 385537K->385537K(397824K)] 1271095K->1275901K(1288192K), 0.1674611 secs] "
                 + "[Times: user=0.24 sys=0.00, real=0.17 secs]";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelSerialOldEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -31,20 +31,19 @@ public class TestParallelSerialOldEvent {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                ParallelSerialOldEvent.match(logLine));
+        assertTrue(ParallelSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
         ParallelSerialOldEvent event = new ParallelSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3600, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(5424), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(38208), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(488), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(5786), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(87424), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(13092), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(13094), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 69936, event.getDuration());
+        assertEquals((long) 3600,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(5424),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(38208),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(488),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(5786),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(87424),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(13092),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(13094),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(69936,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -52,8 +51,7 @@ public class TestParallelSerialOldEvent {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]  ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                ParallelSerialOldEvent.match(logLine));
+        assertTrue(ParallelSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -61,22 +59,20 @@ public class TestParallelSerialOldEvent {
         String logLine = "4.165: [Full GC (System) [PSYoungGen: 1784K->0K(12736K)] "
                 + "[PSOldGen: 1081K->2855K(116544K)] 2865K->2855K(129280K) "
                 + "[PSPermGen: 8600K->8600K(131072K)], 0.0427680 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                ParallelSerialOldEvent.match(logLine));
+        assertTrue(ParallelSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
         ParallelSerialOldEvent event = new ParallelSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4165, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1784), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(12736), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1081), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2855), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(116544), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(8600), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(8600), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 42768, event.getDuration());
+        assertEquals((long) 4165,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not recognized as " + JdkUtil.TriggerType.SYSTEM_GC.toString() + ".");
+        assertEquals(kilobytes(1784),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(12736),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1081),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2855),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(116544),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(8600),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(8600),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(42768,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -84,22 +80,20 @@ public class TestParallelSerialOldEvent {
         String logLine = "2018-12-06T19:04:46.807-0500: 0.122: [Full GC (Ergonomics) [PSYoungGen: 508K->385K(1536K)] "
                 + "[PSOldGen: 408K->501K(2048K)] 916K->887K(3584K), "
                 + "[Metaspace: 3680K->3680K(1056768K)], 0.0030057 secs] [Times: user=0.01 sys=0.00, real=0.00 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                ParallelSerialOldEvent.match(logLine));
+        assertTrue(ParallelSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
         ParallelSerialOldEvent event = new ParallelSerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 122, event.getTimestamp());
-        assertTrue("Trigger not recognized as " + JdkUtil.TriggerType.ERGONOMICS.toString() + ".",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(508), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(385), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1536), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(408), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(501), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2048), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(3680), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(3680), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3005, event.getDuration());
+        assertEquals((long) 122,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not recognized as " + JdkUtil.TriggerType.ERGONOMICS.toString() + ".");
+        assertEquals(kilobytes(508),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(385),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1536),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(408),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(501),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2048),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(3680),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(3680),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3005,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -107,7 +101,6 @@ public class TestParallelSerialOldEvent {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]";
-        assertTrue(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + " not indentified as blocking.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestParallelSerialOldEvent.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestParallelSerialOldEvent {
+class TestParallelSerialOldEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]";
@@ -47,7 +47,7 @@ public class TestParallelSerialOldEvent {
     }
 
     @Test
-    public void testLogLineWhiteSpaceAtEnd() {
+    void testLogLineWhiteSpaceAtEnd() {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]  ";
@@ -55,7 +55,7 @@ public class TestParallelSerialOldEvent {
     }
 
     @Test
-    public void testLogLineJdk16() {
+    void testLogLineJdk16() {
         String logLine = "4.165: [Full GC (System) [PSYoungGen: 1784K->0K(12736K)] "
                 + "[PSOldGen: 1081K->2855K(116544K)] 2865K->2855K(129280K) "
                 + "[PSPermGen: 8600K->8600K(131072K)], 0.0427680 secs]";
@@ -76,7 +76,7 @@ public class TestParallelSerialOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerErgonomicsWithMetaspace() {
+    void testLogLineTriggerErgonomicsWithMetaspace() {
         String logLine = "2018-12-06T19:04:46.807-0500: 0.122: [Full GC (Ergonomics) [PSYoungGen: 508K->385K(1536K)] "
                 + "[PSOldGen: 408K->501K(2048K)] 916K->887K(3584K), "
                 + "[Metaspace: 3680K->3680K(1056768K)], 0.0030057 secs] [Times: user=0.01 sys=0.00, real=0.00 secs]";
@@ -97,7 +97,7 @@ public class TestParallelSerialOldEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "3.600: [Full GC [PSYoungGen: 5424K->0K(38208K)] "
                 + "[PSOldGen: 488K->5786K(87424K)] 5912K->5786K(125632K) "
                 + "[PSPermGen: 13092K->13094K(131072K)], 0.0699360 secs]";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestReferenceGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestReferenceGcEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,8 +32,7 @@ public class TestReferenceGcEvent {
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
                 + "[PSYoungGen: 63488K->3151K(73728K)] 63488K->3159K(241664K), 0.0032820 secs] "
                 + "[Times: user=0.02 sys=0.00, real=0.00 secs]";
-        assertFalse(JdkUtil.LogEventType.REFERENCE_GC.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.REFERENCE_GC.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
@@ -43,8 +42,7 @@ public class TestReferenceGcEvent {
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
                 + "[PSYoungGen: 63488K->3151K(73728K)] 63488K->3159K(241664K), 0.0032820 secs] "
                 + "[Times: user=0.02 sys=0.00, real=0.00 secs]";
-        assertFalse(JdkUtil.LogEventType.REFERENCE_GC.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.REFERENCE_GC.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
@@ -54,10 +52,9 @@ public class TestReferenceGcEvent {
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
                 + "[PSYoungGen: 63488K->3151K(73728K)] 63488K->3159K(241664K), 0.0032820 secs] "
                 + "[Times: user=0.02 sys=0.00, real=0.00 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".",
-                ReferenceGcEvent.match(logLine));
+        assertTrue(ReferenceGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".");
         ReferenceGcEvent event = new ReferenceGcEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 341, event.getTimestamp());
+        assertEquals((long) 341,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
@@ -66,10 +63,9 @@ public class TestReferenceGcEvent {
                 + "0.0000045 secs]6.698: [Preclean FinalReferences, 0.0000025 secs]6.698: "
                 + "[Preclean PhantomReferences, 0.0000026 secs]2015-12-12T08:59:10.539+0000: 6.717: "
                 + "[CMS-concurrent-preclean: 0.019/0.019 secs] [Times: user=0.02 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".",
-                ReferenceGcEvent.match(logLine));
+        assertTrue(ReferenceGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".");
         ReferenceGcEvent event = new ReferenceGcEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6698, event.getTimestamp());
+        assertEquals((long) 6698,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
@@ -79,9 +75,8 @@ public class TestReferenceGcEvent {
                 + "2017-04-05T09:07:18.552-0500: 201524.277: [FinalReference, 2813 refs, 0.0026465 secs]"
                 + "2017-04-05T09:07:18.555-0500: 201524.279: [PhantomReference, 13 refs, 18 refs, 0.0002374 secs]"
                 + "2017-04-05T09:07:18.555-0500: 201524.280: [JNI Weak Reference, 0.0000167 secs], 0.0319874 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".",
-                ReferenceGcEvent.match(logLine));
+        assertTrue(ReferenceGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.REFERENCE_GC.toString() + ".");
         ReferenceGcEvent event = new ReferenceGcEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 201524276, event.getTimestamp());
+        assertEquals((long) 201524276,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestReferenceGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestReferenceGcEvent.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestReferenceGcEvent {
+class TestReferenceGcEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "0.341: [GC (Allocation Failure) 0.344: [SoftReference, 0 refs, 0.0000327 secs]0.344: "
                 + "[WeakReference, 19 refs, 0.0000049 secs]0.344: [FinalReference, 296 refs, 0.0002385 secs]0.344: "
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
@@ -36,7 +36,7 @@ public class TestReferenceGcEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "0.341: [GC (Allocation Failure) 0.344: [SoftReference, 0 refs, 0.0000327 secs]0.344: "
                 + "[WeakReference, 19 refs, 0.0000049 secs]0.344: [FinalReference, 296 refs, 0.0002385 secs]0.344: "
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
@@ -46,7 +46,7 @@ public class TestReferenceGcEvent {
     }
 
     @Test
-    public void testLogLineParallelScavenge() {
+    void testLogLineParallelScavenge() {
         String logLine = "0.341: [GC (Allocation Failure) 0.344: [SoftReference, 0 refs, 0.0000327 secs]0.344: "
                 + "[WeakReference, 19 refs, 0.0000049 secs]0.344: [FinalReference, 296 refs, 0.0002385 secs]0.344: "
                 + "[PhantomReference, 0 refs, 0 refs, 0.0000033 secs]0.344: [JNI Weak Reference, 0.0000041 secs]"
@@ -58,7 +58,7 @@ public class TestReferenceGcEvent {
     }
 
     @Test
-    public void testLogLineConcurrent() {
+    void testLogLineConcurrent() {
         String logLine = "6.698: [Preclean SoftReferences, 0.0000060 secs]6.698: [Preclean WeakReferences, "
                 + "0.0000045 secs]6.698: [Preclean FinalReferences, 0.0000025 secs]6.698: "
                 + "[Preclean PhantomReferences, 0.0000026 secs]2015-12-12T08:59:10.539+0000: 6.717: "
@@ -69,7 +69,7 @@ public class TestReferenceGcEvent {
     }
 
     @Test
-    public void testLogLineDatestamps() {
+    void testLogLineDatestamps() {
         String logLine = "2017-04-05T09:07:18.552-0500: 201524.276: [SoftReference, 0 refs, 0.0002257 secs]"
                 + "2017-04-05T09:07:18.552-0500: 201524.277: [WeakReference, 48 refs, 0.0001397 secs]"
                 + "2017-04-05T09:07:18.552-0500: 201524.277: [FinalReference, 2813 refs, 0.0026465 secs]"

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialNewEvent.java
@@ -23,17 +23,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestSerialNewEvent {
+class TestSerialNewEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SERIAL_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs]";
         assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
@@ -49,14 +49,14 @@ public class TestSerialNewEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs] ";
         assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
     }
 
     @Test
-    public void testLogLineNoSpaceAfterGC() {
+    void testLogLineNoSpaceAfterGC() {
         String logLine = "4.296: [GC4.296: [DefNew: 68160K->8512K(76672K), 0.0528470 secs] "
                 + "68160K->11664K(1325760K), 0.0530640 secs] [Times: user=0.04 sys=0.00, real=0.05 secs]";
         assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
@@ -72,7 +72,7 @@ public class TestSerialNewEvent {
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2016-11-22T09:07:01.358+0100: 1,319: [GC2016-11-22T09:07:01.359+0100: 1,320: [DefNew: "
                 + "68160K->4425K(76672K), 0,0354890 secs] 68160K->4425K(3137216K), 0,0360580 secs] "
                 + "[Times: user=0,04 sys=0,00, real=0,03 secs]";
@@ -89,7 +89,7 @@ public class TestSerialNewEvent {
     }
 
     @Test
-    public void testLogLineWithTrigger() {
+    void testLogLineWithTrigger() {
         String logLine = "2.218: [GC (Allocation Failure) 2.218: [DefNew: 209792K->15933K(235968K), 0.0848369 secs] "
                 + "209792K->15933K(760256K), 0.0849244 secs] [Times: user=0.03 sys=0.06, real=0.08 secs]";
         assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialNewEvent.java
@@ -13,11 +13,11 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -29,50 +29,46 @@ public class TestSerialNewEvent {
     public void testIsBlocking() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs]";
-        assertTrue(JdkUtil.LogEventType.SERIAL_NEW.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SERIAL_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                SerialNewEvent.match(logLine));
+        assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
         SerialNewEvent event = new SerialNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7798, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(37172), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(3631), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(39296), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(4505), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(6683), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(87424), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 21021, event.getDuration());
+        assertEquals((long) 7798,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(37172),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(3631),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(39296),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(4505),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(6683),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(87424),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(21021,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "7.798: [GC 7.798: [DefNew: 37172K->3631K(39296K), 0.0209300 secs] "
                 + "41677K->10314K(126720K), 0.0210210 secs] ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                SerialNewEvent.match(logLine));
+        assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
     }
 
     @Test
     public void testLogLineNoSpaceAfterGC() {
         String logLine = "4.296: [GC4.296: [DefNew: 68160K->8512K(76672K), 0.0528470 secs] "
                 + "68160K->11664K(1325760K), 0.0530640 secs] [Times: user=0.04 sys=0.00, real=0.05 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                SerialNewEvent.match(logLine));
+        assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
         SerialNewEvent event = new SerialNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4296, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(68160), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(8512), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(76672), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(68160 - 68160), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(11664 - 8512), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(1325760 - 76672), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 53064, event.getDuration());
+        assertEquals((long) 4296,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(68160),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(8512),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(76672),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(68160 - 68160),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(11664 - 8512),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(1325760 - 76672),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(53064,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -80,33 +76,31 @@ public class TestSerialNewEvent {
         String logLine = "2016-11-22T09:07:01.358+0100: 1,319: [GC2016-11-22T09:07:01.359+0100: 1,320: [DefNew: "
                 + "68160K->4425K(76672K), 0,0354890 secs] 68160K->4425K(3137216K), 0,0360580 secs] "
                 + "[Times: user=0,04 sys=0,00, real=0,03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                SerialNewEvent.match(logLine));
+        assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
         SerialNewEvent event = new SerialNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1319, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(68160), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(4425), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(76672), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(68160 - 68160), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(4425 - 4425), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(3137216 - 76672), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 36058, event.getDuration());
+        assertEquals((long) 1319,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(68160),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(4425),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(76672),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(68160 - 68160),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(4425 - 4425),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(3137216 - 76672),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(36058,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithTrigger() {
         String logLine = "2.218: [GC (Allocation Failure) 2.218: [DefNew: 209792K->15933K(235968K), 0.0848369 secs] "
                 + "209792K->15933K(760256K), 0.0849244 secs] [Times: user=0.03 sys=0.06, real=0.08 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                SerialNewEvent.match(logLine));
+        assertTrue(SerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
         SerialNewEvent event = new SerialNewEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2218, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(209792), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(15933), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(235968), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(209792 - 209792), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(15933 - 15933), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(760256 - 235968), event.getOldSpace());
-        assertEquals("Duration not parsed correctly.", 84924, event.getDuration());
+        assertEquals((long) 2218,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(209792),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(15933),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(235968),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(209792 - 209792),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(15933 - 15933),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(760256 - 235968),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(84924,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialOldEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -31,8 +31,7 @@ public class TestSerialOldEvent {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]";
-        assertTrue(JdkUtil.LogEventType.SERIAL_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SERIAL_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -40,21 +39,20 @@ public class TestSerialOldEvent {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 187159, event.getTimestamp());
-        assertEquals("Trigger not parsed correctly.", null, event.getTrigger());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(55042), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(91712), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(97171), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(102832), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(815616), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(49152), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(49154), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(49158), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 692925, event.getDuration());
+        assertEquals((long) 187159,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(null,event.getTrigger(),"Trigger not parsed correctly.");
+        assertEquals(kilobytes(55042),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(91712),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(97171),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(102832),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(815616),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(49152),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(49154),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(49158),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(692925,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -62,8 +60,7 @@ public class TestSerialOldEvent {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]       ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -71,21 +68,20 @@ public class TestSerialOldEvent {
         String logLine = "2.457: [Full GC (System) 2.457: "
                 + "[Tenured: 1092K->2866K(116544K), 0.0489980 secs] 11012K->2866K(129664K), "
                 + "[Perm : 8602K->8604K(131072K)], 0.0490880 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2457, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(9920), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(13120), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(1092), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(2866), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(116544), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(8602), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(8604), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(131072), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 49088, event.getDuration());
+        assertEquals((long) 2457,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(9920),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(13120),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(1092),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(2866),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(116544),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(8602),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(8604),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(131072),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(49088,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -93,21 +89,19 @@ public class TestSerialOldEvent {
         String logLine = "3727.365: [GC 3727.365: [DefNew: 400314K->400314K(400384K), 0.0000550 secs]"
                 + "3727.365: [Tenured: 837793K->597490K(889536K), 44.7498530 secs] 1238107K->597490K(1289920K), "
                 + "[Perm : 54745K->54745K(54784K)], 44.7501880 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3727365, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1238107 - 837793),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(597490 - 597490), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1289920 - 889536), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(837793), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(597490), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(889536), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(54745), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(54745), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(54784), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 44750188, event.getDuration());
+        assertEquals((long) 3727365,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1238107 - 837793),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(597490 - 597490),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1289920 - 889536),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(837793),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(597490),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(889536),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(54745),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(54745),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(54784),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(44750188,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -116,20 +110,19 @@ public class TestSerialOldEvent {
                 + "4928K->511K(4928K), 0.0035715 secs]2017-03-26T13:16:18.684+0200: 24.300: [Tenured: "
                 + "11239K->9441K(11328K), 0.1110369 secs] 15728K->9441K(16256K), [Perm : 15599K->15599K(65536K)], "
                 + "0.1148688 secs] [Times: user=0.11 sys=0.02, real=0.13 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 24296, event.getTimestamp());
-        assertEquals("Young begin size not parsed correctly.", kilobytes(15728 - 11239), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(9441 - 9441), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(16256 - 11328), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(11239), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(9441), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(11328), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(15599), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(15599), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(65536), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 114868, event.getDuration());
+        assertEquals((long) 24296,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(15728 - 11239),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(9441 - 9441),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(16256 - 11328),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(11239),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(9441),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(11328),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(15599),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(15599),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(65536),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(114868,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -137,21 +130,20 @@ public class TestSerialOldEvent {
         String logLine = "2.447: [Full GC (Metadata GC Threshold) 2.447: [Tenured: 0K->12062K(524288K), "
                 + "0.1248607 secs] 62508K->12062K(760256K), [Metaspace: 20526K->20526K(1069056K)], 0.1249442 secs] "
                 + "[Times: user=0.18 sys=0.08, real=0.13 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2447, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(62508 - 0), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(12062 - 12062), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(760256 - 524288), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(12062), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(524288), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(20526), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(20526), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1069056), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 124944, event.getDuration());
+        assertEquals((long) 2447,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(62508 - 0),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(12062 - 12062),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(760256 - 524288),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(12062),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(20526),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(20526),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1069056),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(124944,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -160,22 +152,20 @@ public class TestSerialOldEvent {
                 + "0.0000182 secs]38.922: [Tenured: 459834K->79151K(524288K), 0.2871383 secs] "
                 + "689404K->79151K(760256K), [Metaspace: 68373K->68373K(1114112K)], 0.2881307 secs] "
                 + "[Times: user=0.30 sys=0.00, real=0.29 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 38922, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(689404 - 459834),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(79151 - 79151), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(760256 - 524288), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(459834), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(79151), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(524288), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(68373), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(68373), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1114112), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 288130, event.getDuration());
+        assertEquals((long) 38922,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(689404 - 459834),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(79151 - 79151),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(760256 - 524288),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(459834),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(79151),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(68373),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(68373),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1114112),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(288130,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -184,21 +174,19 @@ public class TestSerialOldEvent {
                 + "229660K->235967K(235968K), 0.2897884 secs]117.247: [Tenured: 524288K->144069K(524288K), "
                 + "0.3905008 secs] 674654K->144069K(760256K), [Metaspace: 65384K->65384K(1114112K)], 0.6804246 secs] "
                 + "[Times: user=0.67 sys=0.01, real=0.69 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".",
-                SerialOldEvent.match(logLine));
+        assertTrue(SerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_OLD.toString() + ".");
         SerialOldEvent event = new SerialOldEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 116957, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(674654 - 524288),
-                event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(144069 - 144069), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(760256 - 524288), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(524288), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(144069), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(524288), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(65384), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(65384), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1114112), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 680424, event.getDuration());
+        assertEquals((long) 116957,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_PROMOTION_FAILED), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(674654 - 524288),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(144069 - 144069),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(760256 - 524288),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(144069),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(524288),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(65384),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(65384),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1114112),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(680424,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestSerialOldEvent.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestSerialOldEvent {
+class TestSerialOldEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]";
@@ -35,7 +35,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]";
@@ -56,7 +56,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "187.159: [Full GC 187.160: "
                 + "[Tenured: 97171K->102832K(815616K), 0.6977443 secs] 152213K->102832K(907328K), "
                 + "[Perm : 49152K->49154K(49158K)], 0.6929258 secs]       ";
@@ -64,7 +64,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineJdk16WithTrigger() {
+    void testLogLineJdk16WithTrigger() {
         String logLine = "2.457: [Full GC (System) 2.457: "
                 + "[Tenured: 1092K->2866K(116544K), 0.0489980 secs] 11012K->2866K(129664K), "
                 + "[Perm : 8602K->8604K(131072K)], 0.0490880 secs]";
@@ -85,7 +85,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineWithSerialNewBlock() {
+    void testLogLineWithSerialNewBlock() {
         String logLine = "3727.365: [GC 3727.365: [DefNew: 400314K->400314K(400384K), 0.0000550 secs]"
                 + "3727.365: [Tenured: 837793K->597490K(889536K), 44.7498530 secs] 1238107K->597490K(1289920K), "
                 + "[Perm : 54745K->54745K(54784K)], 44.7501880 secs]";
@@ -105,7 +105,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineWithDateStamps() {
+    void testLogLineWithDateStamps() {
         String logLine = "2017-03-26T13:16:18.668+0200: 24.296: [GC2017-03-26T13:16:18.668+0200: 24.296: [DefNew: "
                 + "4928K->511K(4928K), 0.0035715 secs]2017-03-26T13:16:18.684+0200: 24.300: [Tenured: "
                 + "11239K->9441K(11328K), 0.1110369 secs] 15728K->9441K(16256K), [Perm : 15599K->15599K(65536K)], "
@@ -126,7 +126,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineFullGcWithMetadatGcThresholdTrigger() {
+    void testLogLineFullGcWithMetadatGcThresholdTrigger() {
         String logLine = "2.447: [Full GC (Metadata GC Threshold) 2.447: [Tenured: 0K->12062K(524288K), "
                 + "0.1248607 secs] 62508K->12062K(760256K), [Metaspace: 20526K->20526K(1069056K)], 0.1249442 secs] "
                 + "[Times: user=0.18 sys=0.08, real=0.13 secs]";
@@ -147,7 +147,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineGcWithAllocationFailureTrigger() {
+    void testLogLineGcWithAllocationFailureTrigger() {
         String logLine = "38.922: [GC (Allocation Failure) 38.922: [DefNew: 229570K->229570K(235968K), "
                 + "0.0000182 secs]38.922: [Tenured: 459834K->79151K(524288K), 0.2871383 secs] "
                 + "689404K->79151K(760256K), [Metaspace: 68373K->68373K(1114112K)], 0.2881307 secs] "
@@ -169,7 +169,7 @@ public class TestSerialOldEvent {
     }
 
     @Test
-    public void testLogLineGcPromotionFailedTrigger() {
+    void testLogLineGcPromotionFailedTrigger() {
         String logLine = "116.957: [GC (Allocation Failure) 116.957: [DefNew (promotion failed) : "
                 + "229660K->235967K(235968K), 0.2897884 secs]117.247: [Tenured: 524288K->144069K(524288K), "
                 + "0.3905008 secs] 674654K->144069K(760256K), [Metaspace: 65384K->65384K(1114112K)], 0.6804246 secs] "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahCancellingGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahCancellingGcEvent.java
@@ -27,58 +27,58 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahCancellingGcEvent {
+class TestShenandoahCancellingGcEvent {
 
     @Test
-    public void testLineJdk8() {
+    void testLineJdk8() {
         String logLine = "Cancelling GC: Stopping VM";
         assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
-    public void testLineUnified() {
+    void testLineUnified() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
         assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahCancellingGcEvent, JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CANCELLING_GC);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testUnifiedDetailed() {
+    void testUnifiedDetailed() {
         String logLine = "[69.941s][info][gc           ] Cancelling GC: Stopping VM";
         assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
-    public void testUnifiedUptimeMillis() {
+    void testUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.997-0200][1357909ms] Cancelling GC: Stopping VM";
         assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahCancellingGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahCancellingGcEvent.java
@@ -11,10 +11,9 @@
  *    Mike Millson - initial API and implementation                                                                   *
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +21,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,64 +32,54 @@ public class TestShenandoahCancellingGcEvent {
     @Test
     public void testLineJdk8() {
         String logLine = "Cancelling GC: Stopping VM";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".",
-                ShenandoahCancellingGcEvent.match(logLine));
+        assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
     public void testLineUnified() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".",
-                ShenandoahCancellingGcEvent.match(logLine));
+        assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahCancellingGcEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahCancellingGcEvent, JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[72.659s][info][gc] Cancelling GC: Stopping VM";
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(
-                JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CANCELLING_GC);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testUnifiedDetailed() {
         String logLine = "[69.941s][info][gc           ] Cancelling GC: Stopping VM";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".",
-                ShenandoahCancellingGcEvent.match(logLine));
+        assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 
     @Test
     public void testUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.997-0200][1357909ms] Cancelling GC: Stopping VM";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".",
-                ShenandoahCancellingGcEvent.match(logLine));
+        assertTrue(ShenandoahCancellingGcEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CANCELLING_GC.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConcurrentEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestShenandoahConcurrentEvent {
+class TestShenandoahConcurrentEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.364-0400: 0.426: [Concurrent reset 16434K->16466K(21248K), 0.091 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
@@ -49,7 +49,7 @@ public class TestShenandoahConcurrentEvent {
     }
 
     @Test
-    public void testLogLineUnified() {
+    void testLogLineUnified() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
@@ -61,7 +61,7 @@ public class TestShenandoahConcurrentEvent {
     }
 
     @Test
-    public void testLogLineJdk8PreprocessedWithMetaspace() {
+    void testLogLineJdk8PreprocessedWithMetaspace() {
         String logLine = "2020-08-21T09:40:29.929-0400: 0.467: [Concurrent cleanup 21278K->4701K(37888K), 0.048 ms]"
                 + ", [Metaspace: 6477K->6481K(1056768K)]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
@@ -77,163 +77,163 @@ public class TestShenandoahConcurrentEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CONCURRENT + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahConcurrentEvent, JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CONCURRENT);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testJdk8Marking() {
+    void testJdk8Marking() {
         String logLine = "2020-03-10T08:03:29.365-0400: 0.427: [Concurrent marking 16498K->17020K(21248K), 2.462 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMarking() {
+    void testUnifiedMarking() {
         String logLine = "[0.528s][info][gc] GC(1) Concurrent marking 16M->17M(64M) 7.045ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8MarkingProcessWeakrefs() {
+    void testJdk8MarkingProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.315-0400: 0.377: [Concurrent marking (process weakrefs) "
                 + "17759K->19325K(19456K), 6.892 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMarkingProcessWeakrefs() {
+    void testUnifiedMarkingProcessWeakrefs() {
         String logLine = "[0.454s][info][gc] GC(0) Concurrent marking (process weakrefs) 17M->19M(64M) 15.264ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8MarkingUpdateRefs() {
+    void testJdk8MarkingUpdateRefs() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent update references 9862K->12443K(23296K), "
                 + "3.463 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMarkingUpdateRefs() {
+    void testUnifiedMarkingUpdateRefs() {
         String logLine = "[10.458s][info][gc] GC(279) Concurrent marking (update refs) 47M->48M(64M) 5.559ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8MarkingUpdateRefsProcessWeakrefs() {
+    void testJdk8MarkingUpdateRefsProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.315-0400: 0.377: [Concurrent marking (process weakrefs) "
                 + "17759K->19325K(19456K), 6.892 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedMarkingUpdateRefsProcessWeakrefs() {
+    void testUnifiedMarkingUpdateRefsProcessWeakrefs() {
         String logLine = "[11.012s][info][gc] GC(300) Concurrent marking (update refs) (process weakrefs) "
                 + "49M->49M(64M) 5.416ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8Precleaning() {
+    void testJdk8Precleaning() {
         String logLine = "2020-03-10T08:03:29.322-0400: 0.384: [Concurrent precleaning 19325K->19357K(19456K), "
                 + "0.092 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedPrecleaning() {
+    void testUnifiedPrecleaning() {
         String logLine = "[0.455s][info][gc] GC(0) Concurrent precleaning 19M->19M(64M) 0.202ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8Evacuation() {
+    void testJdk8Evacuation() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent evacuation 9712K->9862K(23296K), 0.144 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedEvacuation() {
+    void testUnifiedEvacuation() {
         String logLine = "[0.465s][info][gc] GC(0) Concurrent evacuation 17M->19M(64M) 6.528ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8UpdateReferences() {
+    void testJdk8UpdateReferences() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent update references 9862K->12443K(23296K), "
                 + "3.463 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedUpdateReferences() {
+    void testUnifiedUpdateReferences() {
         String logLine = "[0.470s][info][gc] GC(0) Concurrent update references 19M->19M(64M) 4.708ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testJdk8Cleanup() {
+    void testJdk8Cleanup() {
         String logLine = "2020-03-10T08:03:29.431-0400: 0.493: [Concurrent cleanup 12501K->8434K(23296K), 0.034 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedCleanup() {
+    void testUnifiedCleanup() {
         String logLine = "[0.472s][info][gc] GC(0) Concurrent cleanup 18M->15M(64M) 0.036ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testResetNoSizes() {
+    void testResetNoSizes() {
         String logLine = "[41.892s][info][gc,start     ] GC(1500) Concurrent reset";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedDetailsResetNoSizes() {
+    void testUnifiedDetailsResetNoSizes() {
         String logLine = "2020-08-13T16:38:29.318+0000: 432034.969: [Concurrent reset, 26.427 ms]";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedDetailsReset() {
+    void testUnifiedDetailsReset() {
         String logLine = "[41.893s][info][gc           ] GC(1500) Concurrent reset 50M->50M(64M) 0.126ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedUptimeMillis() {
+    void testUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] GC(0) Concurrent reset";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedUncommitUptimeMillis() {
+    void testUnifiedUncommitUptimeMillis() {
         String logLine = "[2019-02-05T14:52:31.138-0200][300050ms] Concurrent uncommit 874M->874M(1303M) 5.654ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
@@ -245,13 +245,13 @@ public class TestShenandoahConcurrentEvent {
     }
 
     @Test
-    public void testUnifiedUncommitUptimeMillisNoGcEventNumber() {
+    void testUnifiedUncommitUptimeMillisNoGcEventNumber() {
         String logLine = "[2019-02-05T14:52:31.132-0200][300044ms] Concurrent uncommit";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUnifiedPreprocessedWithMetaspace() {
+    void testUnifiedPreprocessedWithMetaspace() {
         String logLine = "[0.484s][info][gc           ] GC(0) Concurrent cleanup 24M->10M(34M) 0.051ms Metaspace: "
                 + "3231K->3239K(1056768K)";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
@@ -267,7 +267,7 @@ public class TestShenandoahConcurrentEvent {
     }
 
     @Test
-    public void testUnifiedUnloadClasses() {
+    void testUnifiedUnloadClasses() {
         String logLine = "[5.601s][info][gc           ] GC(99) Concurrent marking (unload classes) 7.346ms";
         assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
@@ -276,7 +276,7 @@ public class TestShenandoahConcurrentEvent {
      * Test max heap space and occupancy data.
      */
     @Test
-    public void testUnifiedMaxHeapData() {
+    void testUnifiedMaxHeapData() {
         File testFile = TestUtil.getFile("dataset167.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConcurrentEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -29,7 +29,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,273 +39,237 @@ public class TestShenandoahConcurrentEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.364-0400: 0.426: [Concurrent reset 16434K->16466K(21248K), 0.091 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 426, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(16434), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(16466), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(21248), event.getCombinedSpace());
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 426,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(16434),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(16466),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(21248),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnified() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 437 - 4, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(15 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(16 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(64 * 1024), event.getCombinedSpace());
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (437 - 4),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(15 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(16 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(64 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
     }
 
     @Test
     public void testLogLineJdk8PreprocessedWithMetaspace() {
         String logLine = "2020-08-21T09:40:29.929-0400: 0.467: [Concurrent cleanup 21278K->4701K(37888K), 0.048 ms]"
                 + ", [Metaspace: 6477K->6481K(1056768K)]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 467, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(21278), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(4701), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(37888), event.getCombinedSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(6477), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(6481), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 467,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(21278),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(4701),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(37888),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(kilobytes(6477),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(6481),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_CONCURRENT, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CONCURRENT + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahConcurrentEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahConcurrentEvent, JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.437s][info][gc] GC(0) Concurrent reset 15M->16M(64M) 4.701ms";
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CONCURRENT);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testJdk8Marking() {
         String logLine = "2020-03-10T08:03:29.365-0400: 0.427: [Concurrent marking 16498K->17020K(21248K), 2.462 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedMarking() {
         String logLine = "[0.528s][info][gc] GC(1) Concurrent marking 16M->17M(64M) 7.045ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8MarkingProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.315-0400: 0.377: [Concurrent marking (process weakrefs) "
                 + "17759K->19325K(19456K), 6.892 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedMarkingProcessWeakrefs() {
         String logLine = "[0.454s][info][gc] GC(0) Concurrent marking (process weakrefs) 17M->19M(64M) 15.264ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8MarkingUpdateRefs() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent update references 9862K->12443K(23296K), "
                 + "3.463 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedMarkingUpdateRefs() {
         String logLine = "[10.458s][info][gc] GC(279) Concurrent marking (update refs) 47M->48M(64M) 5.559ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8MarkingUpdateRefsProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.315-0400: 0.377: [Concurrent marking (process weakrefs) "
                 + "17759K->19325K(19456K), 6.892 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedMarkingUpdateRefsProcessWeakrefs() {
         String logLine = "[11.012s][info][gc] GC(300) Concurrent marking (update refs) (process weakrefs) "
                 + "49M->49M(64M) 5.416ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8Precleaning() {
         String logLine = "2020-03-10T08:03:29.322-0400: 0.384: [Concurrent precleaning 19325K->19357K(19456K), "
                 + "0.092 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedPrecleaning() {
         String logLine = "[0.455s][info][gc] GC(0) Concurrent precleaning 19M->19M(64M) 0.202ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8Evacuation() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent evacuation 9712K->9862K(23296K), 0.144 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedEvacuation() {
         String logLine = "[0.465s][info][gc] GC(0) Concurrent evacuation 17M->19M(64M) 6.528ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8UpdateReferences() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Concurrent update references 9862K->12443K(23296K), "
                 + "3.463 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedUpdateReferences() {
         String logLine = "[0.470s][info][gc] GC(0) Concurrent update references 19M->19M(64M) 4.708ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testJdk8Cleanup() {
         String logLine = "2020-03-10T08:03:29.431-0400: 0.493: [Concurrent cleanup 12501K->8434K(23296K), 0.034 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedCleanup() {
         String logLine = "[0.472s][info][gc] GC(0) Concurrent cleanup 18M->15M(64M) 0.036ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testResetNoSizes() {
         String logLine = "[41.892s][info][gc,start     ] GC(1500) Concurrent reset";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedDetailsResetNoSizes() {
         String logLine = "2020-08-13T16:38:29.318+0000: 432034.969: [Concurrent reset, 26.427 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedDetailsReset() {
         String logLine = "[41.893s][info][gc           ] GC(1500) Concurrent reset 50M->50M(64M) 0.126ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] GC(0) Concurrent reset";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedUncommitUptimeMillis() {
         String logLine = "[2019-02-05T14:52:31.138-0200][300050ms] Concurrent uncommit 874M->874M(1303M) 5.654ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 300050 - 5, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(874 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(874 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1303 * 1024),
-                event.getCombinedSpace());
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (300050 - 5),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(874 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(874 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1303 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
     }
 
     @Test
     public void testUnifiedUncommitUptimeMillisNoGcEventNumber() {
         String logLine = "[2019-02-05T14:52:31.132-0200][300044ms] Concurrent uncommit";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUnifiedPreprocessedWithMetaspace() {
         String logLine = "[0.484s][info][gc           ] GC(0) Concurrent cleanup 24M->10M(34M) 0.051ms Metaspace: "
                 + "3231K->3239K(1056768K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
         ShenandoahConcurrentEvent event = new ShenandoahConcurrentEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 484 - 0, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(24 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(10 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(34 * 1024), event.getCombinedSpace());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(3231), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(3239), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (484 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(24 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(10 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(34 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(kilobytes(3231),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(3239),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
     }
 
     @Test
     public void testUnifiedUnloadClasses() {
         String logLine = "[5.601s][info][gc           ] GC(99) Concurrent marking (unload classes) 7.346ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".",
-                ShenandoahConcurrentEvent.match(logLine));
+        assertTrue(ShenandoahConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -318,11 +282,8 @@ public class TestShenandoahConcurrentEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Max heap occupancy for a non blocking event not parsed correctly.", kilobytes(19 * 1024),
-                jvmRun.getMaxHeapOccupancyNonBlocking());
-        assertEquals("Max heap space for a non blocking event not parsed correctly.", kilobytes(33 * 1024),
-                jvmRun.getMaxHeapSpaceNonBlocking());
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(kilobytes(19 * 1024),jvmRun.getMaxHeapOccupancyNonBlocking(),"Max heap occupancy for a non blocking event not parsed correctly.");
+        assertEquals(kilobytes(33 * 1024),jvmRun.getMaxHeapSpaceNonBlocking(),"Max heap space for a non blocking event not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConsiderClUnloadConcMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConsiderClUnloadConcMarkEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -34,77 +34,65 @@ public class TestShenandoahConsiderClUnloadConcMarkEvent {
     public void testLineUnifie() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
-        assertTrue(
-                "Log line not recognized as "
-                        + JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".",
-                ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine));
+        assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "
+		+ JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".");
         ShenandoahConsiderClassUnloadingConcMarkEvent event = new ShenandoahConsiderClassUnloadingConcMarkEvent(
                 logLine);
-        assertEquals("Time stamp not parsed correctly.", 1, event.getTimestamp());
+        assertEquals((long) 1,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahConsiderClassUnloadingConcMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahConsiderClassUnloadingConcMarkEvent, JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
-        assertFalse(
-                JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
-                        + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
+		+ " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(
-                JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
-                        + " indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
+		+ " indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
-                + " incorrectly indentified as unified.", UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
+		+ " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads     ";
-        assertTrue(
-                "Log line not recognized as "
-                        + JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".",
-                ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine));
+        assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "
+		+ JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".");
     }
 
     @Test
     public void testLineTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.090-0200][2ms] Consider -XX:+ClassUnloadingWithConcurrentMark if large "
                 + "pause times are observed on class-unloading sensitive workloads";
-        assertTrue(
-                "Log line not recognized as "
-                        + JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".",
-                ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine));
+        assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "
+		+ JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + ".");
         ShenandoahConsiderClassUnloadingConcMarkEvent event = new ShenandoahConsiderClassUnloadingConcMarkEvent(
                 logLine);
-        assertEquals("Time stamp not parsed correctly.", 2, event.getTimestamp());
+        assertEquals((long) 2,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConsiderClUnloadConcMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahConsiderClUnloadConcMarkEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahConsiderClUnloadConcMarkEvent {
+class TestShenandoahConsiderClUnloadConcMarkEvent {
 
     @Test
-    public void testLineUnifie() {
+    void testLineUnifie() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
         assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "
@@ -42,21 +42,21 @@ public class TestShenandoahConsiderClUnloadConcMarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahConsiderClassUnloadingConcMarkEvent, JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
@@ -64,13 +64,13 @@ public class TestShenandoahConsiderClUnloadConcMarkEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
 		+ " indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_CONSIDER_CLASS_UNLOADING_CONC_MARK.toString()
@@ -78,7 +78,7 @@ public class TestShenandoahConsiderClUnloadConcMarkEvent {
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.001s][info][gc] Consider -XX:+ClassUnloadingWithConcurrentMark if large pause times are "
                 + "observed on class-unloading sensitive workloads     ";
         assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "
@@ -86,7 +86,7 @@ public class TestShenandoahConsiderClUnloadConcMarkEvent {
     }
 
     @Test
-    public void testLineTimeUptimemillis() {
+    void testLineTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.090-0200][2ms] Consider -XX:+ClassUnloadingWithConcurrentMark if large "
                 + "pause times are observed on class-unloading sensitive workloads";
         assertTrue(ShenandoahConsiderClassUnloadingConcMarkEvent.match(logLine), "Log line not recognized as "

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahDegeneratedGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahDegeneratedGcEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahDegeneratedGcEvent {
+class TestShenandoahDegeneratedGcEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
         ShenandoahDegeneratedGcMarkEvent event = new ShenandoahDegeneratedGcMarkEvent(logLine);
@@ -44,25 +44,25 @@ public class TestShenandoahDegeneratedGcEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahDegeneratedGcMarkEvent, JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK;
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         long timestamp = 521;
@@ -72,26 +72,26 @@ public class TestShenandoahDegeneratedGcEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_DEGENERATED_GC_MARK);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) "
                 + "53.697ms   ";
         assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineNotUnified() {
+    void testLogLineNotUnified() {
         String logLine = "2020-08-18T14:05:42.515+0000: 854868.165: [Pause Degenerated GC (Mark) "
                 + "93058M->29873M(98304M), 1285.045 ms]";
         assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
@@ -104,7 +104,7 @@ public class TestShenandoahDegeneratedGcEvent {
     }
 
     @Test
-    public void testLogLineMetaspace() {
+    void testLogLineMetaspace() {
         String logLine = "[2020-10-26T14:51:41.413-0400] GC(413) Pause Degenerated GC (Mark) 90M->12M(96M) 27.501ms "
                 + "Metaspace: 3963K->3963K(1056768K)";
         assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
@@ -120,7 +120,7 @@ public class TestShenandoahDegeneratedGcEvent {
     }
 
     @Test
-    public void testLogLineTriggerOutsideOfCycle() {
+    void testLogLineTriggerOutsideOfCycle() {
         String logLine = "[8.084s] GC(136) Pause Degenerated GC (Outside of Cycle) 90M->6M(96M) 23.018ms "
                 + "Metaspace: 3847K->3847K(1056768K)";
         assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahDegeneratedGcEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahDegeneratedGcEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -34,36 +34,31 @@ public class TestShenandoahDegeneratedGcEvent {
     @Test
     public void testLogLine() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".",
-                ShenandoahDegeneratedGcMarkEvent.match(logLine));
+        assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
         ShenandoahDegeneratedGcMarkEvent event = new ShenandoahDegeneratedGcMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 52937 - 53, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(60 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(30 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(64 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 53697, event.getDuration());
+        assertEquals((long) (52937 - 53),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(60 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(64 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(53697,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahDegeneratedGcMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahDegeneratedGcMarkEvent, JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -72,84 +67,71 @@ public class TestShenandoahDegeneratedGcEvent {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) 53.697ms";
         long timestamp = 521;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
-                        duration) instanceof ShenandoahDegeneratedGcMarkEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
+		duration) instanceof ShenandoahDegeneratedGcMarkEvent, JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_DEGENERATED_GC_MARK);
-        assertFalse(
-                JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[52.937s][info][gc           ] GC(1632) Pause Degenerated GC (Mark) 60M->30M(64M) "
                 + "53.697ms   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".",
-                ShenandoahDegeneratedGcMarkEvent.match(logLine));
+        assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineNotUnified() {
         String logLine = "2020-08-18T14:05:42.515+0000: 854868.165: [Pause Degenerated GC (Mark) "
                 + "93058M->29873M(98304M), 1285.045 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".",
-                ShenandoahDegeneratedGcMarkEvent.match(logLine));
+        assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
         ShenandoahDegeneratedGcMarkEvent event = new ShenandoahDegeneratedGcMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 854868165, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(93058 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(29873 * 1024),
-                event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(98304 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1285045, event.getDuration());
+        assertEquals((long) 854868165,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(93058 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(29873 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(98304 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1285045,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineMetaspace() {
         String logLine = "[2020-10-26T14:51:41.413-0400] GC(413) Pause Degenerated GC (Mark) 90M->12M(96M) 27.501ms "
                 + "Metaspace: 3963K->3963K(1056768K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".",
-                ShenandoahDegeneratedGcMarkEvent.match(logLine));
+        assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
         ShenandoahDegeneratedGcMarkEvent event = new ShenandoahDegeneratedGcMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 657035501386L, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(90 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(96 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 27501, event.getDuration());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(3963), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(3963), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
+        assertEquals(657035501386L,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(90 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(96 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(27501,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(kilobytes(3963),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(3963),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerOutsideOfCycle() {
         String logLine = "[8.084s] GC(136) Pause Degenerated GC (Outside of Cycle) 90M->6M(96M) 23.018ms "
                 + "Metaspace: 3847K->3847K(1056768K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".",
-                ShenandoahDegeneratedGcMarkEvent.match(logLine));
+        assertTrue(ShenandoahDegeneratedGcMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_DEGENERATED_GC_MARK.toString() + ".");
         ShenandoahDegeneratedGcMarkEvent event = new ShenandoahDegeneratedGcMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 8084 - 23, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(90 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(6 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(96 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 23018, event.getDuration());
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(3847), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(3847), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
+        assertEquals((long) (8084 - 23),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(90 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(6 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(96 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(23018,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(kilobytes(3847),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(3847),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalEvacEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalEvacEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,42 +33,37 @@ public class TestShenandoahFinalEvacEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:46.251-0400: 17.313: [Pause Final Evac, 0.009 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".",
-                ShenandoahFinalEvacEvent.match(logLine));
+        assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 17313, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 9, event.getDuration());
+        assertEquals((long) 17313,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(9,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnified() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".",
-                ShenandoahFinalEvacEvent.match(logLine));
+        assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 10486 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 2, event.getDuration());
+        assertEquals((long) (10486 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(2,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalEvacEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalEvacEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -77,38 +72,34 @@ public class TestShenandoahFinalEvacEvent {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         long timestamp = 521;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalEvacEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalEvacEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_EVAC);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".",
-                ShenandoahFinalEvacEvent.match(logLine));
+        assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedDetailed() {
         String logLine = "[41.912s][info][gc           ] GC(1500) Pause Final Evac 0.022ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".",
-                ShenandoahFinalEvacEvent.match(logLine));
+        assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 41912 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 22, event.getDuration());
+        assertEquals((long) (41912 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(22,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalEvacEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalEvacEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahFinalEvacEvent {
+class TestShenandoahFinalEvacEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:46.251-0400: 17.313: [Pause Final Evac, 0.009 ms]";
         assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);
@@ -40,7 +40,7 @@ public class TestShenandoahFinalEvacEvent {
     }
 
     @Test
-    public void testLogLineUnified() {
+    void testLogLineUnified() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);
@@ -49,25 +49,25 @@ public class TestShenandoahFinalEvacEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalEvacEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC;
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms";
         long timestamp = 521;
@@ -77,25 +77,25 @@ public class TestShenandoahFinalEvacEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_EVAC);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[10.486s][info][gc] GC(280) Pause Final Evac 0.002ms    ";
         assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedDetailed() {
+    void testLogLineUnifiedDetailed() {
         String logLine = "[41.912s][info][gc           ] GC(1500) Pause Final Evac 0.022ms";
         assertTrue(ShenandoahFinalEvacEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + ".");
         ShenandoahFinalEvacEvent event = new ShenandoahFinalEvacEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalMarkEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,42 +33,37 @@ public class TestShenandoahFinalMarkEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Pause Final Mark, 0.313 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 489, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 313, event.getDuration());
+        assertEquals((long) 489,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(313,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUnified() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 531 - 1, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 1004, event.getDuration());
+        assertEquals((long) (531 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(1004,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalMarkEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -77,109 +72,98 @@ public class TestShenandoahFinalMarkEvent {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         long timestamp = 456;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalMarkEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalMarkEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_MARK);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " inocrrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " inocrrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineUnifiedWhitespaceAtEnd() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.491-0400: 0.553: [Pause Final Mark (process weakrefs), 0.508 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 553, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 508, event.getDuration());
+        assertEquals((long) 553,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(508,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedProcessWeakrefs() {
         String logLine = "[0.472s][info][gc] GC(0) Pause Final Mark (process weakrefs) 1.772ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 472 - 1, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 1772, event.getDuration());
+        assertEquals((long) (472 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(1772,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineJdk8UpdateRefs() {
         String logLine = "2020-03-10T08:03:46.283-0400: 17.345: [Pause Final Mark (update refs), 0.659 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 17345, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 659, event.getDuration());
+        assertEquals((long) 17345,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(659,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUpdateRefs() {
         String logLine = "[10.459s][info][gc] GC(279) Pause Final Mark (update refs) 0.253ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 10459 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 253, event.getDuration());
+        assertEquals((long) (10459 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(253,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
         String logLine = "[11.012s][info][gc] GC(300) Pause Final Mark (update refs) (process weakrefs) 0.200ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 11012 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 200, event.getDuration());
+        assertEquals((long) (11012 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(200,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedDetailed() {
         String logLine = "[41.911s][info][gc           ] GC(1500) Pause Final Mark (update refs) (process weakrefs) "
                 + "0.429ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 41911 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 429, event.getDuration());
+        assertEquals((long) (41911 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(429,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.202-0200][3114ms] GC(0) Pause Final Mark (process weakrefs) 2.517ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3114 - 2, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 2517, event.getDuration());
+        assertEquals((long) (3114 - 2),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(2517,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnloadClasses() {
         String logLine = "[5.602s][info][gc            ] GC(99) Pause Final Mark (unload classes) 1.561ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".",
-                ShenandoahFinalMarkEvent.match(logLine));
+        assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 5602 - 1, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 1561, event.getDuration());
+        assertEquals((long) (5602 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(1561,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalMarkEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahFinalMarkEvent {
+class TestShenandoahFinalMarkEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.427-0400: 0.489: [Pause Final Mark, 0.313 ms]";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -40,7 +40,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUnified() {
+    void testLogLineUnifiedUnified() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -49,25 +49,25 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalMarkEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK;
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms";
         long timestamp = 456;
@@ -77,25 +77,25 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_MARK);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " inocrrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineUnifiedWhitespaceAtEnd() {
+    void testLogLineUnifiedWhitespaceAtEnd() {
         String logLine = "[0.531s][info][gc] GC(1) Pause Final Mark 1.004ms   ";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ProcessWeakrefs() {
+    void testLogLineJdk8ProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.491-0400: 0.553: [Pause Final Mark (process weakrefs), 0.508 ms]";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -104,7 +104,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedProcessWeakrefs() {
+    void testLogLineUnifiedProcessWeakrefs() {
         String logLine = "[0.472s][info][gc] GC(0) Pause Final Mark (process weakrefs) 1.772ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -113,7 +113,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineJdk8UpdateRefs() {
+    void testLogLineJdk8UpdateRefs() {
         String logLine = "2020-03-10T08:03:46.283-0400: 17.345: [Pause Final Mark (update refs), 0.659 ms]";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -122,7 +122,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUpdateRefs() {
+    void testLogLineUnifiedUpdateRefs() {
         String logLine = "[10.459s][info][gc] GC(279) Pause Final Mark (update refs) 0.253ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -131,7 +131,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
+    void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
         String logLine = "[11.012s][info][gc] GC(300) Pause Final Mark (update refs) (process weakrefs) 0.200ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -140,7 +140,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedDetailed() {
+    void testLogLineUnifiedDetailed() {
         String logLine = "[41.911s][info][gc           ] GC(1500) Pause Final Mark (update refs) (process weakrefs) "
                 + "0.429ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
@@ -150,7 +150,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUptimeMillis() {
+    void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.202-0200][3114ms] GC(0) Pause Final Mark (process weakrefs) 2.517ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);
@@ -159,7 +159,7 @@ public class TestShenandoahFinalMarkEvent {
     }
 
     @Test
-    public void testLogLineUnloadClasses() {
+    void testLogLineUnloadClasses() {
         String logLine = "[5.602s][info][gc            ] GC(99) Pause Final Mark (unload classes) 1.561ms";
         assertTrue(ShenandoahFinalMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + ".");
         ShenandoahFinalMarkEvent event = new ShenandoahFinalMarkEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalUpdateEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalUpdateEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahFinalUpdateEvent {
+class TestShenandoahFinalUpdateEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:47.442-0400: 18.504: [Pause Final Update Refs, 0.206 ms]";
         assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
@@ -40,7 +40,7 @@ public class TestShenandoahFinalUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnified() {
+    void testLogLineUnified() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
@@ -49,25 +49,25 @@ public class TestShenandoahFinalUpdateEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE;
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         long timestamp = 521;
@@ -77,25 +77,25 @@ public class TestShenandoahFinalUpdateEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_UPDATE);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms    ";
         assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedDetailed() {
+    void testLogLineUnifiedDetailed() {
         String logLine = "[69.644s][info][gc           ] GC(2582) Pause Final Update Refs 0.302ms";
         assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
@@ -104,7 +104,7 @@ public class TestShenandoahFinalUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUptimeMillis() {
+    void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.249-0200][3161ms] GC(0) Pause Final Update Refs 0.998ms";
         assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalUpdateEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahFinalUpdateEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,42 +33,37 @@ public class TestShenandoahFinalUpdateEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:47.442-0400: 18.504: [Pause Final Update Refs, 0.206 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".",
-                ShenandoahFinalUpdateEvent.match(logLine));
+        assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 18504, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 206, event.getDuration());
+        assertEquals((long) 18504,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(206,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnified() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".",
-                ShenandoahFinalUpdateEvent.match(logLine));
+        assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 1030 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 97, event.getDuration());
+        assertEquals((long) (1030 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(97,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalUpdateEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahFinalUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -77,48 +72,43 @@ public class TestShenandoahFinalUpdateEvent {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms";
         long timestamp = 521;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalUpdateEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahFinalUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_FINAL_UPDATE);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[1.030s][info][gc] GC(10) Pause Final Update Refs 0.097ms    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".",
-                ShenandoahFinalUpdateEvent.match(logLine));
+        assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedDetailed() {
         String logLine = "[69.644s][info][gc           ] GC(2582) Pause Final Update Refs 0.302ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".",
-                ShenandoahFinalUpdateEvent.match(logLine));
+        assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 69644 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 302, event.getDuration());
+        assertEquals((long) (69644 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(302,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.249-0200][3161ms] GC(0) Pause Final Update Refs 0.998ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".",
-                ShenandoahFinalUpdateEvent.match(logLine));
+        assertTrue(ShenandoahFinalUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + ".");
         ShenandoahFinalUpdateEvent event = new ShenandoahFinalUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3161 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 998, event.getDuration());
+        assertEquals((long) (3161 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(998,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitMarkEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahInitMarkEvent {
+class TestShenandoahInitMarkEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.365-0400: 0.427: [Pause Init Mark, 0.419 ms]";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -40,7 +40,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnified() {
+    void testLogLineUnified() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -49,25 +49,25 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_INIT_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitMarkEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_INIT_MARK;
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         long timestamp = 521;
@@ -77,25 +77,25 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_INIT_MARK);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms   ";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ProcessWeakrefs() {
+    void testLogLineJdk8ProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.489-0400: 0.551: [Pause Init Mark (process weakrefs), 0.314 ms]";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -104,7 +104,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedProcessWeakrefs() {
+    void testLogLineUnifiedProcessWeakrefs() {
         String logLine = "[0.456s][info][gc] GC(0) Pause Init Mark (process weakrefs) 0.868ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -113,7 +113,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUpdateRefs() {
+    void testLogLineUnifiedUpdateRefs() {
         String logLine = "[10.453s][info][gc] GC(279) Pause Init Mark (update refs) 0.244ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -122,7 +122,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
+    void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
         String logLine = "[11.006s][info][gc] GC(300) Pause Init Mark (update refs) (process weakrefs) 0.266ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -131,7 +131,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedDetailed() {
+    void testLogLineUnifiedDetailed() {
         String logLine = "[41.893s][info][gc           ] GC(1500) Pause Init Mark (update refs) "
                 + "(process weakrefs) 0.295ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
@@ -141,7 +141,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUptimeMillis() {
+    void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.178-0200][3090ms] GC(0) Pause Init Mark (process weakrefs) 2.904ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
@@ -150,7 +150,7 @@ public class TestShenandoahInitMarkEvent {
     }
 
     @Test
-    public void testLogLineUnifiedUnloadClasses() {
+    void testLogLineUnifiedUnloadClasses() {
         String logLine = "[5.593s][info][gc           ] GC(99) Pause Init Mark (unload classes) 0.088ms";
         assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitMarkEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,42 +33,37 @@ public class TestShenandoahInitMarkEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:29.365-0400: 0.427: [Pause Init Mark, 0.419 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 427, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 419, event.getDuration());
+        assertEquals((long) 427,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(419,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnified() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 521 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 453, event.getDuration());
+        assertEquals((long) (521 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(453,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_INIT_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_INIT_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitMarkEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -77,99 +72,89 @@ public class TestShenandoahInitMarkEvent {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms";
         long timestamp = 521;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahInitMarkEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahInitMarkEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_INIT_MARK);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.521s][info][gc] GC(1) Pause Init Mark 0.453ms   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ProcessWeakrefs() {
         String logLine = "2020-03-10T08:03:29.489-0400: 0.551: [Pause Init Mark (process weakrefs), 0.314 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 551, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 314, event.getDuration());
+        assertEquals((long) 551,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(314,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedProcessWeakrefs() {
         String logLine = "[0.456s][info][gc] GC(0) Pause Init Mark (process weakrefs) 0.868ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 456 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 868, event.getDuration());
+        assertEquals((long) (456 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(868,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUpdateRefs() {
         String logLine = "[10.453s][info][gc] GC(279) Pause Init Mark (update refs) 0.244ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 10453 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 244, event.getDuration());
+        assertEquals((long) (10453 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(244,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUpdateRefsProcessWeakrefs() {
         String logLine = "[11.006s][info][gc] GC(300) Pause Init Mark (update refs) (process weakrefs) 0.266ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 11006 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 266, event.getDuration());
+        assertEquals((long) (11006 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(266,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedDetailed() {
         String logLine = "[41.893s][info][gc           ] GC(1500) Pause Init Mark (update refs) "
                 + "(process weakrefs) 0.295ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 41893 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 295, event.getDuration());
+        assertEquals((long) (41893 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(295,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.178-0200][3090ms] GC(0) Pause Init Mark (process weakrefs) 2.904ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3090 - 2, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 2904, event.getDuration());
+        assertEquals((long) (3090 - 2),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(2904,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedUnloadClasses() {
         String logLine = "[5.593s][info][gc           ] GC(99) Pause Init Mark (unload classes) 0.088ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".",
-                ShenandoahInitMarkEvent.match(logLine));
+        assertTrue(ShenandoahInitMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + ".");
         ShenandoahInitMarkEvent event = new ShenandoahInitMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 5593 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 88, event.getDuration());
+        assertEquals((long) (5593 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(88,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitUpdateEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitUpdateEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahInitUpdateEvent {
+class TestShenandoahInitUpdateEvent {
 
     @Test
-    public void testLogLineJdk8() {
+    void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:46.284-0400: 17.346: [Pause Init Update Refs, 0.017 ms]";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
@@ -40,7 +40,7 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnified() {
+    void testLogLineUnified() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
@@ -49,25 +49,25 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE;
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         long timestamp = 521;
@@ -77,25 +77,25 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_INIT_UPDATE);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms    ";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedDetailed() {
+    void testLogLineUnifiedDetailed() {
         String logLine = "[69.612s][info][gc           ] GC(2582) Pause Init Update Refs 0.036ms";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
@@ -104,7 +104,7 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnifiedTimeUptimeMillis() {
+    void testLogLineUnifiedTimeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pause Init Update Refs 0.092ms";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
@@ -113,7 +113,7 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnifiedTimeUptime() {
+    void testLogLineUnifiedTimeUptime() {
         String logLine = "[2019-02-05T14:47:34.229-0200][4.766s] GC(0) Pause Init Update Refs 0.092ms";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
@@ -122,7 +122,7 @@ public class TestShenandoahInitUpdateEvent {
     }
 
     @Test
-    public void testLogLineUnifiedTime() {
+    void testLogLineUnifiedTime() {
         String logLine = "[2019-02-05T14:47:34.229-0200] GC(0) Pause Init Update Refs 0.092ms";
         assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitUpdateEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahInitUpdateEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,42 +33,37 @@ public class TestShenandoahInitUpdateEvent {
     @Test
     public void testLogLineJdk8() {
         String logLine = "2020-03-10T08:03:46.284-0400: 17.346: [Pause Init Update Refs, 0.017 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 17346, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 17, event.getDuration());
+        assertEquals((long) 17346,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(17,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnified() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4766 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 4, event.getDuration());
+        assertEquals((long) (4766 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(4,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitUpdateEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahInitUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -77,68 +72,61 @@ public class TestShenandoahInitUpdateEvent {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms";
         long timestamp = 521;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahInitUpdateEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof ShenandoahInitUpdateEvent, JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_INIT_UPDATE);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[4.766s][info][gc] GC(97) Pause Init Update Refs 0.004ms    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedDetailed() {
         String logLine = "[69.612s][info][gc           ] GC(2582) Pause Init Update Refs 0.036ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 69612 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 36, event.getDuration());
+        assertEquals((long) (69612 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(36,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedTimeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pause Init Update Refs 0.092ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3141 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 92, event.getDuration());
+        assertEquals((long) (3141 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(92,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedTimeUptime() {
         String logLine = "[2019-02-05T14:47:34.229-0200][4.766s] GC(0) Pause Init Update Refs 0.092ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4766 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 92, event.getDuration());
+        assertEquals((long) (4766 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(92,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineUnifiedTime() {
         String logLine = "[2019-02-05T14:47:34.229-0200] GC(0) Pause Init Update Refs 0.092ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".",
-                ShenandoahInitUpdateEvent.match(logLine));
+        assertTrue(ShenandoahInitUpdateEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + ".");
         ShenandoahInitUpdateEvent event = new ShenandoahInitUpdateEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 602693254229L - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 92, event.getDuration());
+        assertEquals(602693254229L - 0,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(92,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahStatsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahStatsEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,514 +39,445 @@ public class TestShenandoahStatsEvent {
     @Test
     public void testIdentityEventType() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_STATS + "not identified.", JdkUtil.LogEventType.SHENANDOAH_STATS,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_STATS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_STATS + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahStatsEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahStatsEvent, JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_STATS));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_STATS);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLineAllTimes() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineAllTimesUnified() {
         String logLine = "[0.484s][info][gc,stats     ] All times are wall-clock times, except per-root-class "
                 + "counters, that are sum over";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineAllTimesWithLeadingSpaces() {
         String logLine = "  All times are wall-clock times, except per-root-class counters, that are sum over";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineAllWokers() {
         String logLine = "all workers. Dividing the <total> over the root stage time estimates parallelism.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineAllWokersWithLeadingSpaces() {
         String logLine = "  all workers. Dividing the <total> over the root stage time estimates parallelism.";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testUpdateRegionStates() {
         String logLine = "  Update Region States              789 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testUpdateRegionStatesUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Update Region States                3 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSTotal() {
         String logLine = "    S: <total>                    69130 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSTotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     S: <total>                     1469 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testSJni() {
         String logLine = "    S: JNI Handles Roots              7 us, workers (us): ---,   7, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testSJniUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     S: JNI Handles Roots              1 us, workers (us):"
                 + "   1, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSJfr() {
         String logLine = "    S: JFR Weak Roots                 1 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---,   1, ---, ---, ---, ---, ---, ---, ---";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineSFlat() {
         String logLine = "    S: Flat Profiler Roots          129 us, workers (us): ---, ---, 129, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineWeakRoots() {
         String logLine = "  Weak Roots                         36 us, parallelism: 0.94x";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineWeakRootsUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     Weak Roots                      106 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineWrTotal() {
         String logLine = "    WR: <total>                      34 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineWrJfr() {
         String logLine = "    WR: JFR Weak Roots                0 us, workers (us):   0, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineWrJni() {
         String logLine = "    WR: JNI Weak Roots               33 us, workers (us):  33, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUpdateRegionStates() {
         String logLine = "  Update Region States              234 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUpdateRegionStatesUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Update Region States                4 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineChooseCollectionSet() {
         String logLine = "  Choose Collection Set             440 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineChooseCollectionSetUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Choose Collection Set              41 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineRebuildFreeSet() {
         String logLine = "  Rebuild Free Set                   36 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineRebuildFreeSetUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Rebuild Free Set                    6 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineETotal() {
         String logLine = "    E: <total>                    69151 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineETotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     E: <total>                      876 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testEJni() {
         String logLine = "    E: JNI Handles Roots              3 us, workers (us):   3, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testEJniUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     E: JNI Handles Roots              1 us, workers (us):"
                 + "   1, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineEJfr() {
         String logLine = "    E: JFR Weak Roots                 1 us, workers (us): ---, ---, ---,   1, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineEFlat() {
         String logLine = "    E: Flat Profiler Roots           22 us, workers (us):  22, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUrTotal() {
         String logLine = "    UR: <total>                    3127 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUrTotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     UR: <total>                     139 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineTrashCollectionSet() {
         String logLine = "  Trash Collection Set               61 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineFinishWork() {
         String logLine = "  Finish Work                   1007819 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFinishWork() {
         String logLine = "[2020-10-26T14:51:41.413-0400]   Finish Work                     10950 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLinePauseDegenerateGcG() {
         String logLine = "Pause Degenerated GC (G)        1296188 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLinePauseDegenerateGcN() {
         String logLine = "Pause Degenerated GC (N)        1285099 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDegenUpdateRoots() {
         String logLine = "  Degen Update Roots               5869 us, parallelism: 17.30x";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuThreadRoots() {
         String logLine = "    DU: Thread Roots              11698 us, workers (us): 404, 645, 403, 420, 421, 421, "
                 + "3557, 414, 421, 421, 410, 419, 419, 414, 419, 420, 410, 419, 419, 420,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuCodeCacheRoots() {
         String logLine = "    DU: Code Cache Roots          29622 us, workers (us): 1556, 1454, 1534, 1523, 1747, "
                 + "1460,   0, 1594, 1437, 1478, 1472, 1840, 1637, 1518, 1529, 1572, 1465, 1522, 1611, 1672,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuUniverseRoots() {
         String logLine = "    DU: Universe Roots                1 us, workers (us):   1, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuJniHandlesRoots() {
         String logLine = "    DU: JNI Handles Roots             4 us, workers (us): ---,   4, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuJfrWeakRoots() {
         String logLine = "    DU: JFR Weak Roots                1 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---,   1, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuJniWeakRoots() {
         String logLine = "    DU: JNI Weak Roots               45 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---,  45, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuStringTableRoots() {
         String logLine = "    DU: String Table Roots        24649 us, workers (us): 1289, 1388, 1296, 1366, 1099, "
                 + "1394,  70, 1256, 1344, 1383, 1424, 991, 1209, 1336, 1308, 1283, 1374, 1398, 1276, 1164,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuSynchronizerRoots() {
         String logLine = "    DU: Synchronizer Roots        26688 us, workers (us): 1440, 1441, 1553, 1549, 1526, "
                 + "1508, 1476, 1454, 1422, 1391, 1350, 1334, 1268, 1216, 1185, 1170, 1137, 1104, 1098, 1068,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuFlatProfilerRoots() {
         String logLine = "    DU: Flat Profiler Roots         147 us, workers (us): ---, 147, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuManagementRoots() {
         String logLine = "    DU: Management Roots             15 us, workers (us):  15, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuSystemDictRoots() {
         String logLine = "    DU: System Dict Roots            15 us, workers (us): ---, ---,  15, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuCldgRoots() {
         String logLine = "    DU: CLDG Roots                 8481 us, workers (us): 468, 225, 454, 451, 451, 451,  76, "
                 + "457, 451, 451, 461, 452, 453, 457, 453, 451, 461, 453, 453, 451,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDuJvmtiRoots() {
         String logLine = "    DU: JVMTI Roots                 171 us, workers (us): 171, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineConcurrentCleanup() {
         String logLine = "[0.590s][info][gc,stats     ] Concurrent Cleanup                   38 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineMain2DigitPercent() {
         String logLine = "[0.661s][info][gc,stats     ]      10 of    71 ms ( 14.0%): main";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineUnloadClasses() {
         String logLine = "[5.608s][info][gc,stats      ]     Unload Classes                   52 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCleanup() {
         String logLine = "[5.608s][info][gc,stats      ]     Cleanup                        1275 us, "
                 + "parallelism: 1.93x";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuTotal() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: <total>                  2466 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuCodeCacheRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Code Cache Roots          983 us, "
                 + "workers (us): 488, 495,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuCodeCacheCleaning() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Code Cache Cleaning       149 us, "
                 + "workers (us):  79,  70,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuStringTableRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: String Table Roots        358 us, "
                 + "workers (us): 183, 175,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuResolvedTableRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Resolved Table Roots        9 us, "
                 + "workers (us):   0,   9";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCuCldgRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: CLDG Roots                967 us, "
                 + "workers (us): 479, 489,";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineCldg() {
         String logLine = "[5.608s][info][gc,stats      ]     CLDG                              0 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineDeallocateMetadata() {
         String logLine = "    Deallocate Metadata              24 us";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
     public void testLineC1CompilerThread2() {
         String logLine = "      8 of   105 ms (  7.6%): C1 CompilerThread2";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".",
-                ShenandoahStatsEvent.match(logLine));
+        assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
@@ -558,15 +489,12 @@ public class TestShenandoahStatsEvent {
         File preprocessedFile = gcManager1.preprocess(testFile, null);
         gcManager2.store(preprocessedFile, false);
         JvmRun jvmRun1 = gcManager1.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun1.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE));
+        assertEquals(2,jvmRun1.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.");
         JvmRun jvmRun2 = gcManager2.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun2.getEventTypes().size());
+        assertEquals(0,jvmRun2.getEventTypes().size(),"Event type count not correct.");
     }
 
     @Test
@@ -578,14 +506,11 @@ public class TestShenandoahStatsEvent {
         File preprocessedFile = gcManager1.preprocess(testFile, null);
         gcManager2.store(preprocessedFile, false);
         JvmRun jvmRun1 = gcManager1.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun1.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.",
-                jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE));
+        assertEquals(2,jvmRun1.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun1.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " collector not identified.");
+        assertTrue(jvmRun1.getEventTypes().contains(LogEventType.UNIFIED_BLANK_LINE), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " collector not identified.");
         JvmRun jvmRun2 = gcManager2.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 0, jvmRun2.getEventTypes().size());
+        assertEquals(0,jvmRun2.getEventTypes().size(),"Event type count not correct.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahStatsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahStatsEvent.java
@@ -34,454 +34,454 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahStatsEvent {
+class TestShenandoahStatsEvent {
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_STATS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_STATS + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahStatsEvent, JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_STATS), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_STATS);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLineAllTimes() {
+    void testLineAllTimes() {
         String logLine = "All times are wall-clock times, except per-root-class counters, that are sum over";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineAllTimesUnified() {
+    void testLineAllTimesUnified() {
         String logLine = "[0.484s][info][gc,stats     ] All times are wall-clock times, except per-root-class "
                 + "counters, that are sum over";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineAllTimesWithLeadingSpaces() {
+    void testLineAllTimesWithLeadingSpaces() {
         String logLine = "  All times are wall-clock times, except per-root-class counters, that are sum over";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineAllWokers() {
+    void testLineAllWokers() {
         String logLine = "all workers. Dividing the <total> over the root stage time estimates parallelism.";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineAllWokersWithLeadingSpaces() {
+    void testLineAllWokersWithLeadingSpaces() {
         String logLine = "  all workers. Dividing the <total> over the root stage time estimates parallelism.";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testUpdateRegionStates() {
+    void testUpdateRegionStates() {
         String logLine = "  Update Region States              789 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testUpdateRegionStatesUnified() {
+    void testUpdateRegionStatesUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Update Region States                3 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSTotal() {
+    void testLineSTotal() {
         String logLine = "    S: <total>                    69130 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSTotalUnified() {
+    void testLineSTotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     S: <total>                     1469 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testSJni() {
+    void testSJni() {
         String logLine = "    S: JNI Handles Roots              7 us, workers (us): ---,   7, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testSJniUnified() {
+    void testSJniUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     S: JNI Handles Roots              1 us, workers (us):"
                 + "   1, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSJfr() {
+    void testLineSJfr() {
         String logLine = "    S: JFR Weak Roots                 1 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---,   1, ---, ---, ---, ---, ---, ---, ---";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineSFlat() {
+    void testLineSFlat() {
         String logLine = "    S: Flat Profiler Roots          129 us, workers (us): ---, ---, 129, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineWeakRoots() {
+    void testLineWeakRoots() {
         String logLine = "  Weak Roots                         36 us, parallelism: 0.94x";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineWeakRootsUnified() {
+    void testLineWeakRootsUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     Weak Roots                      106 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineWrTotal() {
+    void testLineWrTotal() {
         String logLine = "    WR: <total>                      34 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineWrJfr() {
+    void testLineWrJfr() {
         String logLine = "    WR: JFR Weak Roots                0 us, workers (us):   0, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineWrJni() {
+    void testLineWrJni() {
         String logLine = "    WR: JNI Weak Roots               33 us, workers (us):  33, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUpdateRegionStates() {
+    void testLineUpdateRegionStates() {
         String logLine = "  Update Region States              234 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUpdateRegionStatesUnified() {
+    void testLineUpdateRegionStatesUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Update Region States                4 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineChooseCollectionSet() {
+    void testLineChooseCollectionSet() {
         String logLine = "  Choose Collection Set             440 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineChooseCollectionSetUnified() {
+    void testLineChooseCollectionSetUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Choose Collection Set              41 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineRebuildFreeSet() {
+    void testLineRebuildFreeSet() {
         String logLine = "  Rebuild Free Set                   36 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineRebuildFreeSetUnified() {
+    void testLineRebuildFreeSetUnified() {
         String logLine = "[0.484s][info][gc,stats     ]   Rebuild Free Set                    6 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineETotal() {
+    void testLineETotal() {
         String logLine = "    E: <total>                    69151 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineETotalUnified() {
+    void testLineETotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     E: <total>                      876 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testEJni() {
+    void testEJni() {
         String logLine = "    E: JNI Handles Roots              3 us, workers (us):   3, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testEJniUnified() {
+    void testEJniUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     E: JNI Handles Roots              1 us, workers (us):"
                 + "   1, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineEJfr() {
+    void testLineEJfr() {
         String logLine = "    E: JFR Weak Roots                 1 us, workers (us): ---, ---, ---,   1, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineEFlat() {
+    void testLineEFlat() {
         String logLine = "    E: Flat Profiler Roots           22 us, workers (us):  22, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUrTotal() {
+    void testLineUrTotal() {
         String logLine = "    UR: <total>                    3127 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUrTotalUnified() {
+    void testLineUrTotalUnified() {
         String logLine = "[0.484s][info][gc,stats     ]     UR: <total>                     139 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineTrashCollectionSet() {
+    void testLineTrashCollectionSet() {
         String logLine = "  Trash Collection Set               61 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineFinishWork() {
+    void testLineFinishWork() {
         String logLine = "  Finish Work                   1007819 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFinishWork() {
+    void testLineUnifiedFinishWork() {
         String logLine = "[2020-10-26T14:51:41.413-0400]   Finish Work                     10950 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLinePauseDegenerateGcG() {
+    void testLinePauseDegenerateGcG() {
         String logLine = "Pause Degenerated GC (G)        1296188 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLinePauseDegenerateGcN() {
+    void testLinePauseDegenerateGcN() {
         String logLine = "Pause Degenerated GC (N)        1285099 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDegenUpdateRoots() {
+    void testLineDegenUpdateRoots() {
         String logLine = "  Degen Update Roots               5869 us, parallelism: 17.30x";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuThreadRoots() {
+    void testLineDuThreadRoots() {
         String logLine = "    DU: Thread Roots              11698 us, workers (us): 404, 645, 403, 420, 421, 421, "
                 + "3557, 414, 421, 421, 410, 419, 419, 414, 419, 420, 410, 419, 419, 420,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuCodeCacheRoots() {
+    void testLineDuCodeCacheRoots() {
         String logLine = "    DU: Code Cache Roots          29622 us, workers (us): 1556, 1454, 1534, 1523, 1747, "
                 + "1460,   0, 1594, 1437, 1478, 1472, 1840, 1637, 1518, 1529, 1572, 1465, 1522, 1611, 1672,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuUniverseRoots() {
+    void testLineDuUniverseRoots() {
         String logLine = "    DU: Universe Roots                1 us, workers (us):   1, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuJniHandlesRoots() {
+    void testLineDuJniHandlesRoots() {
         String logLine = "    DU: JNI Handles Roots             4 us, workers (us): ---,   4, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuJfrWeakRoots() {
+    void testLineDuJfrWeakRoots() {
         String logLine = "    DU: JFR Weak Roots                1 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---,   1, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuJniWeakRoots() {
+    void testLineDuJniWeakRoots() {
         String logLine = "    DU: JNI Weak Roots               45 us, workers (us): ---, ---, ---, ---, ---, ---, ---, "
                 + "---,  45, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuStringTableRoots() {
+    void testLineDuStringTableRoots() {
         String logLine = "    DU: String Table Roots        24649 us, workers (us): 1289, 1388, 1296, 1366, 1099, "
                 + "1394,  70, 1256, 1344, 1383, 1424, 991, 1209, 1336, 1308, 1283, 1374, 1398, 1276, 1164,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuSynchronizerRoots() {
+    void testLineDuSynchronizerRoots() {
         String logLine = "    DU: Synchronizer Roots        26688 us, workers (us): 1440, 1441, 1553, 1549, 1526, "
                 + "1508, 1476, 1454, 1422, 1391, 1350, 1334, 1268, 1216, 1185, 1170, 1137, 1104, 1098, 1068,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuFlatProfilerRoots() {
+    void testLineDuFlatProfilerRoots() {
         String logLine = "    DU: Flat Profiler Roots         147 us, workers (us): ---, 147, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuManagementRoots() {
+    void testLineDuManagementRoots() {
         String logLine = "    DU: Management Roots             15 us, workers (us):  15, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuSystemDictRoots() {
+    void testLineDuSystemDictRoots() {
         String logLine = "    DU: System Dict Roots            15 us, workers (us): ---, ---,  15, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuCldgRoots() {
+    void testLineDuCldgRoots() {
         String logLine = "    DU: CLDG Roots                 8481 us, workers (us): 468, 225, 454, 451, 451, 451,  76, "
                 + "457, 451, 451, 461, 452, 453, 457, 453, 451, 461, 453, 453, 451,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDuJvmtiRoots() {
+    void testLineDuJvmtiRoots() {
         String logLine = "    DU: JVMTI Roots                 171 us, workers (us): 171, ---, ---, ---, ---, ---, ---, "
                 + "---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineConcurrentCleanup() {
+    void testLineConcurrentCleanup() {
         String logLine = "[0.590s][info][gc,stats     ] Concurrent Cleanup                   38 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineMain2DigitPercent() {
+    void testLineMain2DigitPercent() {
         String logLine = "[0.661s][info][gc,stats     ]      10 of    71 ms ( 14.0%): main";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineUnloadClasses() {
+    void testLineUnloadClasses() {
         String logLine = "[5.608s][info][gc,stats      ]     Unload Classes                   52 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCleanup() {
+    void testLineCleanup() {
         String logLine = "[5.608s][info][gc,stats      ]     Cleanup                        1275 us, "
                 + "parallelism: 1.93x";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuTotal() {
+    void testLineCuTotal() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: <total>                  2466 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuCodeCacheRoots() {
+    void testLineCuCodeCacheRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Code Cache Roots          983 us, "
                 + "workers (us): 488, 495,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuCodeCacheCleaning() {
+    void testLineCuCodeCacheCleaning() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Code Cache Cleaning       149 us, "
                 + "workers (us):  79,  70,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuStringTableRoots() {
+    void testLineCuStringTableRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: String Table Roots        358 us, "
                 + "workers (us): 183, 175,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuResolvedTableRoots() {
+    void testLineCuResolvedTableRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: Resolved Table Roots        9 us, "
                 + "workers (us):   0,   9";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCuCldgRoots() {
+    void testLineCuCldgRoots() {
         String logLine = "[5.608s][info][gc,stats      ]       CU: CLDG Roots                967 us, "
                 + "workers (us): 479, 489,";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineCldg() {
+    void testLineCldg() {
         String logLine = "[5.608s][info][gc,stats      ]     CLDG                              0 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineDeallocateMetadata() {
+    void testLineDeallocateMetadata() {
         String logLine = "    Deallocate Metadata              24 us";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testLineC1CompilerThread2() {
+    void testLineC1CompilerThread2() {
         String logLine = "      8 of   105 ms (  7.6%): C1 CompilerThread2";
         assertTrue(ShenandoahStatsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_STATS.toString() + ".");
     }
 
     @Test
-    public void testJdk11() {
+    void testJdk11() {
         File testFile = TestUtil.getFile("dataset195.txt");
         GcManager gcManager1 = new GcManager();
         gcManager1.store(testFile, false);
@@ -498,7 +498,7 @@ public class TestShenandoahStatsEvent {
     }
 
     @Test
-    public void testJdk11Time() {
+    void testJdk11Time() {
         File testFile = TestUtil.getFile("dataset197.txt");
         GcManager gcManager1 = new GcManager();
         gcManager1.store(testFile, false);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahTriggerEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahTriggerEvent.java
@@ -28,133 +28,133 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahTriggerEvent {
+class TestShenandoahTriggerEvent {
 
     @Test
-    public void testLineJdk8TriggerLearning() {
+    void testLineJdk8TriggerLearning() {
         String logLine = "Trigger: Learning 1 of 5. Free (45118K) is below initial threshold (45875K)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerLearning() {
+    void testLineUnifiedTriggerLearning() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
         assertEquals(JdkUtil.LogEventType.SHENANDOAH_TRIGGER,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_TRIGGER + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahTriggerEvent, JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_TRIGGER), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_TRIGGER);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
-    public void testLineUnifiedTriggerAverage() {
+    void testLineUnifiedTriggerAverage() {
         String logLine = "[0.864s][info][gc] Trigger: Average GC time (15.91 ms) is above the time for allocation rate "
                 + "(829.64 MB/s) to deplete free headroom (11M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineJdkTriggerAverageGc() {
+    void testLineJdkTriggerAverageGc() {
         String logLine = "Trigger: Average GC time (12.56 ms) is above the time for allocation rate (899 MB/s) to "
                 + "deplete free headroom (11466K)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerAverageGc() {
+    void testLineUnifiedTriggerAverageGc() {
         String logLine = "[41.917s][info][gc           ] Trigger: Average GC time (26.32 ms) is above the time for "
                 + "allocation rate (324.68 MB/s) to deplete free headroom (8M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerAverageGcAllocationRateWholeNumber() {
+    void testLineUnifiedTriggerAverageGcAllocationRateWholeNumber() {
         String logLine = "[1.757s][info][gc           ] Trigger: Average GC time (9.74 ms) is above the time for "
                 + "allocation rate (1244 MB/s) to deplete free headroom (11236K)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerAverageGcAllocationRateKb6Digits() {
+    void testLineUnifiedTriggerAverageGcAllocationRateKb6Digits() {
         String logLine = "[63.328s][info][gc           ] Trigger: Average GC time (77.12 ms) is above the time for "
                 + "allocation rate (101894 KB/s) to deplete free headroom (6846K)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerAverageGcUptimeMillis() {
+    void testLineUnifiedTriggerAverageGcUptimeMillis() {
         String logLine = "[2019-02-05T14:48:05.666-0200][34578ms] Trigger: Average GC time (52.77 ms) is above the "
                 + "time for allocation rate (1313.84 MB/s) to deplete free headroom (67M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerFree() {
+    void testLineUnifiedTriggerFree() {
         String logLine = "[24.356s][info][gc] Trigger: Free (6M) is below minimum threshold (6M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerFreeSpacesAfterGc() {
+    void testLineUnifiedTriggerFreeSpacesAfterGc() {
         String logLine = "[49.186s][info][gc           ] Trigger: Free (6M) is below minimum threshold (6M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerFreeUptimeMillis() {
+    void testLineUnifiedTriggerFreeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:49.297-0200][18209ms] Trigger: Free (128M) is below minimum threshold "
                 + "(130M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerFreeLearning() {
+    void testLineUnifiedTriggerFreeLearning() {
         String logLine = "[0.410s][info][gc           ] Trigger: Learning 3 of 5. Free (45613K) is below initial "
                 + "threshold (45875K)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTriggerHandleAllocationFailure() {
+    void testLineUnifiedTriggerHandleAllocationFailure() {
         String logLine = "[52.883s][info][gc           ] Trigger: Handle Allocation Failure";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFreeTimeSinceLastGcUptimeMillis() {
+    void testLineUnifiedFreeTimeSinceLastGcUptimeMillis() {
         String logLine = "[2019-02-05T15:10:00.671-0200][1349583ms] Trigger: Time since last GC (300004 ms) is larger "
                 + "than guaranteed interval (300000 ms)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedTrigger() {
+    void testLineUnifiedTrigger() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Trigger: Learning 1 of 5. Free (912M) is below "
                 + "initial threshold (912M)";
         assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahTriggerEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestShenandoahTriggerEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,150 +33,130 @@ public class TestShenandoahTriggerEvent {
     @Test
     public void testLineJdk8TriggerLearning() {
         String logLine = "Trigger: Learning 1 of 5. Free (45118K) is below initial threshold (45875K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerLearning() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
-        assertEquals(JdkUtil.LogEventType.SHENANDOAH_TRIGGER + "not identified.",
-                JdkUtil.LogEventType.SHENANDOAH_TRIGGER, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.SHENANDOAH_TRIGGER,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.SHENANDOAH_TRIGGER + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof ShenandoahTriggerEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof ShenandoahTriggerEvent, JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.448s][info][gc] Trigger: Learning 1 of 5. Free (44M) is below initial threshold (44M)";
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_TRIGGER));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.SHENANDOAH_TRIGGER), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.SHENANDOAH_TRIGGER);
-        assertFalse(JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + " incorrectly indentified as unified.");
     }
 
     @Test
     public void testLineUnifiedTriggerAverage() {
         String logLine = "[0.864s][info][gc] Trigger: Average GC time (15.91 ms) is above the time for allocation rate "
                 + "(829.64 MB/s) to deplete free headroom (11M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineJdkTriggerAverageGc() {
         String logLine = "Trigger: Average GC time (12.56 ms) is above the time for allocation rate (899 MB/s) to "
                 + "deplete free headroom (11466K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerAverageGc() {
         String logLine = "[41.917s][info][gc           ] Trigger: Average GC time (26.32 ms) is above the time for "
                 + "allocation rate (324.68 MB/s) to deplete free headroom (8M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerAverageGcAllocationRateWholeNumber() {
         String logLine = "[1.757s][info][gc           ] Trigger: Average GC time (9.74 ms) is above the time for "
                 + "allocation rate (1244 MB/s) to deplete free headroom (11236K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerAverageGcAllocationRateKb6Digits() {
         String logLine = "[63.328s][info][gc           ] Trigger: Average GC time (77.12 ms) is above the time for "
                 + "allocation rate (101894 KB/s) to deplete free headroom (6846K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerAverageGcUptimeMillis() {
         String logLine = "[2019-02-05T14:48:05.666-0200][34578ms] Trigger: Average GC time (52.77 ms) is above the "
                 + "time for allocation rate (1313.84 MB/s) to deplete free headroom (67M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerFree() {
         String logLine = "[24.356s][info][gc] Trigger: Free (6M) is below minimum threshold (6M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerFreeSpacesAfterGc() {
         String logLine = "[49.186s][info][gc           ] Trigger: Free (6M) is below minimum threshold (6M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerFreeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:49.297-0200][18209ms] Trigger: Free (128M) is below minimum threshold "
                 + "(130M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerFreeLearning() {
         String logLine = "[0.410s][info][gc           ] Trigger: Learning 3 of 5. Free (45613K) is below initial "
                 + "threshold (45875K)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTriggerHandleAllocationFailure() {
         String logLine = "[52.883s][info][gc           ] Trigger: Handle Allocation Failure";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFreeTimeSinceLastGcUptimeMillis() {
         String logLine = "[2019-02-05T15:10:00.671-0200][1349583ms] Trigger: Time since last GC (300004 ms) is larger "
                 + "than guaranteed interval (300000 ms)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedTrigger() {
         String logLine = "[2019-02-05T14:47:34.156-0200][3068ms] Trigger: Learning 1 of 5. Free (912M) is below "
                 + "initial threshold (912M)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".",
-                ShenandoahTriggerEvent.match(logLine));
+        assertTrue(ShenandoahTriggerEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.SHENANDOAH_TRIGGER.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestTenuringDistributionEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestTenuringDistributionEvent.java
@@ -23,40 +23,40 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestTenuringDistributionEvent {
+class TestTenuringDistributionEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
         assertTrue(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as not reportable.");
     }
 
     @Test
-    public void testIdentifyEventType() {
+    void testIdentifyEventType() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
         assertTrue(JdkUtil.identifyEventType(logLine).equals(LogEventType.TENURING_DISTRIBUTION), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof TenuringDistributionEvent, JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.");
     }
 
     @Test
-    public void testDesiredSurvivorSizeLine() {
+    void testDesiredSurvivorSizeLine() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
         assertTrue(TenuringDistributionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".");
     }
 
     @Test
-    public void testAgeLine() {
+    void testAgeLine() {
         String logLine = "- age 1: 3177664 bytes, 3177664 total";
         assertTrue(TenuringDistributionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestTenuringDistributionEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestTenuringDistributionEvent.java
@@ -12,12 +12,12 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,44 +28,37 @@ public class TestTenuringDistributionEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
-        assertFalse(JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
-        assertTrue(
-                JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as not reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " incorrectly indentified as not reportable.");
     }
 
     @Test
     public void testIdentifyEventType() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
-        assertTrue(JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.",
-                JdkUtil.identifyEventType(logLine).equals(LogEventType.TENURING_DISTRIBUTION));
+        assertTrue(JdkUtil.identifyEventType(logLine).equals(LogEventType.TENURING_DISTRIBUTION), JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
-        assertTrue(JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.",
-                JdkUtil.parseLogLine(logLine) instanceof TenuringDistributionEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof TenuringDistributionEvent, JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + " not indentified.");
     }
 
     @Test
     public void testDesiredSurvivorSizeLine() {
         String logLine = "Desired survivor size 2228224 bytes, new threshold 1 (max 15)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".",
-                TenuringDistributionEvent.match(logLine));
+        assertTrue(TenuringDistributionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".");
     }
 
     @Test
     public void testAgeLine() {
         String logLine = "- age 1: 3177664 bytes, 3177664 total";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".",
-                TenuringDistributionEvent.match(logLine));
+        assertTrue(TenuringDistributionEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.TENURING_DISTRIBUTION.toString() + ".");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestThreadDumpEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestThreadDumpEvent.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,242 +27,209 @@ public class TestThreadDumpEvent {
     @Test
     public void testNotBlocking() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
-        assertFalse(JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
-        assertTrue(JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as not reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as not reportable.");
     }
 
     @Test
     public void testBeginningDateTime() {
         String logLine = "2009-12-29 14:17:17";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testTitle() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataRunnable4SpaceNid() {
         String logLine = "\"Thread-144233478\" daemon prio=10 tid=0x22817800 nid=0x77f5 "
                 + "runnable [0x25174000..0x25175030]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataWaiting4SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-2038\" daemon prio=10 tid=0x3eebb000 nid=0x1d16 "
                 + "in Object.wait() [0x252be000..0x252befb0]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataBlocked3SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-65\" daemon prio=10 tid=0x3ee5f800 nid=0x702 "
                 + "waiting for monitor entry [0x3ce62000..0x3ce630b0]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataBlocked4SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-2032\" daemon prio=10 tid=0x3df37000 nid=0x1d0f "
                 + "waiting for monitor entry [0x25363000..0x25363eb0]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNonDaemon() {
         String logLine = "\"JBossLifeThread\" prio=10 tid=0x08f4f400 nid=0x7996 in Object.wait() "
                 + "[0x3e992000..0x3e993030]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameWithSpaces() {
         String logLine = "\"Cache Object Manager Monitor\" prio=10 tid=0x095aa000 nid=0x7992 in Object.wait() "
                 + "[0x3e315000..0x3e315e30]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameWithBrackets() {
         String logLine = "\"ContainerBackgroundProcessor[StandardEngine[jboss.web]]\" daemon prio=10 "
                 + "tid=0x088a2000 nid=0x797a waiting on condition [0x3ea9f000..0x3ea9fe30]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameWithParenthesis() {
         String logLine = "\"Gang worker#0 (Parallel GC Threads)\" prio=10 tid=0x0805d800 nid=0x795b " + "runnable";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameWithSpacesAtEnd() {
         String logLine = "\"Gang worker#0 (Parallel GC Threads)\" prio=10 tid=0x0805d800 nid=0x795b " + "runnable   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameNoSpaceBeforeAddressRange() {
         String logLine = "\"ContainerBackgroundProcessor[StandardEngine[jboss.web]]\" daemon prio=10 "
                 + "tid=0x088a2000 nid=0x797a sleeping[0x3ea9f000..0x3ea9fe30]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadDataNameWithForwardSlash() {
         String logLine = "\"/com/my/MyThread-10\" prio=1 tid=0x093c3318 nid=0x7c5e runnable [0x49fdd000..0x49fdde30]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadData16Bytes() {
         String logLine = "\"LDAPConnThread 10.235.5.15:1502\" daemon prio=1 tid=0x0000002bace3e260 "
                 + "nid=0x2de1 runnable [0x00000000582d0000..0x00000000582d0e30]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadStateRunnable() {
         String logLine = "   java.lang.Thread.State: RUNNABLE";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadStateWaiting() {
         String logLine = "   java.lang.Thread.State: WAITING (on object monitor)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadStateTimedWaitingOnMonitor() {
         String logLine = "   java.lang.Thread.State: TIMED_WAITING (on object monitor)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadStateTimedWaitingSleeping() {
         String logLine = "   java.lang.Thread.State: TIMED_WAITING (sleeping)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testThreadStateBlocked() {
         String logLine = "   java.lang.Thread.State: BLOCKED (on object monitor)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testStackTraceLocation() {
         String logLine = "\tat java.lang.Object.wait(Native Method)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testStackTraceEventLocked() {
         String logLine = "\t- locked <0x94fa4fb0> (a org.apache.tomcat.util.net.JIoEndpoint$Worker)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testStackTraceEventWaitingToLock() {
         String logLine = "\t- waiting to lock <0x4b2da3f0> (a com.voxmobili.impl.pim.ab.BAddressBookContext)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testStackTraceEventWaitingOn() {
         String logLine = "\t- waiting on <0x889d3168> (a java.lang.Object)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryJni() {
         String logLine = "JNI global references: 844";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryHeap() {
         String logLine = "Heap";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryParNewGeneration() {
         String logLine = " par new generation   total 917504K, used 808761K [0x44c40000, 0x84c40000, 0x84c40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryEdenSpace() {
         String logLine = "  eden space 786432K, 100% used [0x44c40000, 0x74c40000, 0x74c40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryFromSpace() {
         String logLine = "  from space 131072K,  17% used [0x7cc40000, 0x7e20e790, 0x84c40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryToSpace() {
         String logLine = "  to   space 131072K,   0% used [0x74c40000, 0x74c40000, 0x7cc40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryCmsGenerationTotal() {
         String logLine = " concurrent mark-sweep generation total 1572864K, used 1572863K "
                 + "[0x84c40000, 0xe4c40000, 0xe4c40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
     public void testSummaryCmsPermGenTotal() {
         String logLine = " concurrent-mark-sweep perm gen total 77736K, used 46547K "
                 + "[0xe4c40000, 0xe982a000, 0xf4c40000)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".",
-                ThreadDumpEvent.match(logLine));
+        assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestThreadDumpEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestThreadDumpEvent.java
@@ -22,212 +22,212 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestThreadDumpEvent {
+class TestThreadDumpEvent {
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
         assertTrue(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.THREAD_DUMP.toString() + " incorrectly indentified as not reportable.");
     }
 
     @Test
-    public void testBeginningDateTime() {
+    void testBeginningDateTime() {
         String logLine = "2009-12-29 14:17:17";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testTitle() {
+    void testTitle() {
         String logLine = "Full thread dump Java HotSpot(TM) Server VM (11.0-b16 mixed mode):";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataRunnable4SpaceNid() {
+    void testThreadDataRunnable4SpaceNid() {
         String logLine = "\"Thread-144233478\" daemon prio=10 tid=0x22817800 nid=0x77f5 "
                 + "runnable [0x25174000..0x25175030]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataWaiting4SpaceNid() {
+    void testThreadDataWaiting4SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-2038\" daemon prio=10 tid=0x3eebb000 nid=0x1d16 "
                 + "in Object.wait() [0x252be000..0x252befb0]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataBlocked3SpaceNid() {
+    void testThreadDataBlocked3SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-65\" daemon prio=10 tid=0x3ee5f800 nid=0x702 "
                 + "waiting for monitor entry [0x3ce62000..0x3ce630b0]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataBlocked4SpaceNid() {
+    void testThreadDataBlocked4SpaceNid() {
         String logLine = "\"ajp-127.0.0.1-8009-2032\" daemon prio=10 tid=0x3df37000 nid=0x1d0f "
                 + "waiting for monitor entry [0x25363000..0x25363eb0]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNonDaemon() {
+    void testThreadDataNonDaemon() {
         String logLine = "\"JBossLifeThread\" prio=10 tid=0x08f4f400 nid=0x7996 in Object.wait() "
                 + "[0x3e992000..0x3e993030]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameWithSpaces() {
+    void testThreadDataNameWithSpaces() {
         String logLine = "\"Cache Object Manager Monitor\" prio=10 tid=0x095aa000 nid=0x7992 in Object.wait() "
                 + "[0x3e315000..0x3e315e30]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameWithBrackets() {
+    void testThreadDataNameWithBrackets() {
         String logLine = "\"ContainerBackgroundProcessor[StandardEngine[jboss.web]]\" daemon prio=10 "
                 + "tid=0x088a2000 nid=0x797a waiting on condition [0x3ea9f000..0x3ea9fe30]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameWithParenthesis() {
+    void testThreadDataNameWithParenthesis() {
         String logLine = "\"Gang worker#0 (Parallel GC Threads)\" prio=10 tid=0x0805d800 nid=0x795b " + "runnable";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameWithSpacesAtEnd() {
+    void testThreadDataNameWithSpacesAtEnd() {
         String logLine = "\"Gang worker#0 (Parallel GC Threads)\" prio=10 tid=0x0805d800 nid=0x795b " + "runnable   ";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameNoSpaceBeforeAddressRange() {
+    void testThreadDataNameNoSpaceBeforeAddressRange() {
         String logLine = "\"ContainerBackgroundProcessor[StandardEngine[jboss.web]]\" daemon prio=10 "
                 + "tid=0x088a2000 nid=0x797a sleeping[0x3ea9f000..0x3ea9fe30]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadDataNameWithForwardSlash() {
+    void testThreadDataNameWithForwardSlash() {
         String logLine = "\"/com/my/MyThread-10\" prio=1 tid=0x093c3318 nid=0x7c5e runnable [0x49fdd000..0x49fdde30]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadData16Bytes() {
+    void testThreadData16Bytes() {
         String logLine = "\"LDAPConnThread 10.235.5.15:1502\" daemon prio=1 tid=0x0000002bace3e260 "
                 + "nid=0x2de1 runnable [0x00000000582d0000..0x00000000582d0e30]";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadStateRunnable() {
+    void testThreadStateRunnable() {
         String logLine = "   java.lang.Thread.State: RUNNABLE";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadStateWaiting() {
+    void testThreadStateWaiting() {
         String logLine = "   java.lang.Thread.State: WAITING (on object monitor)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadStateTimedWaitingOnMonitor() {
+    void testThreadStateTimedWaitingOnMonitor() {
         String logLine = "   java.lang.Thread.State: TIMED_WAITING (on object monitor)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadStateTimedWaitingSleeping() {
+    void testThreadStateTimedWaitingSleeping() {
         String logLine = "   java.lang.Thread.State: TIMED_WAITING (sleeping)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testThreadStateBlocked() {
+    void testThreadStateBlocked() {
         String logLine = "   java.lang.Thread.State: BLOCKED (on object monitor)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testStackTraceLocation() {
+    void testStackTraceLocation() {
         String logLine = "\tat java.lang.Object.wait(Native Method)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testStackTraceEventLocked() {
+    void testStackTraceEventLocked() {
         String logLine = "\t- locked <0x94fa4fb0> (a org.apache.tomcat.util.net.JIoEndpoint$Worker)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testStackTraceEventWaitingToLock() {
+    void testStackTraceEventWaitingToLock() {
         String logLine = "\t- waiting to lock <0x4b2da3f0> (a com.voxmobili.impl.pim.ab.BAddressBookContext)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testStackTraceEventWaitingOn() {
+    void testStackTraceEventWaitingOn() {
         String logLine = "\t- waiting on <0x889d3168> (a java.lang.Object)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryJni() {
+    void testSummaryJni() {
         String logLine = "JNI global references: 844";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryHeap() {
+    void testSummaryHeap() {
         String logLine = "Heap";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryParNewGeneration() {
+    void testSummaryParNewGeneration() {
         String logLine = " par new generation   total 917504K, used 808761K [0x44c40000, 0x84c40000, 0x84c40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryEdenSpace() {
+    void testSummaryEdenSpace() {
         String logLine = "  eden space 786432K, 100% used [0x44c40000, 0x74c40000, 0x74c40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryFromSpace() {
+    void testSummaryFromSpace() {
         String logLine = "  from space 131072K,  17% used [0x7cc40000, 0x7e20e790, 0x84c40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryToSpace() {
+    void testSummaryToSpace() {
         String logLine = "  to   space 131072K,   0% used [0x74c40000, 0x74c40000, 0x7cc40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryCmsGenerationTotal() {
+    void testSummaryCmsGenerationTotal() {
         String logLine = " concurrent mark-sweep generation total 1572864K, used 1572863K "
                 + "[0x84c40000, 0xe4c40000, 0xe4c40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");
     }
 
     @Test
-    public void testSummaryCmsPermGenTotal() {
+    void testSummaryCmsPermGenTotal() {
         String logLine = " concurrent-mark-sweep perm gen total 77736K, used 46547K "
                 + "[0xe4c40000, 0xe982a000, 0xf4c40000)";
         assertTrue(ThreadDumpEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.THREAD_DUMP.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcOldEvent.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestVerboseGcOldEvent {
+class TestVerboseGcOldEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
@@ -46,13 +46,13 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]    ";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
     }
 
     @Test
-    public void testLogLineTriggerMetadataGcThreshold() {
+    void testLogLineTriggerMetadataGcThreshold() {
         String logLine = "18129.496: [Full GC (Metadata GC Threshold)  629455K->457103K(3128704K), 4.4946967 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
@@ -66,7 +66,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerLastDitchCollection() {
+    void testLogLineTriggerLastDitchCollection() {
         String logLine = "18134.427: [Full GC (Last ditch collection)  457103K->449140K(3128704K), 5.6081071 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
@@ -80,7 +80,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineDatestamp() {
+    void testLogLineDatestamp() {
         String logLine = "2016-06-22T14:04:51.080+0100: 22561.627: [Full GC (Last ditch collection)  "
                 + "500269K->500224K(3128704K), 4.2311820 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
@@ -95,7 +95,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineG1Sizes() {
+    void testLogLineG1Sizes() {
         String logLine = "2017-03-20T04:30:01.936+0800: 2950.666: [Full GC 8134M->2349M(8192M), 10.3726320 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
@@ -109,7 +109,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerAllocationFailure() {
+    void testLogLineTriggerAllocationFailure() {
         String logLine = "2017-04-06T15:22:40.708-0500: 303068.960: [Full GC (Allocation Failure)  "
                 + "7455264K->4498878K(7992832K), 13.2445067 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
@@ -124,7 +124,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerErgonomics() {
+    void testLogLineTriggerErgonomics() {
         String logLine = "2412.683: [Full GC (Ergonomics)  728595K->382365K(932352K), 1.2268902 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
@@ -138,7 +138,7 @@ public class TestVerboseGcOldEvent {
     }
 
     @Test
-    public void testLogLineTriggerExplicitGc() {
+    void testLogLineTriggerExplicitGc() {
         String logLine = "8453.778: [Full GC (System.gc())  457601K->176797K(939520K), 1.5623937 secs]";
         assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcOldEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -29,135 +29,125 @@ public class TestVerboseGcOldEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]";
-        assertTrue(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 2143132151L, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1606823), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1409859), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(2976064), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 12085559, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals(2143132151L,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1606823),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1409859),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(2976064),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(12085559,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "2143132.151: [Full GC 1606823K->1409859K(2976064K), 12.0855599 secs]    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
     }
 
     @Test
     public void testLogLineTriggerMetadataGcThreshold() {
         String logLine = "18129.496: [Full GC (Metadata GC Threshold)  629455K->457103K(3128704K), 4.4946967 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 18129496, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(629455), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(457103), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 4494696, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 18129496,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(629455),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(457103),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(4494696,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerLastDitchCollection() {
         String logLine = "18134.427: [Full GC (Last ditch collection)  457103K->449140K(3128704K), 5.6081071 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 18134427, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(457103), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(449140), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 5608107, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 18134427,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(457103),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(449140),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(5608107,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineDatestamp() {
         String logLine = "2016-06-22T14:04:51.080+0100: 22561.627: [Full GC (Last ditch collection)  "
                 + "500269K->500224K(3128704K), 4.2311820 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 22561627, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(500269), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(500224), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 4231182, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 22561627,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_LAST_DITCH_COLLECTION), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(500269),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(500224),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(4231182,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineG1Sizes() {
         String logLine = "2017-03-20T04:30:01.936+0800: 2950.666: [Full GC 8134M->2349M(8192M), 10.3726320 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 2950666, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger() == null);
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(8329216), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(2405376), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(8388608), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 10372632, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 2950666,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger() == null, "Trigger not parsed correctly.");
+        assertEquals(kilobytes(8329216),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(2405376),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(8388608),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(10372632,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerAllocationFailure() {
         String logLine = "2017-04-06T15:22:40.708-0500: 303068.960: [Full GC (Allocation Failure)  "
                 + "7455264K->4498878K(7992832K), 13.2445067 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 303068960, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(7455264), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(4498878), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(7992832), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 13244506, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 303068960,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(7455264),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(4498878),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(7992832),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(13244506,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerErgonomics() {
         String logLine = "2412.683: [Full GC (Ergonomics)  728595K->382365K(932352K), 1.2268902 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 2412683, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(728595), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(382365), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(932352), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1226890, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 2412683,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(728595),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(382365),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(932352),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1226890,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerExplicitGc() {
         String logLine = "8453.778: [Full GC (System.gc())  457601K->176797K(939520K), 1.5623937 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".",
-                VerboseGcOldEvent.match(logLine));
+        assertTrue(VerboseGcOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_OLD.toString() + ".");
         VerboseGcOldEvent event = new VerboseGcOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 8453778, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(457601), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(176797), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(939520), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1562393, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 8453778,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(457601),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(176797),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(939520),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1562393,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcYoungEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcYoungEvent.java
@@ -13,12 +13,12 @@
 package org.eclipselabs.garbagecat.domain.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -29,178 +29,165 @@ public class TestVerboseGcYoungEvent {
     @Test
     public void testIsBlocking() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]";
-        assertTrue(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 2205570508L, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1726387), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(773247), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3097984), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 231803, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals(2205570508L,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1726387),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(773247),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3097984),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(231803,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]        ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
     }
 
     @Test
     public void testLogLineMissingBeginningOccupancy() {
         String logLine = "90.168: [GC 876593K(1851392K), 0.0701780 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 90168, event.getTimestamp());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 90168,event.getTimestamp(),"Time stamp not parsed correctly.");
         // We set beginging to end occupancy
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(876593), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(876593), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1851392), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 70178, event.getDuration());
+        assertEquals(kilobytes(876593),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(876593),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1851392),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(70178,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerAllocationFailure() {
         String logLine = "4.970: [GC (Allocation Failure)  136320K->18558K(3128704K), 0.1028162 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 4970, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(136320), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(18558), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 102816, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 4970,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(136320),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(18558),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(102816,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerCmsInitialMark() {
         String logLine = "12.915: [GC (CMS Initial Mark)  59894K(3128704K), 0.0058845 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 12915, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK));
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 12915,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_INITIAL_MARK), "Trigger not parsed correctly.");
         // We set beginging to end occupancy
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(59894), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(59894), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 5884, event.getDuration());
+        assertEquals(kilobytes(59894),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(59894),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(5884,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerCmsFinalRemark() {
         String logLine = "70.096: [GC (CMS Final Remark)  521627K(3128704K), 0.2481277 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 70096, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK));
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 70096,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_CMS_FINAL_REMARK), "Trigger not parsed correctly.");
         // We set beginging to end occupancy
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(521627), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(521627), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 248127, event.getDuration());
+        assertEquals(kilobytes(521627),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(521627),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(248127,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerGcLockerInitiatedGc() {
         String logLine = "37.357: [GC (GCLocker Initiated GC)  128035K->124539K(3128704K), 0.0713498 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 37357, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(128035), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(124539), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 71349, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 37357,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(128035),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(124539),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(71349,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithDashes() {
         String logLine = "1582.746: [GC-- 5524217K->5911480K(5911488K), 1.5564360 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 1582746, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(5524217), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(5911480), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(5911488), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1556436, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 1582746,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(5524217),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(5911480),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(5911488),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1556436,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerWithDashes() {
         String logLine = "1020971.877: [GC (Allocation Failure) -- 1044870K->1045980K(1046016K), 0.1061259 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 1020971877, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1044870), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1045980), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1046016), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 106125, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 1020971877,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(1044870),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1045980),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1046016),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(106125,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineWithDatestamp() {
         String logLine = "2016-07-22T11:49:00.678+0100: 4.970: [GC (Allocation Failure)  136320K->18558K(3128704K), "
                 + "0.1028162 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 4970, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(136320), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(18558), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(3128704), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 102816, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 4970,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(136320),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(18558),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(3128704),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(102816,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerMetadataGcThreshold() {
         String logLine = "20.748: [GC (Metadata GC Threshold)  288163K->251266K(1253376K), 0.0183041 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 20748, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(288163), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(251266), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1253376), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 18304, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 20748,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(288163),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(251266),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1253376),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(18304,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testLogLineTriggerExplicitGc() {
         String logLine = "8453.745: [GC (System.gc())  525225K->457601K(939520K), 0.0325441 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".",
-                VerboseGcYoungEvent.match(logLine));
+        assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 8453745, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(525225), event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(457601), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(939520), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 32544, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 8453745,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(525225),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(457601),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(939520),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(32544,event.getDuration(),"Duration not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcYoungEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/TestVerboseGcYoungEvent.java
@@ -24,16 +24,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestVerboseGcYoungEvent {
+class TestVerboseGcYoungEvent {
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -46,13 +46,13 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "2205570.508: [GC 1726387K->773247K(3097984K), 0.2318035 secs]        ";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
     }
 
     @Test
-    public void testLogLineMissingBeginningOccupancy() {
+    void testLogLineMissingBeginningOccupancy() {
         String logLine = "90.168: [GC 876593K(1851392K), 0.0701780 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -66,7 +66,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerAllocationFailure() {
+    void testLogLineTriggerAllocationFailure() {
         String logLine = "4.970: [GC (Allocation Failure)  136320K->18558K(3128704K), 0.1028162 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -80,7 +80,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerCmsInitialMark() {
+    void testLogLineTriggerCmsInitialMark() {
         String logLine = "12.915: [GC (CMS Initial Mark)  59894K(3128704K), 0.0058845 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -95,7 +95,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerCmsFinalRemark() {
+    void testLogLineTriggerCmsFinalRemark() {
         String logLine = "70.096: [GC (CMS Final Remark)  521627K(3128704K), 0.2481277 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -110,7 +110,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerGcLockerInitiatedGc() {
+    void testLogLineTriggerGcLockerInitiatedGc() {
         String logLine = "37.357: [GC (GCLocker Initiated GC)  128035K->124539K(3128704K), 0.0713498 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -124,7 +124,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineWithDashes() {
+    void testLogLineWithDashes() {
         String logLine = "1582.746: [GC-- 5524217K->5911480K(5911488K), 1.5564360 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -137,7 +137,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerWithDashes() {
+    void testLogLineTriggerWithDashes() {
         String logLine = "1020971.877: [GC (Allocation Failure) -- 1044870K->1045980K(1046016K), 0.1061259 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -150,7 +150,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineWithDatestamp() {
+    void testLogLineWithDatestamp() {
         String logLine = "2016-07-22T11:49:00.678+0100: 4.970: [GC (Allocation Failure)  136320K->18558K(3128704K), "
                 + "0.1028162 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
@@ -164,7 +164,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerMetadataGcThreshold() {
+    void testLogLineTriggerMetadataGcThreshold() {
         String logLine = "20.748: [GC (Metadata GC Threshold)  288163K->251266K(1253376K), 0.0183041 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);
@@ -178,7 +178,7 @@ public class TestVerboseGcYoungEvent {
     }
 
     @Test
-    public void testLogLineTriggerExplicitGc() {
+    void testLogLineTriggerExplicitGc() {
         String logLine = "8453.745: [GC (System.gc())  525225K->457601K(939520K), 0.0325441 secs]";
         assertTrue(VerboseGcYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + ".");
         VerboseGcYoungEvent event = new VerboseGcYoungEvent(logLine);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapAddressEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapAddressEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -34,61 +34,53 @@ public class TestHeapAddressEvent {
     public void testLogLine() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_ADDRESS.toString() + ".",
-                HeapAddressEvent.match(logLine));
+        assertTrue(HeapAddressEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_ADDRESS.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
-        assertEquals(JdkUtil.LogEventType.HEAP_ADDRESS + "not identified.", JdkUtil.LogEventType.HEAP_ADDRESS,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.HEAP_ADDRESS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.HEAP_ADDRESS + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
-        assertTrue(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
-        assertFalse(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_ADDRESS));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_ADDRESS), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.HEAP_ADDRESS);
-        assertTrue(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testCompressedOops() {
         String logLine = "[0.019s][info][gc,heap,coops] Heap address: 0x00000006c2800000, size: 4056 MB, "
                 + "Compressed Oops mode: Zero based, Oop shift amount: 3";
-        assertTrue(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");
     }
 
     @Test
     public void testTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Heap address: 0x00000000ae900000, size: 1303 MB, "
                 + "Compressed Oops mode: 32-bit";
-        assertTrue(JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapAddressEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapAddressEvent.java
@@ -28,57 +28,57 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeapAddressEvent {
+class TestHeapAddressEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
         assertTrue(HeapAddressEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_ADDRESS.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
         assertEquals(JdkUtil.LogEventType.HEAP_ADDRESS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.HEAP_ADDRESS + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.004s][info][gc,heap,coops] Heap address: 0x00000000fc000000, size: 64 MB, "
                 + "Compressed Oops mode: 32-bit";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_ADDRESS), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.HEAP_ADDRESS);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testCompressedOops() {
+    void testCompressedOops() {
         String logLine = "[0.019s][info][gc,heap,coops] Heap address: 0x00000006c2800000, size: 4056 MB, "
                 + "Compressed Oops mode: Zero based, Oop shift amount: 3";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");
     }
 
     @Test
-    public void testTimeUptimemillis() {
+    void testTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Heap address: 0x00000000ae900000, size: 1303 MB, "
                 + "Compressed Oops mode: 32-bit";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapAddressEvent, JdkUtil.LogEventType.HEAP_ADDRESS.toString() + " not parsed.");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapRegionSizeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapRegionSizeEvent.java
@@ -28,46 +28,46 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestHeapRegionSizeEvent {
+class TestHeapRegionSizeEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
         assertTrue(HeapRegionSizeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
         assertEquals(JdkUtil.LogEventType.HEAP_REGION_SIZE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.HEAP_REGION_SIZE + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapRegionSizeEvent, JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_REGION_SIZE), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.HEAP_REGION_SIZE);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testUptimeMillis() {
+    void testUptimeMillis() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Regions: 2606 x 512K";
         assertTrue(HeapRegionSizeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapRegionSizeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestHeapRegionSizeEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,49 +33,42 @@ public class TestHeapRegionSizeEvent {
     @Test
     public void testLine() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".",
-                HeapRegionSizeEvent.match(logLine));
+        assertTrue(HeapRegionSizeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
-        assertEquals(JdkUtil.LogEventType.HEAP_REGION_SIZE + "not identified.", JdkUtil.LogEventType.HEAP_REGION_SIZE,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.HEAP_REGION_SIZE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.HEAP_REGION_SIZE + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.003s][info][gc,heap] Heap region size: 1M";
-        assertTrue(JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof HeapRegionSizeEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof HeapRegionSizeEvent, JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[25.016s][info][gc,heap,exit  ] Heap";
-        assertFalse(JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_REGION_SIZE));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.HEAP_REGION_SIZE), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.HEAP_REGION_SIZE);
-        assertTrue(JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testUptimeMillis() {
         String logLine = "[2019-02-05T14:47:31.091-0200][3ms] Regions: 2606 x 512K";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".",
-                HeapRegionSizeEvent.match(logLine));
+        assertTrue(HeapRegionSizeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.HEAP_REGION_SIZE.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedApplicationStoppedTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedApplicationStoppedTimeEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -34,60 +34,50 @@ public class TestUnifiedApplicationStoppedTimeEvent {
     public void testLogLine() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".",
-                UnifiedApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(UnifiedApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".");
         UnifiedApplicationStoppedTimeEvent event = new UnifiedApplicationStoppedTimeEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 31, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 64, event.getDuration());
+        assertEquals((long) 31,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(64,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedApplicationStoppedTimeEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedApplicationStoppedTimeEvent, JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
-        assertFalse(
-                JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString()
-                        + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString()
+		+ " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_APPLICATION_STOPPED_TIME);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWithSpacesAtEnd() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds   ";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".",
-                UnifiedApplicationStoppedTimeEvent.match(logLine));
+        assertTrue(UnifiedApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedApplicationStoppedTimeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedApplicationStoppedTimeEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedApplicationStoppedTimeEvent {
+class TestUnifiedApplicationStoppedTimeEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
         assertTrue(UnifiedApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".");
@@ -41,21 +41,21 @@ public class TestUnifiedApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
         assertEquals(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedApplicationStoppedTimeEvent, JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString()
@@ -63,19 +63,19 @@ public class TestUnifiedApplicationStoppedTimeEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_APPLICATION_STOPPED_TIME);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWithSpacesAtEnd() {
+    void testLogLineWithSpacesAtEnd() {
         String logLine = "[0.031s][info][safepoint    ] Total time for which application threads were stopped: "
                 + "0.0000643 seconds, Stopping threads took: 0.0000148 seconds   ";
         assertTrue(UnifiedApplicationStoppedTimeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_APPLICATION_STOPPED_TIME.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedBlankLineEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedBlankLineEvent.java
@@ -29,53 +29,53 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedBlankLineEvent {
+class TestUnifiedBlankLineEvent {
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[69.946s][info][gc,stats     ]";
         assertEquals(JdkUtil.LogEventType.UNIFIED_BLANK_LINE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_BLANK_LINE + "not identified.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         String logLine = "[69.946s][info][gc,stats     ]";
         assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_BLANK_LINE);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineUnifiedFooterStats() {
+    void testLineUnifiedFooterStats() {
         String logLine = "[69.946s][info][gc,stats     ]";
         assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
-    public void testLineUnifiedFooterHeap() {
+    void testLineUnifiedFooterHeap() {
         String logLine = "[69.946s][info][gc,heap,exit ]";
         assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
-    public void testLineTimeUptimeMillis() {
+    void testLineTimeUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]";
         assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
-    public void testLineUptimeMillis() {
+    void testLineUptimeMillis() {
         String logLine = "[1357910ms]";
         assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]   ";
         assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedBlankLineEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedBlankLineEvent.java
@@ -12,9 +12,10 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,57 +34,49 @@ public class TestUnifiedBlankLineEvent {
     @Test
     public void testIdentityEventType() {
         String logLine = "[69.946s][info][gc,stats     ]";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_BLANK_LINE + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_BLANK_LINE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_BLANK_LINE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_BLANK_LINE + "not identified.");
     }
 
     @Test
     public void testReportable() {
         String logLine = "[69.946s][info][gc,stats     ]";
-        assertFalse(JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " incorrectly indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isReportable(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " incorrectly indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_BLANK_LINE);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineUnifiedFooterStats() {
         String logLine = "[69.946s][info][gc,stats     ]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".",
-                UnifiedBlankLineEvent.match(logLine));
+        assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
     public void testLineUnifiedFooterHeap() {
         String logLine = "[69.946s][info][gc,heap,exit ]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".",
-                UnifiedBlankLineEvent.match(logLine));
+        assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
     public void testLineTimeUptimeMillis() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".",
-                UnifiedBlankLineEvent.match(logLine));
+        assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
     public void testLineUptimeMillis() {
         String logLine = "[1357910ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".",
-                UnifiedBlankLineEvent.match(logLine));
+        assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[2019-02-05T15:10:08.998-0200][1357910ms]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".",
-                UnifiedBlankLineEvent.match(logLine));
+        assertTrue(UnifiedBlankLineEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_BLANK_LINE.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedCmsInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedCmsInitialMarkEvent.java
@@ -11,9 +11,8 @@
  *    Mike Millson - initial API and implementation                                                                   *
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +20,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,69 +31,61 @@ public class TestUnifiedCmsInitialMarkEvent {
     @Test
     public void testLogLine() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".",
-                UnifiedCmsInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");
         UnifiedCmsInitialMarkEvent event = new UnifiedCmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 178 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 157, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) (178 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(157,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedCmsInitialMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedCmsInitialMarkEvent, JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testBlocking() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CMS_INITIAL_MARK);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".",
-                UnifiedCmsInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLineWithTimesData() {
         String logLine = "[0.053s][info][gc           ] GC(1) Pause Initial Mark 0M->0M(2M) 0.278ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".",
-                UnifiedCmsInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");
         UnifiedCmsInitialMarkEvent event = new UnifiedCmsInitialMarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 53 - 0, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 278, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals((long) (53 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(278,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedCmsInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedCmsInitialMarkEvent.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedCmsInitialMarkEvent {
+class TestUnifiedCmsInitialMarkEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
         assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");
         UnifiedCmsInitialMarkEvent event = new UnifiedCmsInitialMarkEvent(logLine);
@@ -41,43 +41,43 @@ public class TestUnifiedCmsInitialMarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
         assertEquals(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedCmsInitialMarkEvent, JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testBlocking() {
+    void testBlocking() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CMS_INITIAL_MARK);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.178s][info][gc] GC(5) Pause Initial Mark 1M->1M(2M) 0.157ms     ";
         assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLineWithTimesData() {
+    void testLogLineWithTimesData() {
         String logLine = "[0.053s][info][gc           ] GC(1) Pause Initial Mark 0M->0M(2M) 0.278ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedCmsInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedConcurrentEvent.java
@@ -27,247 +27,247 @@ import org.junit.jupiter.api.Test;
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  */
-public class TestUnifiedConcurrentEvent {
+class TestUnifiedConcurrentEvent {
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
         assertEquals(JdkUtil.LogEventType.UNIFIED_CONCURRENT,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_CONCURRENT + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedConcurrentEvent, JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CONCURRENT), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark    ";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentMark() {
+    void testConcurrentMark() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentMarkWithDuration() {
+    void testConcurrentMarkWithDuration() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Mark 1.428ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentMarkWithTimesData() {
+    void testConcurrentMarkWithTimesData() {
         String logLine = "[0.054s][info][gc           ] GC(1) Concurrent Mark 1.260ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentPreclean() {
+    void testConcurrentPreclean() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Preclean";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentPrecleanWithDuration() {
+    void testConcurrentPrecleanWithDuration() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Preclean 0.032ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentPrecleanWithTimesData() {
+    void testConcurrentPrecleanWithTimesData() {
         String logLine = "[0.054s][info][gc           ] GC(1) Concurrent Preclean 0.033ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentSweep() {
+    void testConcurrentSweep() {
         String logLine = "[0.084s][info][gc] GC(1) Concurrent Sweep";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentSweepWithDuration() {
+    void testConcurrentSweepWithDuration() {
         String logLine = "[0.085s][info][gc] GC(1) Concurrent Sweep 0.364ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentSweepWithTimesData() {
+    void testConcurrentSweepWithTimesData() {
         String logLine = "[0.055s][info][gc           ] GC(1) Concurrent Sweep 0.298ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentReset() {
+    void testConcurrentReset() {
         String logLine = "[0.085s][info][gc] GC(1) Concurrent Reset";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentResetWithDuration() {
+    void testConcurrentResetWithDuration() {
         String logLine = "[0.086s][info][gc] GC(1) Concurrent Reset 0.841ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentResetWithTimesData() {
+    void testConcurrentResetWithTimesData() {
         String logLine = "[0.056s][info][gc           ] GC(1) Concurrent Reset 0.693ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[14.859s][info][gc] GC(1083) Concurrent Cycle";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testLogLineCycleWithDuration() {
+    void testLogLineCycleWithDuration() {
         String logLine = "[14.904s][info][gc] GC(1083) Concurrent Cycle 45.374ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCycleDetailed() {
+    void testCycleDetailed() {
         String logLine = "[16.601s][info][gc           ] GC(1033) Concurrent Cycle";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCycleDetailed12Spaces() {
+    void testCycleDetailed12Spaces() {
         String logLine = "[16.121s][info][gc            ] GC(974) Concurrent Cycle";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCycleDetailedWithDuration() {
+    void testCycleDetailedWithDuration() {
         String logLine = "[16.082s][info][gc            ] GC(969) Concurrent Cycle 65.746ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testClearClaimedMarks() {
+    void testClearClaimedMarks() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Clear Claimed Marks";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testClearClaimedMarksWithDuration() {
+    void testClearClaimedMarksWithDuration() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Clear Claimed Marks 0.019ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testScanRootRegions() {
+    void testScanRootRegions() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Scan Root Regions";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testScanRootRegionsWithDuration() {
+    void testScanRootRegionsWithDuration() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Scan Root Regions 0.283ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkTimestamp() {
+    void testMarkTimestamp() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Mark (16.601s)";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkDoubleTimestampWithDuration() {
+    void testMarkDoubleTimestampWithDuration() {
         String logLine = "[16.050s][info][gc,marking   ] GC(969) Concurrent Mark (16.017s, 16.050s) 33.614ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUsingWorkersForMarking() {
+    void testUsingWorkersForMarking() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Mark From Roots";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testUsingWorkersForFullCompaction() {
+    void testUsingWorkersForFullCompaction() {
         String logLine = "[2020-06-24T18:13:47.695-0700][173690ms] GC(74) Using 2 workers of 2 for full compaction";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testMarkFromRoots() {
+    void testMarkFromRoots() {
         String logLine = "[16.601s][info][gc,task      ] GC(1033) Using 1 workers of 1 for marking";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPreclean() {
+    void testPreclean() {
         String logLine = "[16.601s][info][gc,task      ] GC(1033) Using 1 workers of 1 for marking";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testPrecleanWithDuration() {
+    void testPrecleanWithDuration() {
         String logLine = "[16.050s][info][gc,marking   ] GC(969) Concurrent Preclean 0.115ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testRebuildRememberedSets() {
+    void testRebuildRememberedSets() {
         String logLine = "[16.053s][info][gc,marking    ] GC(969) Concurrent Rebuild Remembered Sets";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCleanupForNextMark() {
+    void testCleanupForNextMark() {
         String logLine = "[16.082s][info][gc,marking    ] GC(969) Concurrent Cleanup for Next Mark";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCleanupForNextMarkWithDuration() {
+    void testCleanupForNextMarkWithDuration() {
         String logLine = "[16.082s][info][gc,marking    ] GC(969) Concurrent Cleanup for Next Mark 0.428ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCreateLiveData() {
+    void testCreateLiveData() {
         String logLine = "[2.730s][info][gc,marking    ] GC(52) Concurrent Create Live Data";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testCreateLiveDataWithDuration() {
+    void testCreateLiveDataWithDuration() {
         String logLine = "[2.731s][info][gc,marking    ] GC(52) Concurrent Create Live Data 0.483ms";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
-    public void testConcurrentMarkAbort() {
+    void testConcurrentMarkAbort() {
         String logLine = "[2020-06-24T18:13:51.156-0700][177151ms] GC(73) Concurrent Mark Abort";
         assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedConcurrentEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedConcurrentEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,283 +32,243 @@ public class TestUnifiedConcurrentEvent {
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_CONCURRENT + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_CONCURRENT, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_CONCURRENT,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_CONCURRENT + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedConcurrentEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedConcurrentEvent, JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
-        assertFalse(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CONCURRENT));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_CONCURRENT), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentMark() {
         String logLine = "[0.082s][info][gc] GC(1) Concurrent Mark";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentMarkWithDuration() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Mark 1.428ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentMarkWithTimesData() {
         String logLine = "[0.054s][info][gc           ] GC(1) Concurrent Mark 1.260ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentPreclean() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Preclean";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentPrecleanWithDuration() {
         String logLine = "[0.083s][info][gc] GC(1) Concurrent Preclean 0.032ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentPrecleanWithTimesData() {
         String logLine = "[0.054s][info][gc           ] GC(1) Concurrent Preclean 0.033ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentSweep() {
         String logLine = "[0.084s][info][gc] GC(1) Concurrent Sweep";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentSweepWithDuration() {
         String logLine = "[0.085s][info][gc] GC(1) Concurrent Sweep 0.364ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentSweepWithTimesData() {
         String logLine = "[0.055s][info][gc           ] GC(1) Concurrent Sweep 0.298ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentReset() {
         String logLine = "[0.085s][info][gc] GC(1) Concurrent Reset";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentResetWithDuration() {
         String logLine = "[0.086s][info][gc] GC(1) Concurrent Reset 0.841ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentResetWithTimesData() {
         String logLine = "[0.056s][info][gc           ] GC(1) Concurrent Reset 0.693ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testLogLine() {
         String logLine = "[14.859s][info][gc] GC(1083) Concurrent Cycle";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testLogLineCycleWithDuration() {
         String logLine = "[14.904s][info][gc] GC(1083) Concurrent Cycle 45.374ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCycleDetailed() {
         String logLine = "[16.601s][info][gc           ] GC(1033) Concurrent Cycle";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCycleDetailed12Spaces() {
         String logLine = "[16.121s][info][gc            ] GC(974) Concurrent Cycle";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCycleDetailedWithDuration() {
         String logLine = "[16.082s][info][gc            ] GC(969) Concurrent Cycle 65.746ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testClearClaimedMarks() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Clear Claimed Marks";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testClearClaimedMarksWithDuration() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Clear Claimed Marks 0.019ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testScanRootRegions() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Scan Root Regions";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testScanRootRegionsWithDuration() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Scan Root Regions 0.283ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkTimestamp() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Mark (16.601s)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkDoubleTimestampWithDuration() {
         String logLine = "[16.050s][info][gc,marking   ] GC(969) Concurrent Mark (16.017s, 16.050s) 33.614ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUsingWorkersForMarking() {
         String logLine = "[16.601s][info][gc,marking   ] GC(1033) Concurrent Mark From Roots";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testUsingWorkersForFullCompaction() {
         String logLine = "[2020-06-24T18:13:47.695-0700][173690ms] GC(74) Using 2 workers of 2 for full compaction";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testMarkFromRoots() {
         String logLine = "[16.601s][info][gc,task      ] GC(1033) Using 1 workers of 1 for marking";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPreclean() {
         String logLine = "[16.601s][info][gc,task      ] GC(1033) Using 1 workers of 1 for marking";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testPrecleanWithDuration() {
         String logLine = "[16.050s][info][gc,marking   ] GC(969) Concurrent Preclean 0.115ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testRebuildRememberedSets() {
         String logLine = "[16.053s][info][gc,marking    ] GC(969) Concurrent Rebuild Remembered Sets";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCleanupForNextMark() {
         String logLine = "[16.082s][info][gc,marking    ] GC(969) Concurrent Cleanup for Next Mark";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCleanupForNextMarkWithDuration() {
         String logLine = "[16.082s][info][gc,marking    ] GC(969) Concurrent Cleanup for Next Mark 0.428ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCreateLiveData() {
         String logLine = "[2.730s][info][gc,marking    ] GC(52) Concurrent Create Live Data";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testCreateLiveDataWithDuration() {
         String logLine = "[2.731s][info][gc,marking    ] GC(52) Concurrent Create Live Data 0.483ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 
     @Test
     public void testConcurrentMarkAbort() {
         String logLine = "[2020-06-24T18:13:51.156-0700][177151ms] GC(73) Concurrent Mark Abort";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".",
-                UnifiedConcurrentEvent.match(logLine));
+        assertTrue(UnifiedConcurrentEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1CleanupEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1CleanupEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,76 +33,66 @@ public class TestUnifiedG1CleanupEvent {
     @Test
     public void testLogLine() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".",
-                UnifiedG1CleanupEvent.match(logLine));
+        assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");
         UnifiedG1CleanupEvent event = new UnifiedG1CleanupEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 15101 - 0, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(30 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(30 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(44 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 0, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (15101 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(30 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(44 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(0,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_G1_CLEANUP, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_CLEANUP + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1CleanupEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1CleanupEvent, JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_CLEANUP);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".",
-                UnifiedG1CleanupEvent.match(logLine));
+        assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");
     }
 
     @Test
     public void testLogLinePreprocessed() {
         String logLine = "[16.082s][info][gc            ] GC(969) Pause Cleanup 28M->28M(46M) 0.064ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".",
-                UnifiedG1CleanupEvent.match(logLine));
+        assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");
         UnifiedG1CleanupEvent event = new UnifiedG1CleanupEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 16082 - 0, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(28 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(28 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(46 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 0, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (16082 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(28 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(46 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(0,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1CleanupEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1CleanupEvent.java
@@ -28,10 +28,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1CleanupEvent {
+class TestUnifiedG1CleanupEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
         assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");
         UnifiedG1CleanupEvent event = new UnifiedG1CleanupEvent(logLine);
@@ -44,43 +44,43 @@ public class TestUnifiedG1CleanupEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_CLEANUP + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1CleanupEvent, JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_CLEANUP);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[15.101s][info][gc] GC(1099) Pause Cleanup 30M->30M(44M) 0.058ms     ";
         assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");
     }
 
     @Test
-    public void testLogLinePreprocessed() {
+    void testLogLinePreprocessed() {
         String logLine = "[16.082s][info][gc            ] GC(969) Pause Cleanup 28M->28M(46M) 0.064ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1CleanupEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1InfoEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1InfoEvent.java
@@ -28,46 +28,46 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1InfoEvent {
+class TestUnifiedG1InfoEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
         assertTrue(UnifiedG1InfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".");
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_INFO,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_INFO + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1InfoEvent, JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_INFO), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_INFO);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLine6Spaces() {
+    void testLogLine6Spaces() {
         String logLine = "[2.751s][info][gc,start      ] GC(53) Pause Initial Mark (G1 Humongous Allocation)";
         assertTrue(UnifiedG1InfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1InfoEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1InfoEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +22,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,49 +33,42 @@ public class TestUnifiedG1InfoEvent {
     @Test
     public void testLogLine() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".",
-                UnifiedG1InfoEvent.match(logLine));
+        assertTrue(UnifiedG1InfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_INFO + "not identified.", JdkUtil.LogEventType.UNIFIED_G1_INFO,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_INFO,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_INFO + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1InfoEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1InfoEvent, JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[2.726s][info][gc,start     ] GC(51) Pause Initial Mark (G1 Humongous Allocation)";
-        assertFalse(JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertFalse(JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_INFO));
+        assertFalse(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_INFO), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_INFO);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLine6Spaces() {
         String logLine = "[2.751s][info][gc,start      ] GC(53) Pause Initial Mark (G1 Humongous Allocation)";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".",
-                UnifiedG1InfoEvent.match(logLine));
+        assertTrue(UnifiedG1InfoEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_INFO.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1MixedPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1MixedPauseEvent.java
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1MixedPauseEvent {
+class TestUnifiedG1MixedPauseEvent {
 
     @Test
-    public void testLogLinePreprocessed() {
+    void testLogLinePreprocessed() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".");
@@ -60,28 +60,28 @@ public class TestUnifiedG1MixedPauseEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1MixedPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE;
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
@@ -92,19 +92,19 @@ public class TestUnifiedG1MixedPauseEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_MIXED_PAUSE);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s     ";
         ;
@@ -112,7 +112,7 @@ public class TestUnifiedG1MixedPauseEvent {
     }
 
     @Test
-    public void testPreprocessing() {
+    void testPreprocessing() {
         File testFile = TestUtil.getFile("dataset169.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1MixedPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1MixedPauseEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,47 +42,42 @@ public class TestUnifiedG1MixedPauseEvent {
     public void testLogLinePreprocessed() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".",
-                UnifiedG1MixedPauseEvent.match(logLine));
+        assertTrue(UnifiedG1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".");
         UnifiedG1MixedPauseEvent event = new UnifiedG1MixedPauseEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 16629, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(3801), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(3801), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(15 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(31 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1202, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 16629,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(3801),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(3801),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(kilobytes(15 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1202,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1MixedPauseEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1MixedPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -92,22 +87,20 @@ public class TestUnifiedG1MixedPauseEvent {
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s";
         long timestamp = 15108;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedG1MixedPauseEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedG1MixedPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_MIXED_PAUSE);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -115,8 +108,7 @@ public class TestUnifiedG1MixedPauseEvent {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 15M->12M(31M) 1.202ms User=0.00s Sys=0.00s Real=0.00s     ";
         ;
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".",
-                UnifiedG1MixedPauseEvent.match(logLine));
+        assertTrue(UnifiedG1MixedPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".");
     }
 
     @Test
@@ -126,10 +118,8 @@ public class TestUnifiedG1MixedPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_MIXED_PAUSE.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungInitialMarkEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -35,73 +35,61 @@ public class TestUnifiedG1YoungInitialMarkEvent {
     public void testLogLine() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".",
-                UnifiedG1YoungInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");
         UnifiedG1YoungInitialMarkEvent event = new UnifiedG1YoungInitialMarkEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString(),
-                event.getName());
-        assertEquals("Time stamp not parsed correctly.", 2752 - 1, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.",
-                event.getTrigger().matches(JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(562 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(5 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1250 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1212, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (2752 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(562 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(5 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1250 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1212,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungInitialMarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungInitialMarkEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".",
-                UnifiedG1YoungInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     @Test
     public void testLogLine11Spaces() {
         String logLine = "[2.727s][info][gc           ] GC(51) Pause Initial Mark (G1 Humongous Allocation) "
                 + "1162M->5M(1250M) 1.336ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".",
-                UnifiedG1YoungInitialMarkEvent.match(logLine));
+        assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungInitialMarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungInitialMarkEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1YoungInitialMarkEvent {
+class TestUnifiedG1YoungInitialMarkEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");
@@ -47,47 +47,47 @@ public class TestUnifiedG1YoungInitialMarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungInitialMarkEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[2.752s][info][gc            ] GC(53) Pause Initial Mark (G1 Humongous Allocation) "
                 + "562M->5M(1250M) 1.212ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     @Test
-    public void testLogLine11Spaces() {
+    void testLogLine11Spaces() {
         String logLine = "[2.727s][info][gc           ] GC(51) Pause Initial Mark (G1 Humongous Allocation) "
                 + "1162M->5M(1250M) 1.336ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1YoungInitialMarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_INITIAL_MARK.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPauseEvent.java
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1YoungPauseEvent {
+class TestUnifiedG1YoungPauseEvent {
 
     @Test
-    public void testLogLinePreprocessed() {
+    void testLogLinePreprocessed() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
@@ -57,28 +57,28 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE;
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
@@ -89,26 +89,26 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_PAUSE);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s    ";
         assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
-    public void testLogLinePreprocessedDatestampMillis() {
+    void testLogLinePreprocessedDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 26116K->26116K(278528K) 65M->8M(1304M) 57.263ms User=0.02s Sys=0.01s Real=0.06s";
         assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
@@ -130,7 +130,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedTimeUptimemillisTriggerGcLocker() {
+    void testLogLinePreprocessedTimeUptimemillisTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.136+0000][11728ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC) "
                 + "Metaspace: 35318K->35318K(288768K) 78M->22M(1304M) 35.722ms User=0.02s Sys=0.00s Real=0.04s";
         assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
@@ -152,7 +152,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedConcurrentStartTriggerMetaGcThreshold() {
+    void testLogLinePreprocessedConcurrentStartTriggerMetaGcThreshold() {
         String logLine = "[2020-06-24T18:11:52.676-0700][58671ms] GC(44) Pause Young (Concurrent Start) "
                 + "(Metadata GC Threshold) Metaspace: 88802K->88802K(1134592K) 733M->588M(1223M) 105.541ms "
                 + "User=0.18s Sys=0.00s Real=0.11s";
@@ -175,7 +175,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testUnifiedG1YoungPauseJdk9() {
+    void testUnifiedG1YoungPauseJdk9() {
         File testFile = TestUtil.getFile("dataset158.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -187,7 +187,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testUnifiedG1YoungPauseDatestampMillis() {
+    void testUnifiedG1YoungPauseDatestampMillis() {
         File testFile = TestUtil.getFile("dataset166.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -199,7 +199,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testUnifiedG1YoungPauseConcurrentStartTriggerMetaGcThreshold() {
+    void testUnifiedG1YoungPauseConcurrentStartTriggerMetaGcThreshold() {
         File testFile = TestUtil.getFile("dataset183.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -211,7 +211,7 @@ public class TestUnifiedG1YoungPauseEvent {
     }
 
     @Test
-    public void testUnifiedG1YoungPauseConcurrentStartTriggerG1HumongousAllocation() {
+    void testUnifiedG1YoungPauseConcurrentStartTriggerG1HumongousAllocation() {
         File testFile = TestUtil.getFile("dataset185.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPauseEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPauseEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,44 +42,39 @@ public class TestUnifiedG1YoungPauseEvent {
     public void testLogLinePreprocessed() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                UnifiedG1YoungPauseEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
         UnifiedG1YoungPauseEvent event = new UnifiedG1YoungPauseEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 15086 - 0, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(3771), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(3771), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(24 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(13 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(31 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 401, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (15086 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(3771),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(3771),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(kilobytes(24 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(13 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(401,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPauseEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -89,80 +84,71 @@ public class TestUnifiedG1YoungPauseEvent {
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedG1YoungPauseEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedG1YoungPauseEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_PAUSE);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[15.086s][info][gc,start     ] GC(1192) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 3771K->3771K(1056768K) 24M->13M(31M) 0.401ms User=0.00s Sys=0.00s Real=0.00s    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                UnifiedG1YoungPauseEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
     public void testLogLinePreprocessedDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "Metaspace: 26116K->26116K(278528K) 65M->8M(1304M) 57.263ms User=0.02s Sys=0.01s Real=0.06s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                UnifiedG1YoungPauseEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
         UnifiedG1YoungPauseEvent event = new UnifiedG1YoungPauseEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 5355, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(26116), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(26116), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(278528), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(65 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(8 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1304 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 57263, event.getDuration());
-        assertEquals("User time not parsed correctly.", 2, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 6, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 50, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 5355,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(26116),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(26116),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(278528),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(kilobytes(65 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(8 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1304 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(57263,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(2,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(6,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(50,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedTimeUptimemillisTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.136+0000][11728ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC) "
                 + "Metaspace: 35318K->35318K(288768K) 78M->22M(1304M) 35.722ms User=0.02s Sys=0.00s Real=0.04s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                UnifiedG1YoungPauseEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
         UnifiedG1YoungPauseEvent event = new UnifiedG1YoungPauseEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 11728, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC));
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(35318), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(35318), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(288768), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(78 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(22 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1304 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 35722, event.getDuration());
-        assertEquals("User time not parsed correctly.", 2, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 4, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 50, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 11728,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(35318),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(35318),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(288768),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(kilobytes(78 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(22 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1304 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(35722,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(2,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(4,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(50,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -170,25 +156,22 @@ public class TestUnifiedG1YoungPauseEvent {
         String logLine = "[2020-06-24T18:11:52.676-0700][58671ms] GC(44) Pause Young (Concurrent Start) "
                 + "(Metadata GC Threshold) Metaspace: 88802K->88802K(1134592K) 733M->588M(1223M) 105.541ms "
                 + "User=0.18s Sys=0.00s Real=0.11s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                UnifiedG1YoungPauseEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPauseEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
         UnifiedG1YoungPauseEvent event = new UnifiedG1YoungPauseEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 58671, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD));
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(88802), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(88802), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1134592), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(733 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(588 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1223 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 105541, event.getDuration());
-        assertEquals("User time not parsed correctly.", 18, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 0, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 11, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 164, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 58671,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(88802),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(88802),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1134592),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(kilobytes(733 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(588 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1223 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(105541,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(18,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(11,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(164,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -198,11 +181,9 @@ public class TestUnifiedG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
@@ -212,11 +193,9 @@ public class TestUnifiedG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
@@ -226,11 +205,9 @@ public class TestUnifiedG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 
     @Test
@@ -240,10 +217,8 @@ public class TestUnifiedG1YoungPauseEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPrepareMixedEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPrepareMixedEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,48 +42,42 @@ public class TestUnifiedG1YoungPrepareMixedEvent {
     public void testLogLinePreprocessed() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".",
-                UnifiedG1YoungPrepareMixedEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPrepareMixedEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".");
         UnifiedG1YoungPrepareMixedEvent event = new UnifiedG1YoungPrepareMixedEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString(),
-                event.getName());
-        assertEquals("Time stamp not parsed correctly.", 16627 - 0, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE));
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(3801), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(3801), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(24 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(13 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(31 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 361, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (16627 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(3801),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(3801),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(kilobytes(24 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(13 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(31 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(361,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPrepareMixedEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPrepareMixedEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -93,31 +87,27 @@ public class TestUnifiedG1YoungPrepareMixedEvent {
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
         long timestamp = 15108;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
-                        duration) instanceof UnifiedG1YoungPrepareMixedEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
+		duration) instanceof UnifiedG1YoungPrepareMixedEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".",
-                UnifiedG1YoungPrepareMixedEvent.match(logLine));
+        assertTrue(UnifiedG1YoungPrepareMixedEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".");
     }
 
     @Test
@@ -127,11 +117,9 @@ public class TestUnifiedG1YoungPrepareMixedEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPrepareMixedEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedG1YoungPrepareMixedEvent.java
@@ -36,10 +36,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedG1YoungPrepareMixedEvent {
+class TestUnifiedG1YoungPrepareMixedEvent {
 
     @Test
-    public void testLogLinePreprocessed() {
+    void testLogLinePreprocessed() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedG1YoungPrepareMixedEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".");
@@ -60,28 +60,28 @@ public class TestUnifiedG1YoungPrepareMixedEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
         assertEquals(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedG1YoungPrepareMixedEvent, JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED;
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s";
@@ -92,26 +92,26 @@ public class TestUnifiedG1YoungPrepareMixedEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[16.627s][info][gc,start      ] GC(1354) Pause Young (Prepare Mixed) (G1 Evacuation Pause) "
                 + "Metaspace: 3801K->3801K(1056768K) 24M->13M(31M) 0.361ms User=0.00s Sys=0.00s Real=0.00s    ";
         assertTrue(UnifiedG1YoungPrepareMixedEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PREPARE_MIXED.toString() + ".");
     }
 
     @Test
-    public void testPreprocessing() {
+    void testPreprocessing() {
         File testFile = TestUtil.getFile("dataset168.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedOldEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,83 +42,72 @@ public class TestUnifiedOldEvent {
     @Test
     public void testLogLine() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                UnifiedOldEvent.match(logLine));
+        assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
         UnifiedOldEvent event = new UnifiedOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 231 - 2, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(1 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(1 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(7 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 2969, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (231 - 2),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(1 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(7 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(2969,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_OLD + "not identified.", JdkUtil.LogEventType.UNIFIED_OLD,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_OLD,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_OLD + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedOldEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedOldEvent, JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_OLD));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_OLD), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_OLD);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                UnifiedOldEvent.match(logLine));
+        assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
     }
 
     @Test
     public void testPreprocessedTriggerSystemGc() {
         String logLine = "[2020-06-24T18:13:47.695-0700][173690ms] GC(74) Pause Full (System.gc()) Metaspace: "
                 + "260211K->260197K(1290240K) 887M->583M(1223M) 3460.196ms User=1.78s Sys=0.01s Real=3.46s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                UnifiedOldEvent.match(logLine));
+        assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
         UnifiedOldEvent event = new UnifiedOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 173690 - 3460, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Metaspace begin size not parsed correctly.", kilobytes(260211), event.getPermOccupancyInit());
-        assertEquals("Metaspace end size not parsed correctly.", kilobytes(260197), event.getPermOccupancyEnd());
-        assertEquals("Metaspace allocation size not parsed correctly.", kilobytes(1290240), event.getPermSpace());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(887 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(583 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(1223 * 1024),
-                event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 3460196, event.getDuration());
-        assertEquals("User time not parsed correctly.", 178, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 346, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 52, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (173690 - 3460),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(260211),event.getPermOccupancyInit(),"Metaspace begin size not parsed correctly.");
+        assertEquals(kilobytes(260197),event.getPermOccupancyEnd(),"Metaspace end size not parsed correctly.");
+        assertEquals(kilobytes(1290240),event.getPermSpace(),"Metaspace allocation size not parsed correctly.");
+        assertEquals(kilobytes(887 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(583 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(1223 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(3460196,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(178,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(346,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(52,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -128,15 +117,11 @@ public class TestUnifiedOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD));
-        assertTrue(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING), Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.");
     }
 
     @Test
@@ -146,17 +131,12 @@ public class TestUnifiedOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SERIAL));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SERIAL), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN), Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.");
     }
 
     @Test
@@ -166,10 +146,8 @@ public class TestUnifiedOldEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_OLD), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedOldEvent.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedOldEvent {
+class TestUnifiedOldEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
         assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
         UnifiedOldEvent event = new UnifiedOldEvent(logLine);
@@ -54,43 +54,43 @@ public class TestUnifiedOldEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
         assertEquals(JdkUtil.LogEventType.UNIFIED_OLD,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_OLD + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedOldEvent, JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_OLD), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_OLD);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.231s][info][gc] GC(6) Pause Full (Ergonomics) 1M->1M(7M) 2.969ms     ";
         assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
     }
 
     @Test
-    public void testPreprocessedTriggerSystemGc() {
+    void testPreprocessedTriggerSystemGc() {
         String logLine = "[2020-06-24T18:13:47.695-0700][173690ms] GC(74) Pause Full (System.gc()) Metaspace: "
                 + "260211K->260197K(1290240K) 887M->583M(1223M) 3460.196ms User=1.78s Sys=0.01s Real=3.46s";
         assertTrue(UnifiedOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_OLD.toString() + ".");
@@ -111,7 +111,7 @@ public class TestUnifiedOldEvent {
     }
 
     @Test
-    public void testUnifiedOldStandardLogging() {
+    void testUnifiedOldStandardLogging() {
         File testFile = TestUtil.getFile("dataset148.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -125,7 +125,7 @@ public class TestUnifiedOldEvent {
     }
 
     @Test
-    public void testUnifiedOldExplictGc() {
+    void testUnifiedOldExplictGc() {
         File testFile = TestUtil.getFile("dataset153.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -140,7 +140,7 @@ public class TestUnifiedOldEvent {
     }
 
     @Test
-    public void testUnifiedSerialOldTriggerSystemGc() {
+    void testUnifiedSerialOldTriggerSystemGc() {
         File testFile = TestUtil.getFile("dataset184.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParNewEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedParNewEvent {
+class TestUnifiedParNewEvent {
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
@@ -58,7 +58,7 @@ public class TestUnifiedParNewEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
@@ -66,7 +66,7 @@ public class TestUnifiedParNewEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
@@ -74,7 +74,7 @@ public class TestUnifiedParNewEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
@@ -82,7 +82,7 @@ public class TestUnifiedParNewEvent {
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_PAR_NEW;
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
@@ -93,19 +93,19 @@ public class TestUnifiedParNewEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PAR_NEW), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PAR_NEW);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s    ";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParNewEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -36,26 +36,25 @@ public class TestUnifiedParNewEvent {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + ".",
-                UnifiedParNewEvent.match(logLine));
+        assertTrue(UnifiedParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + ".");
         UnifiedParNewEvent event = new UnifiedParNewEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 49, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(974), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(128), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1152), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(518), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(960), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(250), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(250), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3544, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Sys time not parsed correctly.", 1, event.getTimeSys());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 200, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 49,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(974),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(128),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1152),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(518),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(960),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(250),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(250),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3544,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeSys(),"Sys time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(200,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -63,8 +62,7 @@ public class TestUnifiedParNewEvent {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_PAR_NEW + "not identified.", JdkUtil.LogEventType.UNIFIED_PAR_NEW,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PAR_NEW,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_PAR_NEW + "not identified.");
     }
 
     @Test
@@ -72,8 +70,7 @@ public class TestUnifiedParNewEvent {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedParNewEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedParNewEvent, JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not parsed.");
     }
 
     @Test
@@ -81,8 +78,7 @@ public class TestUnifiedParNewEvent {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -93,22 +89,19 @@ public class TestUnifiedParNewEvent {
                 + "User=0.01s Sys=0.01s Real=0.01s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedParNewEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedParNewEvent, JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PAR_NEW));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PAR_NEW), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PAR_NEW);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -116,7 +109,6 @@ public class TestUnifiedParNewEvent {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) ParNew: "
                 + "974K->128K(1152K) CMS: 0K->518K(960K) Metaspace: 250K->250K(1056768K) 0M->0M(2M) 3.544ms "
                 + "User=0.01s Sys=0.01s Real=0.01s    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + ".",
-                UnifiedParNewEvent.match(logLine));
+        assertTrue(UnifiedParNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelCompactingOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelCompactingOldEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedParallelCompactingOldEvent {
+class TestUnifiedParallelCompactingOldEvent {
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
@@ -57,7 +57,7 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
@@ -65,7 +65,7 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
@@ -73,7 +73,7 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
@@ -81,7 +81,7 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD;
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
@@ -93,19 +93,19 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s    ";
@@ -113,7 +113,7 @@ public class TestUnifiedParallelCompactingOldEvent {
     }
 
     @Test
-    public void testLogLine7SpacesAfterStart() {
+    void testLogLine7SpacesAfterStart() {
         String logLine = "[28.977s][info][gc,start       ] GC(2269) Pause Full (Ergonomics) PSYoungGen: "
                 + "64K->0K(20992K) ParOldGen: 26612K->21907K(32768K) Metaspace: 3886K->3886K(1056768K) 26M->21M(52M) "
                 + "48.135ms User=0.09s Sys=0.00s Real=0.05s";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelCompactingOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelCompactingOldEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -36,27 +36,24 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".",
-                UnifiedParallelCompactingOldEvent.match(logLine));
+        assertTrue(UnifiedParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".");
         UnifiedParallelCompactingOldEvent event = new UnifiedParallelCompactingOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString(),
-                event.getName());
-        assertEquals("Time stamp not parsed correctly.", 83, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(502), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(496), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1536), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(472), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(432), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2048), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(701), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(701), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 4336, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 1, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 83,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(502),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(496),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1536),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(472),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(432),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2048),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(701),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(701),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(4336,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(1,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -64,8 +61,7 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD + "not identified.");
     }
 
     @Test
@@ -73,8 +69,7 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedParallelCompactingOldEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedParallelCompactingOldEvent, JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not parsed.");
     }
 
     @Test
@@ -82,8 +77,7 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -94,23 +88,20 @@ public class TestUnifiedParallelCompactingOldEvent {
                 + "User=0.01s Sys=0.00s Real=0.01s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
-                        duration) instanceof UnifiedParallelCompactingOldEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp,
+		duration) instanceof UnifiedParallelCompactingOldEvent, JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -118,9 +109,7 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[0.083s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->496K(1536K) "
                 + "ParOldGen: 472K->432K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 4.336ms "
                 + "User=0.01s Sys=0.00s Real=0.01s    ";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".",
-                UnifiedParallelCompactingOldEvent.match(logLine));
+        assertTrue(UnifiedParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".");
     }
 
     @Test
@@ -128,8 +117,6 @@ public class TestUnifiedParallelCompactingOldEvent {
         String logLine = "[28.977s][info][gc,start       ] GC(2269) Pause Full (Ergonomics) PSYoungGen: "
                 + "64K->0K(20992K) ParOldGen: 26612K->21907K(32768K) Metaspace: 3886K->3886K(1056768K) 26M->21M(52M) "
                 + "48.135ms User=0.09s Sys=0.00s Real=0.05s";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".",
-                UnifiedParallelCompactingOldEvent.match(logLine));
+        assertTrue(UnifiedParallelCompactingOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelScavengeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelScavengeEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -36,26 +36,24 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".",
-                UnifiedParallelScavengeEvent.match(logLine));
+        assertTrue(UnifiedParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".");
         UnifiedParallelScavengeEvent event = new UnifiedParallelScavengeEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString(),
-                event.getName());
-        assertEquals("Time stamp not parsed correctly.", 31, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(512), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(464), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1024), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(8), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(512), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(120), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(120), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1195, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", Integer.MAX_VALUE, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 31,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(512),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(464),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1024),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(8),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(512),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(120),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(120),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1195,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(Integer.MAX_VALUE,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -63,8 +61,7 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE + "not identified.");
     }
 
     @Test
@@ -72,8 +69,7 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedParallelScavengeEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedParallelScavengeEvent, JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not parsed.");
     }
 
     @Test
@@ -81,8 +77,7 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -93,22 +88,20 @@ public class TestUnifiedParallelScavengeEvent {
                 + "User=0.01s Sys=0.01s Real=0.00s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not parsed.", JdkUtil
-                .hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedParallelScavengeEvent);
+        assertTrue(JdkUtil
+		.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedParallelScavengeEvent, JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PARALLEL_SCAVENGE);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -116,8 +109,7 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".",
-                UnifiedParallelScavengeEvent.match(logLine));
+        assertTrue(UnifiedParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".");
     }
 
     @Test
@@ -125,8 +117,7 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[15.030s][info][gc,start       ] GC(1199) Pause Young (Allocation Failure) PSYoungGen: "
                 + "20544K->64K(20992K) PSOldGen: 15496K->15504K(17920K) Metaspace: 3779K->3779K(1056768K) "
                 + "35M->15M(38M) 0.402ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".",
-                UnifiedParallelScavengeEvent.match(logLine));
+        assertTrue(UnifiedParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".");
     }
 
     @Test
@@ -134,25 +125,23 @@ public class TestUnifiedParallelScavengeEvent {
         String logLine = "[0.029s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->432K(1024K) ParOldGen: 0K->8K(512K) Metaspace: 121K->121K(1056768K) 0M->0M(1M) 0.762ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".",
-                UnifiedParallelScavengeEvent.match(logLine));
+        assertTrue(UnifiedParallelScavengeEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + ".");
         UnifiedParallelScavengeEvent event = new UnifiedParallelScavengeEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString(),
-                event.getName());
-        assertEquals("Time stamp not parsed correctly.", 29, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(512), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(432), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1024), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(8), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(512), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(121), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(121), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 762, event.getDuration());
-        assertEquals("User time not parsed correctly.", 0, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", 100, event.getParallelism());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 29,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(512),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(432),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1024),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(8),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(512),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(121),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(121),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(762,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(0,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(100,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelScavengeEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedParallelScavengeEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedParallelScavengeEvent {
+class TestUnifiedParallelScavengeEvent {
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
@@ -57,7 +57,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
@@ -65,7 +65,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
@@ -73,7 +73,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s";
@@ -81,7 +81,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE;
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
@@ -93,19 +93,19 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_PARALLEL_SCAVENGE);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.031s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->464K(1024K) PSOldGen: 0K->8K(512K) Metaspace: 120K->120K(1056768K) 0M->0M(1M) 1.195ms "
                 + "User=0.01s Sys=0.01s Real=0.00s    ";
@@ -113,7 +113,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testLogLine7SpacesAfterStart() {
+    void testLogLine7SpacesAfterStart() {
         String logLine = "[15.030s][info][gc,start       ] GC(1199) Pause Young (Allocation Failure) PSYoungGen: "
                 + "20544K->64K(20992K) PSOldGen: 15496K->15504K(17920K) Metaspace: 3779K->3779K(1056768K) "
                 + "35M->15M(38M) 0.402ms User=0.00s Sys=0.00s Real=0.00s";
@@ -121,7 +121,7 @@ public class TestUnifiedParallelScavengeEvent {
     }
 
     @Test
-    public void testPreprocessedParallelCompactingOld() {
+    void testPreprocessedParallelCompactingOld() {
         String logLine = "[0.029s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) PSYoungGen: "
                 + "512K->432K(1024K) ParOldGen: 0K->8K(512K) Metaspace: 121K->121K(1056768K) 0M->0M(1M) 0.762ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedRemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedRemarkEvent.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedRemarkEvent {
+class TestUnifiedRemarkEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
         assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
         UnifiedRemarkEvent event = new UnifiedRemarkEvent(logLine);
@@ -39,43 +39,43 @@ public class TestUnifiedRemarkEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
         assertEquals(JdkUtil.LogEventType.UNIFIED_REMARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_REMARK + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedRemarkEvent, JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_REMARK), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_REMARK);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms           ";
         assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
     }
 
     @Test
-    public void testLogLinePreprocessedWithTimesData() {
+    void testLogLinePreprocessedWithTimesData() {
         String logLine = "[16.053s][info][gc            ] GC(969) Pause Remark 29M->29M(46M) 2.328ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
@@ -88,7 +88,7 @@ public class TestUnifiedRemarkEvent {
     }
 
     @Test
-    public void testLogLinePreprocessedWithTimesData12SpacesAfterGc() {
+    void testLogLinePreprocessedWithTimesData12SpacesAfterGc() {
         String logLine = "[0.091s][info][gc           ] GC(3) Pause Remark 0M->0M(2M) 0.414ms User=0.00s "
                 + "Sys=0.00s Real=0.00s";
         assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedRemarkEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedRemarkEvent.java
@@ -12,8 +12,8 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +21,7 @@ import java.util.List;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,75 +32,66 @@ public class TestUnifiedRemarkEvent {
     @Test
     public void testLogLine() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".",
-                UnifiedRemarkEvent.match(logLine));
+        assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
         UnifiedRemarkEvent event = new UnifiedRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 7944 - 1, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 1767, event.getDuration());
+        assertEquals((long) (7944 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(1767,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_REMARK + "not identified.", JdkUtil.LogEventType.UNIFIED_REMARK,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_REMARK,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_REMARK + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedRemarkEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedRemarkEvent, JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_REMARK));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_REMARK), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_REMARK);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[7.944s][info][gc] GC(6432) Pause Remark 8M->8M(10M) 1.767ms           ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".",
-                UnifiedRemarkEvent.match(logLine));
+        assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
     }
 
     @Test
     public void testLogLinePreprocessedWithTimesData() {
         String logLine = "[16.053s][info][gc            ] GC(969) Pause Remark 29M->29M(46M) 2.328ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".",
-                UnifiedRemarkEvent.match(logLine));
+        assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
         UnifiedRemarkEvent event = new UnifiedRemarkEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 16053 - 2, event.getTimestamp());
-        assertEquals("Duration not parsed correctly.", 2328, event.getDuration());
-        assertEquals("User time not parsed correctly.", 1, event.getTimeUser());
-        assertEquals("Real time not parsed correctly.", 0, event.getTimeReal());
-        assertEquals("Parallelism not calculated correctly.", Integer.MAX_VALUE, event.getParallelism());
+        assertEquals((long) (16053 - 2),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(2328,event.getDuration(),"Duration not parsed correctly.");
+        assertEquals(1,event.getTimeUser(),"User time not parsed correctly.");
+        assertEquals(0,event.getTimeReal(),"Real time not parsed correctly.");
+        assertEquals(Integer.MAX_VALUE,event.getParallelism(),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testLogLinePreprocessedWithTimesData12SpacesAfterGc() {
         String logLine = "[0.091s][info][gc           ] GC(3) Pause Remark 0M->0M(2M) 0.414ms User=0.00s "
                 + "Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".",
-                UnifiedRemarkEvent.match(logLine));
+        assertTrue(UnifiedRemarkEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_REMARK.toString() + ".");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialNewEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedSerialNewEvent {
+class TestUnifiedSerialNewEvent {
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
@@ -54,7 +54,7 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
@@ -62,7 +62,7 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
@@ -70,7 +70,7 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
@@ -78,7 +78,7 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_SERIAL_NEW;
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
@@ -89,19 +89,19 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_SERIAL_NEW);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s   ";
@@ -109,7 +109,7 @@ public class TestUnifiedSerialNewEvent {
     }
 
     @Test
-    public void testLogLine7SpacesAfterStart() {
+    void testLogLine7SpacesAfterStart() {
         String logLine = "[0.112s][info][gc,start       ] GC(3) Pause Young (Allocation Failure) DefNew: "
                 + "1016K->128K(1152K) Tenured: 929K->1044K(1552K) Metaspace: 1222K->1222K(1056768K) 1M->1M(2M) "
                 + "0.700ms User=0.00s Sys=0.00s Real=0.00s";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialNewEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialNewEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -36,22 +36,21 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".",
-                UnifiedSerialNewEvent.match(logLine));
+        assertTrue(UnifiedSerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".");
         UnifiedSerialNewEvent event = new UnifiedSerialNewEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 41, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(983), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(128), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1152), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(0), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(458), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(768), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(246), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(246), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1393, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 41,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(983),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(128),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1152),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(458),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(768),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(246),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(246),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1393,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -59,8 +58,7 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_SERIAL_NEW, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_SERIAL_NEW + "not identified.");
     }
 
     @Test
@@ -68,8 +66,7 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedSerialNewEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedSerialNewEvent, JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not parsed.");
     }
 
     @Test
@@ -77,8 +74,7 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -89,22 +85,19 @@ public class TestUnifiedSerialNewEvent {
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedSerialNewEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedSerialNewEvent, JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_SERIAL_NEW);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -112,8 +105,7 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.041s][info][gc,start     ] GC(0) Pause Young (Allocation Failure) "
                 + "DefNew: 983K->128K(1152K) Tenured: 0K->458K(768K) Metaspace: 246K->246K(1056768K) 0M->0M(1M) "
                 + "1.393ms User=0.00s Sys=0.00s Real=0.00s   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".",
-                UnifiedSerialNewEvent.match(logLine));
+        assertTrue(UnifiedSerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".");
     }
 
     @Test
@@ -121,7 +113,6 @@ public class TestUnifiedSerialNewEvent {
         String logLine = "[0.112s][info][gc,start       ] GC(3) Pause Young (Allocation Failure) DefNew: "
                 + "1016K->128K(1152K) Tenured: 929K->1044K(1552K) Metaspace: 1222K->1222K(1056768K) 1M->1M(2M) "
                 + "0.700ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".",
-                UnifiedSerialNewEvent.match(logLine));
+        assertTrue(UnifiedSerialNewEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialOldEvent.java
@@ -13,8 +13,8 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -36,22 +36,21 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".",
-                UnifiedSerialOldEvent.match(logLine));
+        assertTrue(UnifiedSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".");
         UnifiedSerialOldEvent event = new UnifiedSerialOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 75, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(1152), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(0), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1152), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(458), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(929), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(960), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(697), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(697), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 3061, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 75,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(1152),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(0),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1152),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(458),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(929),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(960),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(697),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(697),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(3061,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
@@ -59,8 +58,7 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD + "not identified.",
-                JdkUtil.LogEventType.UNIFIED_SERIAL_OLD, JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_SERIAL_OLD + "not identified.");
     }
 
     @Test
@@ -68,8 +66,7 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedSerialOldEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedSerialOldEvent, JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not parsed.");
     }
 
     @Test
@@ -77,8 +74,7 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as blocking.");
     }
 
     @Test
@@ -89,22 +85,19 @@ public class TestUnifiedSerialOldEvent {
                 + "User=0.00s Sys=0.00s Real=0.00s";
         long timestamp = 27091;
         int duration = 0;
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not parsed.",
-                JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedSerialOldEvent);
+        assertTrue(JdkUtil.hydrateBlockingEvent(eventType, logLine, timestamp, duration) instanceof UnifiedSerialOldEvent, JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not parsed.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_SERIAL_OLD);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
@@ -112,8 +105,7 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".",
-                UnifiedSerialOldEvent.match(logLine));
+        assertTrue(UnifiedSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -121,8 +113,7 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.119s][info][gc,start       ] GC(5) Pause Full (Allocation Failure) DefNew: "
                 + "1142K->110K(1152K) Tenured: 1044K->1934K(1936K) Metaspace: 1295K->1295K(1056768K) 2M->1M(4M) "
                 + "3.178ms User=0.00s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".",
-                UnifiedSerialOldEvent.match(logLine));
+        assertTrue(UnifiedSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".");
     }
 
     @Test
@@ -130,22 +121,21 @@ public class TestUnifiedSerialOldEvent {
         String logLine = "[0.091s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->436K(1536K) "
                 + "PSOldGen: 460K->511K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 1.849ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".",
-                UnifiedSerialOldEvent.match(logLine));
+        assertTrue(UnifiedSerialOldEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + ".");
         UnifiedSerialOldEvent event = new UnifiedSerialOldEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 91, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS));
-        assertEquals("Young begin size not parsed correctly.", kilobytes(502), event.getYoungOccupancyInit());
-        assertEquals("Young end size not parsed correctly.", kilobytes(436), event.getYoungOccupancyEnd());
-        assertEquals("Young available size not parsed correctly.", kilobytes(1536), event.getYoungSpace());
-        assertEquals("Old begin size not parsed correctly.", kilobytes(460), event.getOldOccupancyInit());
-        assertEquals("Old end size not parsed correctly.", kilobytes(511), event.getOldOccupancyEnd());
-        assertEquals("Old allocation size not parsed correctly.", kilobytes(2048), event.getOldSpace());
-        assertEquals("Perm gen begin size not parsed correctly.", kilobytes(701), event.getPermOccupancyInit());
-        assertEquals("Perm gen end size not parsed correctly.", kilobytes(701), event.getPermOccupancyEnd());
-        assertEquals("Perm gen allocation size not parsed correctly.", kilobytes(1056768), event.getPermSpace());
-        assertEquals("Duration not parsed correctly.", 1849, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) 91,event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ERGONOMICS), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(502),event.getYoungOccupancyInit(),"Young begin size not parsed correctly.");
+        assertEquals(kilobytes(436),event.getYoungOccupancyEnd(),"Young end size not parsed correctly.");
+        assertEquals(kilobytes(1536),event.getYoungSpace(),"Young available size not parsed correctly.");
+        assertEquals(kilobytes(460),event.getOldOccupancyInit(),"Old begin size not parsed correctly.");
+        assertEquals(kilobytes(511),event.getOldOccupancyEnd(),"Old end size not parsed correctly.");
+        assertEquals(kilobytes(2048),event.getOldSpace(),"Old allocation size not parsed correctly.");
+        assertEquals(kilobytes(701),event.getPermOccupancyInit(),"Perm gen begin size not parsed correctly.");
+        assertEquals(kilobytes(701),event.getPermOccupancyEnd(),"Perm gen end size not parsed correctly.");
+        assertEquals(kilobytes(1056768),event.getPermSpace(),"Perm gen allocation size not parsed correctly.");
+        assertEquals(1849,event.getDuration(),"Duration not parsed correctly.");
     }
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialOldEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedSerialOldEvent.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedSerialOldEvent {
+class TestUnifiedSerialOldEvent {
 
     @Test
-    public void testPreprocessed() {
+    void testPreprocessed() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
@@ -54,7 +54,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
@@ -62,7 +62,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
@@ -70,7 +70,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s";
@@ -78,7 +78,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testHydration() {
+    void testHydration() {
         LogEventType eventType = JdkUtil.LogEventType.UNIFIED_SERIAL_OLD;
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
@@ -89,19 +89,19 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_SERIAL_OLD);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure) DefNew: "
                 + "1152K->0K(1152K) Tenured: 458K->929K(960K) Metaspace: 697K->697K(1056768K) 1M->0M(2M) 3.061ms "
                 + "User=0.00s Sys=0.00s Real=0.00s    ";
@@ -109,7 +109,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testLogLine7SpacesAfterStart() {
+    void testLogLine7SpacesAfterStart() {
         String logLine = "[0.119s][info][gc,start       ] GC(5) Pause Full (Allocation Failure) DefNew: "
                 + "1142K->110K(1152K) Tenured: 1044K->1934K(1936K) Metaspace: 1295K->1295K(1056768K) 2M->1M(4M) "
                 + "3.178ms User=0.00s Sys=0.00s Real=0.00s";
@@ -117,7 +117,7 @@ public class TestUnifiedSerialOldEvent {
     }
 
     @Test
-    public void testPreprocessedTriggerErgonomics() {
+    void testPreprocessedTriggerErgonomics() {
         String logLine = "[0.091s][info][gc,start     ] GC(3) Pause Full (Ergonomics) PSYoungGen: 502K->436K(1536K) "
                 + "PSOldGen: 460K->511K(2048K) Metaspace: 701K->701K(1056768K) 0M->0M(3M) 1.849ms "
                 + "User=0.01s Sys=0.00s Real=0.00s";

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedYoungEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedYoungEvent.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedYoungEvent {
+class TestUnifiedYoungEvent {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
         assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
         UnifiedYoungEvent event = new UnifiedYoungEvent(logLine);
@@ -54,43 +54,43 @@ public class TestUnifiedYoungEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
         assertEquals(JdkUtil.LogEventType.UNIFIED_YOUNG,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_YOUNG + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedYoungEvent, JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not parsed.");
     }
 
     @Test
-    public void testIsBlocking() {
+    void testIsBlocking() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
         assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_YOUNG), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_YOUNG);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLogLineWhitespaceAtEnd() {
+    void testLogLineWhitespaceAtEnd() {
         String logLine = "[1.102s][info][gc] GC(48) Pause Young (Allocation Failure) 23M->3M(25M) 0.409ms     ";
         assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
     }
 
     @Test
-    public void testTriggerExplicitGc() {
+    void testTriggerExplicitGc() {
         String logLine = "[7.487s][info][gc] GC(497) Pause Young (System.gc()) 16M->10M(36M) 0.940ms";
         assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
         UnifiedYoungEvent event = new UnifiedYoungEvent(logLine);
@@ -104,13 +104,13 @@ public class TestUnifiedYoungEvent {
     }
 
     @Test
-    public void testNoData() {
+    void testNoData() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure)";
         assertEquals(JdkUtil.LogEventType.UNKNOWN,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNKNOWN + "not identified.");
     }
 
     @Test
-    public void testUnifiedYoungStandardLogging() {
+    void testUnifiedYoungStandardLogging() {
         File testFile = TestUtil.getFile("dataset149.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -124,7 +124,7 @@ public class TestUnifiedYoungEvent {
     }
 
     @Test
-    public void testUnifiedYoungExplictGc() {
+    void testUnifiedYoungExplictGc() {
         File testFile = TestUtil.getFile("dataset154.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedYoungEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUnifiedYoungEvent.java
@@ -13,9 +13,9 @@
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,82 +42,71 @@ public class TestUnifiedYoungEvent {
     @Test
     public void testLogLine() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                UnifiedYoungEvent.match(logLine));
+        assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
         UnifiedYoungEvent event = new UnifiedYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_YOUNG.toString(), event.getName());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE));
-        assertEquals("Time stamp not parsed correctly.", 9602 - 1, event.getTimestamp());
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(32 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(12 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(38 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 1812, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_ALLOCATION_FAILURE), "Trigger not parsed correctly.");
+        assertEquals((long) (9602 - 1),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertEquals(kilobytes(32 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(12 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(38 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(1812,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
-        assertEquals(JdkUtil.LogEventType.UNIFIED_YOUNG + "not identified.", JdkUtil.LogEventType.UNIFIED_YOUNG,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNIFIED_YOUNG,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNIFIED_YOUNG + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UnifiedYoungEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UnifiedYoungEvent, JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not parsed.");
     }
 
     @Test
     public void testIsBlocking() {
         String logLine = "[9.602s][info][gc] GC(569) Pause Young (Allocation Failure) 32M->12M(38M) 1.812ms";
-        assertTrue(JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertTrue(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_YOUNG));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.UNIFIED_YOUNG), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_YOUNG);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLogLineWhitespaceAtEnd() {
         String logLine = "[1.102s][info][gc] GC(48) Pause Young (Allocation Failure) 23M->3M(25M) 0.409ms     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                UnifiedYoungEvent.match(logLine));
+        assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
     }
 
     @Test
     public void testTriggerExplicitGc() {
         String logLine = "[7.487s][info][gc] GC(497) Pause Young (System.gc()) 16M->10M(36M) 0.940ms";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                UnifiedYoungEvent.match(logLine));
+        assertTrue(UnifiedYoungEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
         UnifiedYoungEvent event = new UnifiedYoungEvent(logLine);
-        assertEquals("Event name incorrect.", JdkUtil.LogEventType.UNIFIED_YOUNG.toString(), event.getName());
-        assertEquals("Time stamp not parsed correctly.", 7487 - 0, event.getTimestamp());
-        assertTrue("Trigger not parsed correctly.", event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC));
-        assertEquals("Combined begin size not parsed correctly.", kilobytes(16 * 1024),
-                event.getCombinedOccupancyInit());
-        assertEquals("Combined end size not parsed correctly.", kilobytes(10 * 1024), event.getCombinedOccupancyEnd());
-        assertEquals("Combined allocation size not parsed correctly.", kilobytes(36 * 1024), event.getCombinedSpace());
-        assertEquals("Duration not parsed correctly.", 940, event.getDuration());
+        assertEquals(JdkUtil.LogEventType.UNIFIED_YOUNG.toString(),event.getName(),"Event name incorrect.");
+        assertEquals((long) (7487 - 0),event.getTimestamp(),"Time stamp not parsed correctly.");
+        assertTrue(event.getTrigger().matches(JdkRegEx.TRIGGER_SYSTEM_GC), "Trigger not parsed correctly.");
+        assertEquals(kilobytes(16 * 1024),event.getCombinedOccupancyInit(),"Combined begin size not parsed correctly.");
+        assertEquals(kilobytes(10 * 1024),event.getCombinedOccupancyEnd(),"Combined end size not parsed correctly.");
+        assertEquals(kilobytes(36 * 1024),event.getCombinedSpace(),"Combined allocation size not parsed correctly.");
+        assertEquals(940,event.getDuration(),"Duration not parsed correctly.");
     }
 
     @Test
     public void testNoData() {
         String logLine = "[0.049s][info][gc,start     ] GC(0) Pause Young (Allocation Failure)";
-        assertEquals(JdkUtil.LogEventType.UNKNOWN + "not identified.", JdkUtil.LogEventType.UNKNOWN,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.UNKNOWN,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.UNKNOWN + "not identified.");
     }
 
     @Test
@@ -127,15 +116,11 @@ public class TestUnifiedYoungEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG));
-        assertTrue(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING), Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis not identified.");
     }
 
     @Test
@@ -145,14 +130,10 @@ public class TestUnifiedYoungEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.UNIFIED_YOUNG), "Log line not recognized as " + JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN), Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingCmsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingCmsEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUsingCmsEvent {
+class TestUsingCmsEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
         assertTrue(UsingCmsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".");
         UsingCmsEvent event = new UsingCmsEvent(logLine);
@@ -45,37 +45,37 @@ public class TestUsingCmsEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
         assertEquals(JdkUtil.LogEventType.USING_CMS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_CMS + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingCmsEvent, JdkUtil.LogEventType.USING_CMS.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_CMS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_CMS), JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_CMS);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep     ";
         assertTrue(UsingCmsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".");
     }
@@ -84,7 +84,7 @@ public class TestUsingCmsEvent {
      * Test logging.
      */
     @Test
-    public void testLog() {
+    void testLog() {
         File testFile = TestUtil.getFile("dataset151.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingCmsEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingCmsEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,52 +39,45 @@ public class TestUsingCmsEvent {
     @Test
     public void testLine() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".",
-                UsingCmsEvent.match(logLine));
+        assertTrue(UsingCmsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".");
         UsingCmsEvent event = new UsingCmsEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3, event.getTimestamp());
+        assertEquals((long) 3,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
-        assertEquals(JdkUtil.LogEventType.USING_CMS + "not identified.", JdkUtil.LogEventType.USING_CMS,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.USING_CMS,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_CMS + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
-        assertTrue(JdkUtil.LogEventType.USING_CMS.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UsingCmsEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingCmsEvent, JdkUtil.LogEventType.USING_CMS.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep";
-        assertFalse(JdkUtil.LogEventType.USING_CMS.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_CMS.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.USING_CMS));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_CMS), JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_CMS);
-        assertTrue(JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_CMS.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.003s][info][gc] Using Concurrent Mark Sweep     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".",
-                UsingCmsEvent.match(logLine));
+        assertTrue(UsingCmsEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".");
     }
 
     /**
@@ -97,10 +90,8 @@ public class TestUsingCmsEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_CMS));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_CMS), "Log line not recognized as " + JdkUtil.LogEventType.USING_CMS.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingG1Event.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingG1Event.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,68 +39,59 @@ public class TestUsingG1Event {
     @Test
     public void testLine() {
         String logLine = "[0.005s][info][gc] Using G1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".",
-                UsingG1Event.match(logLine));
+        assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
         UsingG1Event event = new UsingG1Event(logLine);
-        assertEquals("Time stamp not parsed correctly.", 5, event.getTimestamp());
+        assertEquals((long) 5,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.005s][info][gc] Using G1";
-        assertEquals(JdkUtil.LogEventType.USING_G1 + "not identified.", JdkUtil.LogEventType.USING_G1,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.USING_G1,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_G1 + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.005s][info][gc] Using G1";
-        assertTrue(JdkUtil.LogEventType.USING_G1.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UsingG1Event);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingG1Event, JdkUtil.LogEventType.USING_G1.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.005s][info][gc] Using G1";
-        assertFalse(JdkUtil.LogEventType.USING_G1.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_G1.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.USING_G1.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.USING_G1));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_G1), JdkUtil.LogEventType.USING_G1.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_G1);
-        assertTrue(JdkUtil.LogEventType.USING_G1.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_G1.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.005s][info][gc] Using G1   ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".",
-                UsingG1Event.match(logLine));
+        assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
     }
 
     @Test
     public void testLineDetailedLogging() {
         String logLine = "[0.003s][info][gc     ] Using G1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".",
-                UsingG1Event.match(logLine));
+        assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
     }
 
     @Test
     public void testLineDatestampMillisNoLevelNoGc() {
         String logLine = "[2019-05-09T01:38:55.426+0000][18ms] Using G1";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".",
-                UsingG1Event.match(logLine));
+        assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
         UsingG1Event event = new UsingG1Event(logLine);
-        assertEquals("Time stamp not parsed correctly.", 18, event.getTimestamp());
+        assertEquals((long) 18,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     /**
@@ -113,10 +104,8 @@ public class TestUsingG1Event {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_G1));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_G1), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingG1Event.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingG1Event.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUsingG1Event {
+class TestUsingG1Event {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.005s][info][gc] Using G1";
         assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
         UsingG1Event event = new UsingG1Event(logLine);
@@ -45,49 +45,49 @@ public class TestUsingG1Event {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.005s][info][gc] Using G1";
         assertEquals(JdkUtil.LogEventType.USING_G1,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_G1 + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.005s][info][gc] Using G1";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingG1Event, JdkUtil.LogEventType.USING_G1.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.005s][info][gc] Using G1";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_G1.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_G1), JdkUtil.LogEventType.USING_G1.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_G1);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_G1.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.005s][info][gc] Using G1   ";
         assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
     }
 
     @Test
-    public void testLineDetailedLogging() {
+    void testLineDetailedLogging() {
         String logLine = "[0.003s][info][gc     ] Using G1";
         assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
     }
 
     @Test
-    public void testLineDatestampMillisNoLevelNoGc() {
+    void testLineDatestampMillisNoLevelNoGc() {
         String logLine = "[2019-05-09T01:38:55.426+0000][18ms] Using G1";
         assertTrue(UsingG1Event.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_G1.toString() + ".");
         UsingG1Event event = new UsingG1Event(logLine);
@@ -98,7 +98,7 @@ public class TestUsingG1Event {
      * Test logging.
      */
     @Test
-    public void testLog() {
+    void testLog() {
         File testFile = TestUtil.getFile("dataset152.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingParallelEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingParallelEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUsingParallelEvent {
+class TestUsingParallelEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.002s][info][gc] Using Parallel";
         assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
         UsingParallelEvent event = new UsingParallelEvent(logLine);
@@ -45,43 +45,43 @@ public class TestUsingParallelEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.002s][info][gc] Using Parallel";
         assertEquals(JdkUtil.LogEventType.USING_PARALLEL,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_PARALLEL + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.002s][info][gc] Using Parallel";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingParallelEvent, JdkUtil.LogEventType.USING_PARALLEL.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.002s][info][gc] Using Parallel";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_PARALLEL.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_PARALLEL), JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_PARALLEL);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.002s][info][gc] Using Parallel     ";
         assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
     }
 
     @Test
-    public void testLineUptimemillsis() {
+    void testLineUptimemillsis() {
         String logLine = "[18ms][info][gc] Using Parallel";
         assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
         UsingParallelEvent event = new UsingParallelEvent(logLine);
@@ -92,7 +92,7 @@ public class TestUsingParallelEvent {
      * Test logging.
      */
     @Test
-    public void testLog() {
+    void testLog() {
         File testFile = TestUtil.getFile("dataset150.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingParallelEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingParallelEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,61 +39,53 @@ public class TestUsingParallelEvent {
     @Test
     public void testLine() {
         String logLine = "[0.002s][info][gc] Using Parallel";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                UsingParallelEvent.match(logLine));
+        assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
         UsingParallelEvent event = new UsingParallelEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 2, event.getTimestamp());
+        assertEquals((long) 2,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.002s][info][gc] Using Parallel";
-        assertEquals(JdkUtil.LogEventType.USING_PARALLEL + "not identified.", JdkUtil.LogEventType.USING_PARALLEL,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.USING_PARALLEL,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_PARALLEL + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.002s][info][gc] Using Parallel";
-        assertTrue(JdkUtil.LogEventType.USING_PARALLEL.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UsingParallelEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingParallelEvent, JdkUtil.LogEventType.USING_PARALLEL.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.002s][info][gc] Using Parallel";
-        assertFalse(JdkUtil.LogEventType.USING_PARALLEL.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_PARALLEL.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.USING_PARALLEL));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_PARALLEL), JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_PARALLEL);
-        assertTrue(JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_PARALLEL.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.002s][info][gc] Using Parallel     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                UsingParallelEvent.match(logLine));
+        assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
     }
 
     @Test
     public void testLineUptimemillsis() {
         String logLine = "[18ms][info][gc] Using Parallel";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                UsingParallelEvent.match(logLine));
+        assertTrue(UsingParallelEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
         UsingParallelEvent event = new UsingParallelEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 18, event.getTimestamp());
+        assertEquals((long) 18,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     /**
@@ -106,10 +98,8 @@ public class TestUsingParallelEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_PARALLEL), "Log line not recognized as " + JdkUtil.LogEventType.USING_PARALLEL.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingSerialEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingSerialEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,52 +39,45 @@ public class TestUsingSerialEvent {
     @Test
     public void testLine() {
         String logLine = "[0.003s][info][gc] Using Serial";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".",
-                UsingSerialEvent.match(logLine));
+        assertTrue(UsingSerialEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
         UsingSerialEvent event = new UsingSerialEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 3, event.getTimestamp());
+        assertEquals((long) 3,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.003s][info][gc] Using Serial";
-        assertEquals(JdkUtil.LogEventType.USING_SERIAL + "not identified.", JdkUtil.LogEventType.USING_SERIAL,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.USING_SERIAL,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_SERIAL + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.003s][info][gc] Using Serial";
-        assertTrue(JdkUtil.LogEventType.USING_SERIAL.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UsingSerialEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingSerialEvent, JdkUtil.LogEventType.USING_SERIAL.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.003s][info][gc] Using Serial";
-        assertFalse(JdkUtil.LogEventType.USING_SERIAL.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_SERIAL.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.USING_SERIAL));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_SERIAL), JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SERIAL);
-        assertTrue(JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.003s][info][gc] Using Serial     ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".",
-                UsingSerialEvent.match(logLine));
+        assertTrue(UsingSerialEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
     }
 
     /**
@@ -97,10 +90,8 @@ public class TestUsingSerialEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SERIAL));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SERIAL), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingSerialEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingSerialEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUsingSerialEvent {
+class TestUsingSerialEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.003s][info][gc] Using Serial";
         assertTrue(UsingSerialEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
         UsingSerialEvent event = new UsingSerialEvent(logLine);
@@ -45,37 +45,37 @@ public class TestUsingSerialEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.003s][info][gc] Using Serial";
         assertEquals(JdkUtil.LogEventType.USING_SERIAL,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_SERIAL + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.003s][info][gc] Using Serial";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingSerialEvent, JdkUtil.LogEventType.USING_SERIAL.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.003s][info][gc] Using Serial";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_SERIAL.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_SERIAL), JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SERIAL);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SERIAL.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.003s][info][gc] Using Serial     ";
         assertTrue(UsingSerialEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SERIAL.toString() + ".");
     }
@@ -84,7 +84,7 @@ public class TestUsingSerialEvent {
      * Test logging.
      */
     @Test
-    public void testLog() {
+    void testLog() {
         File testFile = TestUtil.getFile("dataset147.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingShenandoahEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingShenandoahEvent.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUsingShenandoahEvent {
+class TestUsingShenandoahEvent {
 
     @Test
-    public void testLine() {
+    void testLine() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
         assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
         UsingShenandoahEvent event = new UsingShenandoahEvent(logLine);
@@ -45,49 +45,49 @@ public class TestUsingShenandoahEvent {
     }
 
     @Test
-    public void testIdentityEventType() {
+    void testIdentityEventType() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
         assertEquals(JdkUtil.LogEventType.USING_SHENANDOAH,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_SHENANDOAH + "not identified.");
     }
 
     @Test
-    public void testParseLogLine() {
+    void testParseLogLine() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
         assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingShenandoahEvent, JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not parsed.");
     }
 
     @Test
-    public void testNotBlocking() {
+    void testNotBlocking() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
         assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
-    public void testReportable() {
+    void testReportable() {
         assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_SHENANDOAH), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as reportable.");
     }
 
     @Test
-    public void testUnified() {
+    void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SHENANDOAH);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as unified.");
     }
 
     @Test
-    public void testLineWithSpaces() {
+    void testLineWithSpaces() {
         String logLine = "[0.006s][info][gc] Using Shenandoah    ";
         assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLineDetailedLogging() {
+    void testLineDetailedLogging() {
         String logLine = "[0.005s][info][gc     ] Using Shenandoah";
         assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLineWithTimeUptimemillis() {
+    void testLineWithTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Using Shenandoah";
         assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
         UsingShenandoahEvent event = new UsingShenandoahEvent(logLine);
@@ -98,7 +98,7 @@ public class TestUsingShenandoahEvent {
      * Test logging.
      */
     @Test
-    public void testLog() {
+    void testLog() {
         File testFile = TestUtil.getFile("dataset159.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingShenandoahEvent.java
+++ b/src/test/java/org/eclipselabs/garbagecat/domain/jdk/unified/TestUsingShenandoahEvent.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.domain.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -39,68 +39,59 @@ public class TestUsingShenandoahEvent {
     @Test
     public void testLine() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".",
-                UsingShenandoahEvent.match(logLine));
+        assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
         UsingShenandoahEvent event = new UsingShenandoahEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 6, event.getTimestamp());
+        assertEquals((long) 6,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     @Test
     public void testIdentityEventType() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
-        assertEquals(JdkUtil.LogEventType.USING_SHENANDOAH + "not identified.", JdkUtil.LogEventType.USING_SHENANDOAH,
-                JdkUtil.identifyEventType(logLine));
+        assertEquals(JdkUtil.LogEventType.USING_SHENANDOAH,JdkUtil.identifyEventType(logLine),JdkUtil.LogEventType.USING_SHENANDOAH + "not identified.");
     }
 
     @Test
     public void testParseLogLine() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
-        assertTrue(JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not parsed.",
-                JdkUtil.parseLogLine(logLine) instanceof UsingShenandoahEvent);
+        assertTrue(JdkUtil.parseLogLine(logLine) instanceof UsingShenandoahEvent, JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not parsed.");
     }
 
     @Test
     public void testNotBlocking() {
         String logLine = "[0.006s][info][gc] Using Shenandoah";
-        assertFalse(JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " incorrectly indentified as blocking.",
-                JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)));
+        assertFalse(JdkUtil.isBlocking(JdkUtil.identifyEventType(logLine)), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " incorrectly indentified as blocking.");
     }
 
     @Test
     public void testReportable() {
-        assertTrue(JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as reportable.",
-                JdkUtil.isReportable(JdkUtil.LogEventType.USING_SHENANDOAH));
+        assertTrue(JdkUtil.isReportable(JdkUtil.LogEventType.USING_SHENANDOAH), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as reportable.");
     }
 
     @Test
     public void testUnified() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SHENANDOAH);
-        assertTrue(JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SHENANDOAH.toString() + " not indentified as unified.");
     }
 
     @Test
     public void testLineWithSpaces() {
         String logLine = "[0.006s][info][gc] Using Shenandoah    ";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".",
-                UsingShenandoahEvent.match(logLine));
+        assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLineDetailedLogging() {
         String logLine = "[0.005s][info][gc     ] Using Shenandoah";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".",
-                UsingShenandoahEvent.match(logLine));
+        assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLineWithTimeUptimemillis() {
         String logLine = "[2019-02-05T14:47:31.092-0200][4ms] Using Shenandoah";
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".",
-                UsingShenandoahEvent.match(logLine));
+        assertTrue(UsingShenandoahEvent.match(logLine), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
         UsingShenandoahEvent event = new UsingShenandoahEvent(logLine);
-        assertEquals("Time stamp not parsed correctly.", 4, event.getTimestamp());
+        assertEquals((long) 4,event.getTimestamp(),"Time stamp not parsed correctly.");
     }
 
     /**
@@ -113,10 +104,8 @@ public class TestUsingShenandoahEvent {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SHENANDOAH));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.USING_SHENANDOAH), "Log line not recognized as " + JdkUtil.LogEventType.USING_SHENANDOAH.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
+++ b/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
@@ -12,14 +12,14 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.hsql;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.eclipselabs.garbagecat.domain.BlockingEvent;
 import org.eclipselabs.garbagecat.domain.jdk.ParNewEvent;
 import org.eclipselabs.garbagecat.domain.jdk.SerialOldEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>

--- a/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
+++ b/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJvmDao {
+class TestJvmDao {
 
     @Test
-    public void testSameTimestampOrdering() {
+    void testSameTimestampOrdering() {
         JvmDao jvmDao = new JvmDao();
         ParNewEvent event1 = new ParNewEvent("3010778.296: [GC 3010778.296: [ParNew: 337824K->32173K(368640K),"
                 + " 0.0803880 secs] 806117K->500466K(1187840K), 0.0805980 secs]");

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationConcurrentTimePreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationConcurrentTimePreprocessAction.java
@@ -12,10 +12,10 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,8 +27,8 @@ public class TestApplicationConcurrentTimePreprocessAction {
     public void testLine1Timestamp() {
         String priorLogLine = "";
         String logLine = "1122748.949Application time: 0.0005210 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
@@ -36,16 +36,16 @@ public class TestApplicationConcurrentTimePreprocessAction {
         String priorLogLine = "";
         String logLine = "1987600.604: [CMS-concurrent-preclean: 0.016/0.017 secs]Application time: "
                 + "4.5432350 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
     public void testLine2CmsConcurrent() {
         String priorLogLine = "1122748.949Application time: 0.0005210 seconds";
         String logLine = ": [CMS-concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
@@ -53,8 +53,8 @@ public class TestApplicationConcurrentTimePreprocessAction {
         String priorLogLine = "1987600.604: [CMS-concurrent-preclean: 0.016/0.017 secs]Application time: "
                 + "4.5432350 seconds";
         String logLine = " [Times: user=0.02 sys=0.00, real=0.02 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
@@ -62,8 +62,8 @@ public class TestApplicationConcurrentTimePreprocessAction {
         String priorLogLine = "235820.289: [CMS-concurrent-abortable-preclean: 0.049/1.737 secs]Application "
                 + "time: 0.0001370 seconds";
         String logLine = " [Times: user=0.90 sys=0.05, real=1.74 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
@@ -71,8 +71,8 @@ public class TestApplicationConcurrentTimePreprocessAction {
         String priorLogLine = "408365.532: [CMS-concurrent-mark: 0.476/10.257 secs]Application time: "
                 + "0.0576080 seconds";
         String logLine = " [Times: user=6.00 sys=0.28, real=10.26 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 
     @Test
@@ -80,7 +80,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
         String priorLogLine = "408365.532: [CMS-concurrent-mark: 0.476/10.257 secs]Application time: "
                 + "0.0576080 seconds";
         String logLine = " [Times: user=6.00 sys=0.28, real=10.26 secs]       ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
-                + ".", ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
+		+ ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationConcurrentTimePreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationConcurrentTimePreprocessAction.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestApplicationConcurrentTimePreprocessAction {
+class TestApplicationConcurrentTimePreprocessAction {
 
     @Test
-    public void testLine1Timestamp() {
+    void testLine1Timestamp() {
         String priorLogLine = "";
         String logLine = "1122748.949Application time: 0.0005210 seconds";
         assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
@@ -32,7 +32,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine1CmsConcurrent() {
+    void testLine1CmsConcurrent() {
         String priorLogLine = "";
         String logLine = "1987600.604: [CMS-concurrent-preclean: 0.016/0.017 secs]Application time: "
                 + "4.5432350 seconds";
@@ -41,7 +41,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine2CmsConcurrent() {
+    void testLine2CmsConcurrent() {
         String priorLogLine = "1122748.949Application time: 0.0005210 seconds";
         String logLine = ": [CMS-concurrent-mark-start]";
         assertTrue(ApplicationConcurrentTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_CONCURRENT_TIME.toString()
@@ -49,7 +49,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine1PrecleanLine2TimesBlock() {
+    void testLine1PrecleanLine2TimesBlock() {
         String priorLogLine = "1987600.604: [CMS-concurrent-preclean: 0.016/0.017 secs]Application time: "
                 + "4.5432350 seconds";
         String logLine = " [Times: user=0.02 sys=0.00, real=0.02 secs]";
@@ -58,7 +58,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine1AbortablePrecleanLine2TimesBlock() {
+    void testLine1AbortablePrecleanLine2TimesBlock() {
         String priorLogLine = "235820.289: [CMS-concurrent-abortable-preclean: 0.049/1.737 secs]Application "
                 + "time: 0.0001370 seconds";
         String logLine = " [Times: user=0.90 sys=0.05, real=1.74 secs]";
@@ -67,7 +67,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine1MarkLine2TimesBlock() {
+    void testLine1MarkLine2TimesBlock() {
         String priorLogLine = "408365.532: [CMS-concurrent-mark: 0.476/10.257 secs]Application time: "
                 + "0.0576080 seconds";
         String logLine = " [Times: user=6.00 sys=0.28, real=10.26 secs]";
@@ -76,7 +76,7 @@ public class TestApplicationConcurrentTimePreprocessAction {
     }
 
     @Test
-    public void testLine1MarkLine2TimesBlockWhitespaceAtEnd() {
+    void testLine1MarkLine2TimesBlockWhitespaceAtEnd() {
         String priorLogLine = "408365.532: [CMS-concurrent-mark: 0.476/10.257 secs]Application time: "
                 + "0.0576080 seconds";
         String logLine = " [Times: user=6.00 sys=0.28, real=10.26 secs]       ";

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationStoppedTimePreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationStoppedTimePreprocessAction.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestApplicationStoppedTimePreprocessAction {
+class TestApplicationStoppedTimePreprocessAction {
 
     @Test
-    public void testLine2CmsConcurrent() {
+    void testLine2CmsConcurrent() {
         String priorLogLine = "6545.692Total time for which application threads were stopped: 0.0007993 seconds";
         String logLine = ": [CMS-concurrent-abortable-preclean: 0.025/0.042 secs] "
                 + "[Times: user=0.04 sys=0.00, real=0.04 secs]";
@@ -32,7 +32,7 @@ public class TestApplicationStoppedTimePreprocessAction {
     }
 
     @Test
-    public void testLine2TimesBlock() {
+    void testLine2TimesBlock() {
         String priorLogLine = "234784.781: [CMS-concurrent-abortable-preclean: 0.038/0.118 secs]Total time for"
                 + " which application threads were stopped: 0.0123330 seconds";
         String logLine = " [Times: user=0.10 sys=0.00, real=0.12 secs]";
@@ -40,7 +40,7 @@ public class TestApplicationStoppedTimePreprocessAction {
     }
 
     @Test
-    public void testLine2TimesBlockWhitespaceAtEnd() {
+    void testLine2TimesBlockWhitespaceAtEnd() {
         String priorLogLine = "234784.781: [CMS-concurrent-abortable-preclean: 0.038/0.118 secs]Total time for"
                 + " which application threads were stopped: 0.0123330 seconds";
         String logLine = " [Times: user=0.10 sys=0.00, real=0.12 secs]   ";

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationStoppedTimePreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestApplicationStoppedTimePreprocessAction.java
@@ -12,10 +12,10 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -28,9 +28,7 @@ public class TestApplicationStoppedTimePreprocessAction {
         String priorLogLine = "6545.692Total time for which application threads were stopped: 0.0007993 seconds";
         String logLine = ": [CMS-concurrent-abortable-preclean: 0.025/0.042 secs] "
                 + "[Times: user=0.04 sys=0.00, real=0.04 secs]";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 
     @Test
@@ -38,9 +36,7 @@ public class TestApplicationStoppedTimePreprocessAction {
         String priorLogLine = "234784.781: [CMS-concurrent-abortable-preclean: 0.038/0.118 secs]Total time for"
                 + " which application threads were stopped: 0.0123330 seconds";
         String logLine = " [Times: user=0.10 sys=0.00, real=0.12 secs]";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 
     @Test
@@ -48,8 +44,6 @@ public class TestApplicationStoppedTimePreprocessAction {
         String priorLogLine = "234784.781: [CMS-concurrent-abortable-preclean: 0.038/0.118 secs]Total time for"
                 + " which application threads were stopped: 0.0123330 seconds";
         String logLine = " [Times: user=0.10 sys=0.00, real=0.12 secs]   ";
-        assertTrue(
-                "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".",
-                ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine));
+        assertTrue(ApplicationStoppedTimePreprocessAction.match(logLine, priorLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.APPLICATION_STOPPED_TIME.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestCmsPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestCmsPreprocessAction.java
@@ -37,10 +37,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestCmsPreprocessAction {
+class TestCmsPreprocessAction {
 
     @Test
-    public void testLogLineParNewMixedConcurrent() {
+    void testLogLineParNewMixedConcurrent() {
         String logLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] [Times: user=1.56 sys=0.01, real=2.23 secs]";
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
@@ -50,7 +50,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewMixedConcurrentReset() {
+    void testLogLineParNewMixedConcurrentReset() {
         String priorLogLine = null;
         String logLine = "2017-03-21T16:02:23.633+0530: 53277.279: [GC 53277.279: [ParNew: "
                 + "2853312K->2853312K(2853312K), 0.0000310 secs]53277.279: [CMS2017-03-21T16:02:23.655+0530: "
@@ -67,7 +67,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewMixedConcurrentWithWhitespaceEnd() {
+    void testLogLineParNewMixedConcurrentWithWhitespaceEnd() {
         String logLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
@@ -78,7 +78,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEnd() {
+    void testLogLineEnd() {
         String logLine = ": 153599K->17023K(153600K), 0.0383370 secs] 229326K->114168K(494976K), 0.0384820 secs] "
                 + "[Times: user=0.15 sys=0.01, real=0.04 secs]";
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
@@ -88,7 +88,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndWithWhitespaceEnd() {
+    void testLogLineEndWithWhitespaceEnd() {
         String logLine = ": 153599K->17023K(153600K), 0.0383370 secs] 229326K->114168K(494976K), 0.0384820 secs] "
                 + "[Times: user=0.15 sys=0.01, real=0.04 secs]    ";
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
@@ -98,7 +98,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewNoTriggerMixedConcurrent() {
+    void testLogLineParNewNoTriggerMixedConcurrent() {
         String logLine = "10.963: [GC10.963: [ParNew10.977: [CMS-concurrent-abortable-preclean: 0.088/0.197 secs] "
                 + "[Times: user=0.33 sys=0.05, real=0.20 secs]";
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
@@ -108,7 +108,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewPromotionFailed() {
+    void testLogLineParNewPromotionFailed() {
         String logLine = "233333.318: [GC 233333.319: [ParNew (promotion failed): 673108K->673108K(707840K), "
                 + "1.5366054 secs]233334.855: [CMS233334.856: [CMS-concurrent-abortable-preclean: 12.033/27.431 secs]";
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
@@ -118,13 +118,13 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddle() {
+    void testLogLineMiddle() {
         String logLine = "1907.974: [CMS-concurrent-mark: 23.751/40.476 secs]";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineParNewTriggerMixedConcurrentJdk8() {
+    void testLogLineParNewTriggerMixedConcurrentJdk8() {
         String logLine = "45.574: [GC (Allocation Failure) 45.574: [ParNew45.670: [CMS-concurrent-abortable-preclean: "
                 + "3.276/4.979 secs] [Times: user=7.75 sys=0.28, real=4.98 secs]";
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
@@ -138,7 +138,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewConcurrentModeFailureMixedConcurrentJdk8() {
+    void testLogLineParNewConcurrentModeFailureMixedConcurrentJdk8() {
         String logLine = "719.519: [GC (Allocation Failure) 719.521: [ParNew: 1382400K->1382400K(1382400K), "
                 + "0.0000470 secs]719.521: [CMS722.601: [CMS-concurrent-mark: 3.567/3.633 secs] "
                 + "[Times: user=10.91 sys=0.69, real=3.63 secs]";
@@ -149,7 +149,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldMixedConcurrentMark() {
+    void testLogLineCmsSerialOldMixedConcurrentMark() {
         String logLine = "2016-02-26T16:37:58.740+1100: 44.684: [Full GC2016-02-26T16:37:58.740+1100: 44.684: [CMS"
                 + "2016-02-26T16:37:58.933+1100: 44.877: [CMS-concurrent-mark: 1.508/2.428 secs] "
                 + "[Times: user=3.44 sys=0.49, real=2.42 secs]";
@@ -157,14 +157,14 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldMixedConcurrentAbortablePreclean() {
+    void testLogLineCmsSerialOldMixedConcurrentAbortablePreclean() {
         String logLine = "85217.903: [Full GC 85217.903: [CMS85217.919: [CMS-concurrent-abortable-preclean: "
                 + "0.723/3.756 secs] [Times: user=2.54 sys=0.08, real=3.76 secs]";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineCmsSerialOldMixedAbortPrecleanConcurrentAbortablePreclean() {
+    void testLogLineCmsSerialOldMixedAbortPrecleanConcurrentAbortablePreclean() {
         String logLine = "2017-06-22T21:22:03.269-0400: 23.858: [Full GC 23.859: [CMS CMS: abort preclean due to "
                 + "time 2017-06-22T21:22:03.269-0400: 23.859: [CMS-concurrent-abortable-preclean: 0.338/5.115 secs] "
                 + "[Times: user=14.57 sys=0.83, real=5.11 secs]";
@@ -179,21 +179,21 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldMixedConcurrentSpaceAfterGC() {
+    void testLogLineCmsSerialOldMixedConcurrentSpaceAfterGC() {
         String logLine = "85238.030: [Full GC 85238.030: [CMS85238.672: [CMS-concurrent-mark: 0.666/0.686 secs] "
                 + "[Times: user=1.40 sys=0.01, real=0.69 secs]";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineCmsSerialOldWithTriggerMixedConcurrent() {
+    void testLogLineCmsSerialOldWithTriggerMixedConcurrent() {
         String logLine = "706.707: [Full GC (Allocation Failure) 706.708: [CMS709.137: [CMS-concurrent-mark: "
                 + "3.381/5.028 secs] [Times: user=23.92 sys=3.02, real=5.03 secs]";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineEndWithPerm() {
+    void testLogLineEndWithPerm() {
         String logLine = " (concurrent mode failure): 1218548K->413373K(1465840K), 1.3656970 secs] "
                 + "1229657K->413373K(1581168K), [CMS Perm : 83805K->80520K(83968K)], 1.3659420 secs] "
                 + "[Times: user=1.33 sys=0.01, real=1.37 secs]";
@@ -203,7 +203,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndWithMetaspace() {
+    void testLogLineEndWithMetaspace() {
         String logLine = " (concurrent mode failure): 2655937K->2373842K(2658304K), 11.6746550 secs] "
                 + "3973407K->2373842K(4040704K), [Metaspace: 72496K->72496K(1118208K)] icms_dc=77 , 11.6770830 secs] "
                 + "[Times: user=14.05 sys=0.02, real=11.68 secs]";
@@ -214,7 +214,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndPromotionFailedConcurrentModeFailure() {
+    void testLogLineEndPromotionFailedConcurrentModeFailure() {
         String logLine = " (promotion failed): 471871K->471872K(471872K), 0.7685416 secs]66645.266: [CMS (concurrent "
                 + "mode failure): 1572864K->1572863K(1572864K), 6.3611861 secs] 2001479K->1657572K(2044736K), "
                 + "[Metaspace: 567956K->567956K(1609728K)], 7.1304658 secs] "
@@ -226,7 +226,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewNoTriggerMixedConcurrentWithCommas() {
+    void testLogLineParNewNoTriggerMixedConcurrentWithCommas() {
         String logLine = "32552,602: [GC32552,602: [ParNew32552,610: "
                 + "[CMS-concurrent-abortable-preclean: 3,090/4,993 secs] "
                 + "[Times: user=3,17 sys=0,02, real=5,00 secs]";
@@ -237,7 +237,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndWithCommas() {
+    void testLogLineEndWithCommas() {
         String logLine = ": 289024K->17642K(306688K), 0,0788160 secs] 4086255K->3814874K(12548864K), 0,0792920 secs] "
                 + "[Times: user=0,28 sys=0,00, real=0,08 secs]";
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
@@ -247,33 +247,33 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineSerialBailing() {
+    void testLogLineSerialBailing() {
         String logLine = "4300.825: [Full GC 4300.825: [CMSbailing out to foreground collection";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineParNewBailing() {
+    void testLogLineParNewBailing() {
         String logLine = "2137.769: [GC 2137.769: [ParNew (promotion failed): 242304K->242304K(242304K), "
                 + "8.4066690 secs]2146.176: [CMSbailing out to foreground collection";
         assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineParNewHotspotBailing() {
+    void testLogLineParNewHotspotBailing() {
         String logLine = "1901.217: [GC 1901.217: [ParNew: 261760K->261760K(261952K), 0.0000570 secs]1901.217: "
                 + "[CMSJava HotSpot(TM) Server VM warning: bailing out to foreground collection";
         assertTrue(CmsPreprocessAction.match(logLine, null, ""), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineParTriggerPromotionFailed() {
+    void testLogLineParTriggerPromotionFailed() {
         String logLine = "182314.858: [GC 182314.859: [ParNew (promotion failed)";
         assertTrue(CmsPreprocessAction.match(logLine, null, ""), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
-    public void testLogLineParNewConcurrentModeFailurePermDataMixedConcurrentSweep() {
+    void testLogLineParNewConcurrentModeFailurePermDataMixedConcurrentSweep() {
         String logLine = "11202.526: [GC (Allocation Failure) 1202.528: [ParNew: 1355422K->1355422K(1382400K), "
                 + "0.0000500 secs]1202.528: [CMS1203.491: [CMS-concurrent-sweep: 1.009/1.060 secs] "
                 + "[Times: user=1.55 sys=0.12, real=1.06 secs]";
@@ -284,7 +284,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldWithConcurrentModeFailureMixedConcurrentPreclean() {
+    void testLogLineCmsSerialOldWithConcurrentModeFailureMixedConcurrentPreclean() {
         String logLine = "1278.200: [Full GC (Allocation Failure) 1278.202: [CMS1280.173: "
                 + "[CMS-concurrent-preclean: 2.819/2.865 secs] [Times: user=6.97 sys=0.41, real=2.87 secs]";
         String nextLogLine = " (concurrent mode failure): 2658303K->2658303K(2658304K), 9.1546180 secs] "
@@ -294,7 +294,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldWithConcurrentModeFailureMixedConcurrentSweep() {
+    void testLogLineCmsSerialOldWithConcurrentModeFailureMixedConcurrentSweep() {
         String logLine = "2440.336: [Full GC (Allocation Failure) 2440.338: [CMS"
                 + "2440.542: [CMS-concurrent-sweep: 1.137/1.183 secs] [Times: user=5.33 sys=0.51, real=1.18 secs]";
         String nextLogLine = " (concurrent mode failure): 2658304K->2658303K(2658304K), 9.4908960 secs] "
@@ -304,7 +304,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewMixedCmsConcurrentAbortablePreclean() {
+    void testLogLineParNewMixedCmsConcurrentAbortablePreclean() {
         String priorLogLine = "";
         String logLine = "2210.281: [GC 2210.282: [ParNew2210.314: [CMS-concurrent-abortable-preclean: "
                 + "0.043/0.144 secs] [Times: user=0.58 sys=0.03, real=0.14 secs]";
@@ -314,7 +314,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewMixedCmsConcurrentAbortablePreclean2() {
+    void testLogLineParNewMixedCmsConcurrentAbortablePreclean2() {
         String priorLogLine = "2210.281: [GC 2210.282: [ParNew2210.314: [CMS-concurrent-abortable-preclean: "
                 + "0.043/0.144 secs] [Times: user=0.58 sys=0.03, real=0.14 secs]";
         String logLine = ": 212981K->3156K(242304K), 0.0364435 secs] 4712182K->4502357K(4971420K), "
@@ -324,7 +324,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewMixedCmsConcurrentSweep() {
+    void testLogLineParNewMixedCmsConcurrentSweep() {
         String priorLogLine = "";
         String logLine = "1821.661: [GC 1821.661: [ParNew1821.661: [CMS-concurrent-sweep: "
                 + "42.841/48.076 secs] [Times: user=19.45 sys=0.45, real=48.06 secs]";
@@ -334,7 +334,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentModeInterrupted() {
+    void testLogLineConcurrentModeInterrupted() {
         String priorLogLine = "";
         String logLine = " (concurrent mode interrupted): 861863K->904027K(1797568K), 42.9053262 secs] "
                 + "1045947K->904027K(2047232K), [CMS Perm : 252246K->252202K(262144K)], 42.9070278 secs] "
@@ -344,7 +344,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcBeginSerial() {
+    void testLogLinePrintHeapAtGcBeginSerial() {
         String priorLogLine = "";
         String logLine = "28282.075: [Full GC {Heap before gc invocations=528:";
         String nextLogLine = "";
@@ -352,7 +352,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcBeginParNew() {
+    void testLogLinePrintHeapAtGcBeginParNew() {
         String priorLogLine = "";
         String logLine = "27067.966: [GC {Heap before gc invocations=498:";
         String nextLogLine = "";
@@ -360,7 +360,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcBeginCmsRemark() {
+    void testLogLinePrintHeapAtGcBeginCmsRemark() {
         String priorLogLine = "";
         String logLine = "2017-04-03T08:55:45.544-0500: 20653.796: [GC (CMS Final Remark) {Heap before GC "
                 + "invocations=686 (full 15):";
@@ -369,7 +369,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcBeginCmsRemarkJdk8() {
+    void testLogLinePrintHeapAtGcBeginCmsRemarkJdk8() {
         String priorLogLine = "";
         String logLine = "2017-06-18T05:23:16.634-0500: 15.364: [GC (CMS Final Remark) [YG occupancy: 576424 K "
                 + "(1677760 K)]{Heap before GC invocations=8 (full 2):";
@@ -378,7 +378,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogMiddleSerialConcurrentPrecleanMixed() {
+    void testLogMiddleSerialConcurrentPrecleanMixed() {
         String priorLogLine = "";
         String logLine = "28282.075: [CMS28284.687: [CMS-concurrent-preclean: 3.706/3.706 secs]";
         String nextLogLine = "";
@@ -386,7 +386,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogMiddleParNewConcurrentAbortablePrecleanMixed() {
+    void testLogMiddleParNewConcurrentAbortablePrecleanMixed() {
         String priorLogLine = "";
         String logLine = "27067.966: [ParNew: 261760K->261760K(261952K), 0.0000160 secs]27067.966: [CMS"
                 + "27067.966: [CMS-concurrent-abortable-preclean: 2.272/29.793 secs]";
@@ -395,7 +395,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogMiddleParNewConcurrentMarkMixed() {
+    void testLogMiddleParNewConcurrentMarkMixed() {
         String priorLogLine = "";
         String logLine = "28308.701: [ParNew (promotion failed): 261951K->261951K(261952K), 0.7470390 secs]28309.448: "
                 + "[CMS28312.544: [CMS-concurrent-mark: 5.114/5.863 secs]";
@@ -404,7 +404,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogMiddleParNewTruncatedConcurrentMarkMixed() {
+    void testLogMiddleParNewTruncatedConcurrentMarkMixed() {
         String priorLogLine = "";
         String logLine = ": 153344K->153344K(153344K), 0.2049130 secs]2017-02-15T16:22:05.602+0900: 1223922.433: "
                 + "[CMS2017-02-15T16:22:06.001+0900: 1223922.832: [CMS-concurrent-mark: 3.589/4.431 secs] "
@@ -414,7 +414,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcMiddleSerial() {
+    void testLogLinePrintHeapAtGcMiddleSerial() {
         String priorLogLine = "";
         String logLine = "49830.934: [CMS: 1640998K->1616248K(3407872K), 11.0964500 secs] "
                 + "1951125K->1616248K(4193600K), [CMS Perm : 507386K->499194K(786432K)]"
@@ -424,7 +424,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintClassHistogramMiddleSerial() {
+    void testLogLinePrintClassHistogramMiddleSerial() {
         String priorLogLine = "";
         String logLine = "11700.930: [CMS: 2844387K->635365K(7331840K), 46.4488813 secs]11747.379: [Class Histogram";
         String nextLogLine = "";
@@ -432,7 +432,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcMiddleSerialConcurrentModeFailure() {
+    void testLogLinePrintHeapAtGcMiddleSerialConcurrentModeFailure() {
         String priorLogLine = "";
         String logLine = " (concurrent mode failure): 1179601K->1179648K(1179648K), 10.7510650 secs] "
                 + "1441361K->1180553K(1441600K), [CMS Perm : 71172K->71171K(262144K)]Heap after gc invocations=529:";
@@ -441,7 +441,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintHeapAtGcParNewConcurrentModeFailure() {
+    void testLogLinePrintHeapAtGcParNewConcurrentModeFailure() {
         String priorLogLine = "";
         String logLine = " (concurrent mode failure): 1147900K->1155037K(1179648K), 7.3953900 secs] "
                 + "1409660K->1155037K(1441600K)Heap after gc invocations=499:";
@@ -450,7 +450,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineDuration() {
+    void testLogLineDuration() {
         String priorLogLine = "";
         String logLine = ", 10.7515460 secs]";
         String nextLogLine = "";
@@ -458,7 +458,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineClassHistogramTrigger() {
+    void testLogLineClassHistogramTrigger() {
         String priorLogLine = "";
         String logLine = "1662.232: [Full GC 11662.233: [Class Histogram:";
         String nextLogLine = "";
@@ -466,7 +466,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineDateStampClassHistogramTrigger() {
+    void testLogLineDateStampClassHistogramTrigger() {
         String priorLogLine = "";
         String logLine = "2017-04-24T21:07:32.713+0100: 669928.617: [Full GC 669928.619: [Class Histogram:";
         String nextLogLine = "";
@@ -474,7 +474,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineRetainMiddleClassHistogram() {
+    void testLogLineRetainMiddleClassHistogram() {
         String priorLogLine = "";
         String logLine = ": 516864K->516864K(516864K), 2.0947428 secs]182316.954: [Class Histogram: ";
         String nextLogLine = "";
@@ -482,7 +482,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineRetainEndClassHistogram() {
+    void testLogLineRetainEndClassHistogram() {
         String priorLogLine = "";
         String logLine = " 3863904K->756393K(7848704K), [CMS Perm : 682507K->442221K(1048576K)], 107.6553710 secs]"
                 + " [Times: user=112.83 sys=0.28, real=107.66 secs]";
@@ -491,7 +491,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineRetainBeginningConcurrentModeFailure() {
+    void testLogLineRetainBeginningConcurrentModeFailure() {
         String priorLogLine = "";
         String logLine = " (concurrent mode failure): 5355855K->991044K(7331840K), 58.3748587 secs]639860.666: "
                 + "[Class Histogram";
@@ -500,7 +500,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineRetainMiddleSerialConcurrentMixed() {
+    void testLogLineRetainMiddleSerialConcurrentMixed() {
         String priorLogLine = "";
         String logLine = ": 917504K->917504K(917504K), 5.5887120 secs]877375.047: [CMS877378.691: "
                 + "[CMS-concurrent-mark: 5.714/11.380 secs] [Times: user=14.72 sys=4.81, real=11.38 secs]";
@@ -509,7 +509,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineRetainBeginningParNewNoSpaceAfterGc() {
+    void testLogLineRetainBeginningParNewNoSpaceAfterGc() {
         String priorLogLine = "";
         String logLine = "12.891: [GC12.891: [ParNew";
         String nextLogLine = "";
@@ -517,7 +517,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewPrefixed() {
+    void testLogLineParNewPrefixed() {
         String priorLogLine = "";
         String logLine = "831626.089: [ParNew831628.158: [ParNew833918.729: [GC (Allocation Failure) 833918.729: "
                 + "[ParNew: 595103K->12118K(619008K), 0.0559019 secs] 1247015K->664144K(4157952K), 0.0561698 secs] "
@@ -531,7 +531,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningSerialConcurrentWithJvmtiEnvForceGarbageCollectionTrigger() {
+    void testLogLineBeginningSerialConcurrentWithJvmtiEnvForceGarbageCollectionTrigger() {
         String priorLogLine = "";
         String logLine = "262372.344: [Full GC (JvmtiEnv ForceGarbageCollection) 262372.344: [CMS262372.426: "
                 + "[CMS-concurrent-mark: 0.082/0.083 secs] [Times: user=0.08 sys=0.00, real=0.09 secs]";
@@ -544,7 +544,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningSerialConcurrentWithMetadataGcThreshold() {
+    void testLogLineBeginningSerialConcurrentWithMetadataGcThreshold() {
         String priorLogLine = "";
         String logLine = "262375.122: [Full GC (Metadata GC Threshold) 262375.122: [CMS262375.200: "
                 + "[CMS-concurrent-mark: 0.082/0.082 secs] [Times: user=0.08 sys=0.00, real=0.08 secs]";
@@ -557,7 +557,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningSerialNoSpaceAfterTrigger() {
+    void testLogLineBeginningSerialNoSpaceAfterTrigger() {
         String priorLogLine = "";
         String logLine = "5026.107: [Full GC (Allocation Failure)5026.108: [CMS"
                 + "5027.062: [CMS-concurrent-sweep: 9.543/33.853 secs] "
@@ -571,7 +571,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningSerialConcurrentWithGcLockerInitiatedGc() {
+    void testLogLineBeginningSerialConcurrentWithGcLockerInitiatedGc() {
         String priorLogLine = "";
         String logLine = "58626.878: [Full GC (GCLocker Initiated GC)58626.878: [CMS"
                 + "58630.075: [CMS-concurrent-sweep: 3.220/3.228 secs] [Times: user=3.38 sys=0.01, real=3.22 secs]";
@@ -584,7 +584,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewWithFlsStatistics() {
+    void testLogLineBeginningParNewWithFlsStatistics() {
         String priorLogLine = "";
         String logLine = "1.118: [GC Before GC:";
         String nextLogLine = "";
@@ -596,7 +596,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleParNewWithFlsStatistics() {
+    void testLogLineMiddleParNewWithFlsStatistics() {
         String priorLogLine = "";
         String logLine = "1.118: [ParNew: 377487K->8426K(5505024K), 0.0535260 secs] 377487K->8426K(43253760K)After GC:";
         String nextLogLine = "";
@@ -608,7 +608,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineDurationWithTimeStamp() {
+    void testLogLineDurationWithTimeStamp() {
         String priorLogLine = "";
         String logLine = ", 0.0536040 secs] [Times: user=0.89 sys=0.01, real=0.06 secs]";
         String nextLogLine = "";
@@ -620,7 +620,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinParNewPromotionFailedTruncatedWithCmsConcurrentMark() {
+    void testLogLinParNewPromotionFailedTruncatedWithCmsConcurrentMark() {
         String priorLogLine = "";
         String logLine = "36455.096: [GC 36455.096: [ParNew (promotion failed): 153344K->153344K(153344K), "
                 + "0.6818450 secs]36455.778: [CMS36459.090: [CMS-concurrent-mark: 3.439/4.155 secs] "
@@ -635,7 +635,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinParNewPromotionFailedTruncatedWithCmsConcurrentPreclean() {
+    void testLogLinParNewPromotionFailedTruncatedWithCmsConcurrentPreclean() {
         String priorLogLine = "";
         String logLine = "65778.258: [GC65778.258: [ParNew (promotion failed): 8300210K->8088352K(8388608K), "
                 + "1.4967400 secs]65779.755: [CMS65781.579: [CMS-concurrent-preclean: 2.150/47.638 secs] "
@@ -650,7 +650,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewWithNoParNewWithCmsConcurrentPreclean() {
+    void testLogLineBeginningParNewWithNoParNewWithCmsConcurrentPreclean() {
         String priorLogLine = "";
         String logLine = "3576157.596: [GC 3576157.596: [CMS-concurrent-abortable-preclean: 0.997/1.723 secs] "
                 + "[Times: user=3.20 sys=0.03, real=1.73 secs]";
@@ -663,7 +663,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLinParNewPromotionFailedWithCmsAbortPrecleanDueToTime() {
+    void testLogLinParNewPromotionFailedWithCmsAbortPrecleanDueToTime() {
         String priorLogLine = "";
         String logLine = "73241.738: [GC (Allocation Failure)73241.738: [ParNew (promotion failed): "
                 + "8205461K->8187503K(8388608K), 2.1449990 secs]73243.883: [CMS CMS: abort preclean due to time "
@@ -679,7 +679,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndParNew() {
+    void testLogLineEndParNew() {
         String priorLogLine = "";
         String logLine = "3576157.596: [ParNew: 147599K->17024K(153344K), 0.0795160 secs] "
                 + "2371401K->2244459K(6274432K), 0.0810030 secs] [Times: user=0.44 sys=0.00, real=0.08 secs]";
@@ -693,7 +693,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewDatestamp() {
+    void testLogLineBeginningParNewDatestamp() {
         String priorLogLine = "";
         String logLine = "2016-09-07T16:59:44.005-0400: 26536.942: [GC"
                 + "2016-09-07T16:59:44.005-0400: 26536.943: [ParNew";
@@ -707,7 +707,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsSerialOldCombinedConcurrentDatestamp() {
+    void testLogLineCmsSerialOldCombinedConcurrentDatestamp() {
         String priorLogLine = "";
         String logLine = "2016-10-10T19:17:37.771-0700: 2030.108: [GC (Allocation Failure) "
                 + "2016-10-10T19:17:37.771-0700: 2030.108: [ParNew2016-10-10T19:17:37.773-0700: "
@@ -724,7 +724,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginParNewCombinedFlsStatistics() {
+    void testLogLineBeginParNewCombinedFlsStatistics() {
         String priorLogLine = "";
         String logLine = "2017-02-27T14:29:54.533+0000: 2.730: [GC (Allocation Failure) Before GC:";
         String nextLogLine = "";
@@ -737,7 +737,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleParNewCombinedFlsStatistics() {
+    void testLogLineMiddleParNewCombinedFlsStatistics() {
         String priorLogLine = "";
         String logLine = "2017-02-27T14:29:54.534+0000: 2.730: [ParNew: 2048000K->191475K(2304000K), 0.0366288 secs] "
                 + "2048000K->191475K(7424000K)After GC:";
@@ -752,7 +752,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleParNewCombinedFlsStatisticsPrintPromotionFailure() {
+    void testLogLineMiddleParNewCombinedFlsStatisticsPrintPromotionFailure() {
         String priorLogLine = "";
         String logLine = "2017-02-28T00:43:55.587+0000: 36843.783: [ParNew (0: promotion failure size = 200)  "
                 + "(1: promotion failure size = 8)  (2: promotion failure size = 200)  "
@@ -802,7 +802,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleSerialFlsStatistics() {
+    void testLogLineMiddleSerialFlsStatistics() {
         String priorLogLine = "";
         String logLine = ": 2818067K->2769354K(5120000K), 3.8341757 secs] 5094036K->2769354K(7424000K), "
                 + "[Metaspace: 18583K->18583K(1067008K)]After GC:";
@@ -817,7 +817,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleParNewTruncatedBeginMixedConcurrentFlsStatistics2() {
+    void testLogLineMiddleParNewTruncatedBeginMixedConcurrentFlsStatistics2() {
         String priorLogLine = "";
         String logLine = "2017-03-19T11:48:55.207+0000: 356616.193: [ParNew2017-03-19T11:48:55.211+0000: 356616.198: "
                 + "[CMS-concurrent-abortable-preclean: 1.046/3.949 secs] [Times: user=1.16 sys=0.05, real=3.95 secs]";
@@ -831,7 +831,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleParNewTruncatedEndMixedConcurrentFlsStatistics2() {
+    void testLogLineMiddleParNewTruncatedEndMixedConcurrentFlsStatistics2() {
         String priorLogLine = "";
         String logLine = ": 66097K->7194K(66368K), 0.0440189 secs] 5274098K->5219953K(10478400K)After GC:";
         String nextLogLine = "";
@@ -844,7 +844,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndCmsScavengeBeforeRemark() {
+    void testLogLineEndCmsScavengeBeforeRemark() {
         String priorLogLine = "";
         String logLine = " 1677988K(7992832K), 0.3055773 secs]";
         String nextLogLine = "";
@@ -857,7 +857,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsRemarkWithoutGcDetails() {
+    void testLogLineCmsRemarkWithoutGcDetails() {
         String priorLogLine = "";
         String logLine = "2017-04-03T03:12:02.134-0500: 30.385: [GC (CMS Final Remark)  890910K->620060K(7992832K), "
                 + "0.1223879 secs]";
@@ -871,7 +871,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleCmsSerialOldMixedAbortPrecleanDueToTime() {
+    void testLogLineMiddleCmsSerialOldMixedAbortPrecleanDueToTime() {
         String priorLogLine = "";
         String logLine = "471419.156: [CMS CMS: abort preclean due to time 2017-04-22T13:59:06.831+0100: 471423.282: "
                 + "[CMS-concurrent-abortable-preclean: 3.663/31.735 secs] "
@@ -886,7 +886,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleCmsSerialOldMixedConcurrentSweep() {
+    void testLogLineMiddleCmsSerialOldMixedConcurrentSweep() {
         String priorLogLine = "";
         String logLine = "669950.539: [CMS2017-04-24T21:08:04.965+0100: 669960.868: [CMS-concurrent-sweep: "
                 + "13.324/39.970 secs] [Times: user=124.31 sys=2.44, real=39.97 secs]";
@@ -900,7 +900,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleCmsSerialOldWithDatestampMixedConcurrentSweep() {
+    void testLogLineMiddleCmsSerialOldWithDatestampMixedConcurrentSweep() {
         String priorLogLine = "";
         String logLine = "2017-05-03T14:47:16.910-0400: 1801.570: [CMS2017-05-03T14:47:22.416-0400: 1807.075: "
                 + "[CMS-concurrent-mark: 29.707/71.001 secs] [Times: user=121.03 sys=35.41, real=70.99 secs]";
@@ -914,7 +914,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndCmsSerialOld() {
+    void testLogLineEndCmsSerialOld() {
         String priorLogLine = "";
         String logLine = " 7778348K->1168095K(7848704K), [CMS Perm : 481281K->451017K(771512K)], 123.0277354 secs] "
                 + "[Times: user=123.19 sys=0.18, real=123.03 secs]";
@@ -928,7 +928,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewConcurrentModeFailureClassHistogram() {
+    void testLogLineBeginningParNewConcurrentModeFailureClassHistogram() {
         String priorLogLine = "";
         String logLine = "2017-04-22T12:43:48.008+0100: 466904.470: [GC 466904.473: [ParNew: "
                 + "516864K->516864K(516864K), 0.0001999 secs]466904.473: [Class Histogram:";
@@ -942,7 +942,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewConcurrentModeFailureClassHistogramWithDatestamps() {
+    void testLogLineBeginningParNewConcurrentModeFailureClassHistogramWithDatestamps() {
         String priorLogLine = "";
         String logLine = "2017-05-03T14:47:00.002-0400: 1784.661: [GC 2017-05-03T14:47:00.006-0400: 1784.664: "
                 + "[ParNew: 4147200K->4147200K(4147200K), 0.0677200 secs]"
@@ -957,7 +957,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleConcurrentModeFailureMixedClassHistogram() {
+    void testLogLineMiddleConcurrentModeFailureMixedClassHistogram() {
         String priorLogLine = "";
         String logLine = " (concurrent mode failure): 7835032K->8154090K(9216000K), 56.0787320 secs]"
                 + "2017-05-03T14:48:13.002-0400: 1857.661: [Class Histogram";
@@ -970,7 +970,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningSerialMixedClassHistogramWithDatestamp() {
+    void testLogLineBeginningSerialMixedClassHistogramWithDatestamp() {
         String priorLogLine = "";
         String logLine = "2017-05-03T14:51:32.659-0400: 2057.323: [Full GC "
                 + "2017-05-03T14:51:32.680-0400: 2057.341: [Class Histogram:";
@@ -983,7 +983,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningCmsConcurrentMixedApplicationConcurrentTime() {
+    void testLogLineBeginningCmsConcurrentMixedApplicationConcurrentTime() {
         String priorLogLine = "";
         String logLine = "2017-06-18T05:23:03.452-0500: 2.182: 2017-06-18T05:23:03.452-0500: "
                 + "[CMS-concurrent-preclean: 0.016/0.048 secs]2.182: Application time: 0.0055079 seconds";
@@ -996,7 +996,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndTimesData() {
+    void testLogLineEndTimesData() {
         String priorLogLine = "2017-06-18T05:23:03.452-0500: 2.182: 2017-06-18T05:23:03.452-0500: "
                 + "[CMS-concurrent-preclean: 0.016/0.048 secs]2.182: Application time: 0.0055079 seconds";
         String logLine = " [Times: user=0.15 sys=0.02, real=0.05 secs]";
@@ -1010,7 +1010,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleCmsRemarkJdk8() {
+    void testLogLineMiddleCmsRemarkJdk8() {
         String priorLogLine = "";
         String logLine = "2017-06-18T05:23:16.634-0500: 15.364: [GC (CMS Final Remark) 2017-06-18T05:23:16.634-0500: "
                 + "15.364: [ParNew";
@@ -1023,7 +1023,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewTenuringDistribution() {
+    void testLogLineBeginningParNewTenuringDistribution() {
         String priorLogLine = "";
         String logLine = "2016-09-23T09:05:18.745-0700: 2.372: [GC (Allocation Failure) "
                 + "2016-09-23T09:05:18.745-0700: 2.372: [ParNew";
@@ -1036,7 +1036,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParNewMixedHeapAtGc() {
+    void testLogLineBeginningParNewMixedHeapAtGc() {
         String priorLogLine = "";
         String logLine = "4237.297: [GC[YG occupancy: 905227 K (4194240 K)]{Heap before GC invocations=85 (full 1):";
         String nextLogLine = "";
@@ -1051,7 +1051,7 @@ public class TestCmsPreprocessAction {
      * Test preprocessing <code>PrintHeapAtGcEvent</code> with underlying <code>CmsSerialOldEvent</code>.
      */
     @Test
-    public void testSplitPrintHeapAtGcCmsSerialOldLogging() {
+    void testSplitPrintHeapAtGcCmsSerialOldLogging() {
         File testFile = TestUtil.getFile("dataset6.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1066,7 +1066,7 @@ public class TestCmsPreprocessAction {
      * Test with underlying <code>CmsSerialOld</code> triggered by concurrent mode failure.
      */
     @Test
-    public void testSplitPrintHeapAtGcCmsSerialOldConcurrentModeFailureLogging() {
+    void testSplitPrintHeapAtGcCmsSerialOldConcurrentModeFailureLogging() {
         File testFile = TestUtil.getFile("dataset8.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1083,7 +1083,7 @@ public class TestCmsPreprocessAction {
      * Test <code>CmsPreprocessAction</code>: split <code>CmsSerialOldEvent</code> and <code>CmsConcurrentEvent</code>.
      */
     @Test
-    public void testSplitCmsConcurrentModeFailureEventMarkLogging() {
+    void testSplitCmsConcurrentModeFailureEventMarkLogging() {
         File testFile = TestUtil.getFile("dataset10.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1100,7 +1100,7 @@ public class TestCmsPreprocessAction {
      * Test <code>CmsPreprocessAction</code>: split <code>CmsSerialOldEvent</code> and <code>CmsConcurrentEvent</code>.
      */
     @Test
-    public void testSplitCmsConcurrentModeFailureEventAbortablePrecleanLogging() {
+    void testSplitCmsConcurrentModeFailureEventAbortablePrecleanLogging() {
         File testFile = TestUtil.getFile("dataset11.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1117,7 +1117,7 @@ public class TestCmsPreprocessAction {
      * Test preprocessing <code>CmsSerialOldConcurrentModeFailureEvent</code> split over 3 lines.
      */
     @Test
-    public void testSplit3LinesCmsConcurrentModeFailureEventLogging() {
+    void testSplit3LinesCmsConcurrentModeFailureEventLogging() {
         File testFile = TestUtil.getFile("dataset14.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1134,7 +1134,7 @@ public class TestCmsPreprocessAction {
      * -XX:+PrintTenuringDistribution logging between the initial and final lines.
      */
     @Test
-    public void testSplitMixedTenuringParNewPromotionFailedEventLogging() {
+    void testSplitMixedTenuringParNewPromotionFailedEventLogging() {
         File testFile = TestUtil.getFile("dataset18.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1150,7 +1150,7 @@ public class TestCmsPreprocessAction {
      * Test preprocessing <code>PrintHeapAtGcEvent</code> with underlying <code>ParNewConcurrentModeFailureEvent</code>.
      */
     @Test
-    public void testSplitPrintHeapAtGcParNewPromotionFailedCmsConcurrentModeFailureEventLogging() {
+    void testSplitPrintHeapAtGcParNewPromotionFailedCmsConcurrentModeFailureEventLogging() {
         File testFile = TestUtil.getFile("dataset21.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1164,7 +1164,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewPromotionFailedTruncatedEventLogging() {
+    void testParNewPromotionFailedTruncatedEventLogging() {
         File testFile = TestUtil.getFile("dataset23.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1183,7 +1183,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testParNewMixedCmsConcurrent() {
+    void testParNewMixedCmsConcurrent() {
         File testFile = TestUtil.getFile("dataset58.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1200,7 +1200,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialConcurrentModeFailureMixedCmsConcurrent() {
+    void testCmsSerialConcurrentModeFailureMixedCmsConcurrent() {
         File testFile = TestUtil.getFile("dataset61.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1218,7 +1218,7 @@ public class TestCmsPreprocessAction {
      * and final lines.
      */
     @Test
-    public void testSplitMixedTenuringParNewPromotionEventWithTriggerLogging() {
+    void testSplitMixedTenuringParNewPromotionEventWithTriggerLogging() {
         File testFile = TestUtil.getFile("dataset67.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1233,7 +1233,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialConcurrentModeFailureMixedCmsConcurrentJdk8() {
+    void testCmsSerialConcurrentModeFailureMixedCmsConcurrentJdk8() {
         File testFile = TestUtil.getFile("dataset69.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1252,7 +1252,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialOldConcurrentModeInterruptedMixedCmsConcurrent() {
+    void testCmsSerialOldConcurrentModeInterruptedMixedCmsConcurrent() {
         File testFile = TestUtil.getFile("dataset71.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1270,7 +1270,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialOldPrintClassHistogramTriggerAcross5Lines() {
+    void testCmsSerialOldPrintClassHistogramTriggerAcross5Lines() {
         File testFile = TestUtil.getFile("dataset81.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1286,7 +1286,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testParNewPrintHeapAtGc() {
+    void testParNewPrintHeapAtGc() {
         File testFile = TestUtil.getFile("dataset83.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1303,7 +1303,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testParNewPrefixed() {
+    void testParNewPrefixed() {
         File testFile = TestUtil.getFile("dataset89.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1319,7 +1319,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialOldTriggerJvmtiEnvForceGarbageCollectionWithConcurrentModeInterrupted() {
+    void testCmsSerialOldTriggerJvmtiEnvForceGarbageCollectionWithConcurrentModeInterrupted() {
         File testFile = TestUtil.getFile("dataset90.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1337,7 +1337,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testCmsSerialOldTriggerMetadataGcThresholdWithConcurrentModeInterrupted() {
+    void testCmsSerialOldTriggerMetadataGcThresholdWithConcurrentModeInterrupted() {
         File testFile = TestUtil.getFile("dataset91.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1355,7 +1355,7 @@ public class TestCmsPreprocessAction {
      * 
      */
     @Test
-    public void testParNewWithFlsStatistics() {
+    void testParNewWithFlsStatistics() {
         File testFile = TestUtil.getFile("dataset94.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1368,7 +1368,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testBeginningParNewWithNoParNewWithCmsConcurrentPreclean() {
+    void testBeginningParNewWithNoParNewWithCmsConcurrentPreclean() {
         File testFile = TestUtil.getFile("dataset105.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1384,7 +1384,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testUnknownWithCmsConcurrent() {
+    void testUnknownWithCmsConcurrent() {
         File testFile = TestUtil.getFile("dataset111.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1401,7 +1401,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewCmsConcurrentOver3Lines() {
+    void testParNewCmsConcurrentOver3Lines() {
         File testFile = TestUtil.getFile("dataset112.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1414,7 +1414,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testPrintPromotionFailure() {
+    void testPrintPromotionFailure() {
         File testFile = TestUtil.getFile("dataset115.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1426,7 +1426,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testPrintFLSStatistics2ParNewOver4Lines() {
+    void testPrintFLSStatistics2ParNewOver4Lines() {
         File testFile = TestUtil.getFile("dataset117.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1439,7 +1439,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testCmsScavengeBeforeRemarkNoPrintGcDetails() {
+    void testCmsScavengeBeforeRemarkNoPrintGcDetails() {
         File testFile = TestUtil.getFile("dataset120.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1450,7 +1450,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewConcurrentModeFailureMixedAbortPrecleanDueToTime() {
+    void testParNewConcurrentModeFailureMixedAbortPrecleanDueToTime() {
         File testFile = TestUtil.getFile("dataset121.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1463,7 +1463,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewConcurrentModeFailureMixedConcurrentPreclean() {
+    void testParNewConcurrentModeFailureMixedConcurrentPreclean() {
         File testFile = TestUtil.getFile("dataset122.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1476,7 +1476,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewConcurrentModeFailureMixedConcurrentMark() {
+    void testParNewConcurrentModeFailureMixedConcurrentMark() {
         File testFile = TestUtil.getFile("dataset123.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1489,7 +1489,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testCmsSerialOldConcurrentModeFailureMixedConcurrentMark() {
+    void testCmsSerialOldConcurrentModeFailureMixedConcurrentMark() {
         File testFile = TestUtil.getFile("dataset124.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1502,7 +1502,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testCmsConcurrentMixedApplicationConcurrentTime() {
+    void testCmsConcurrentMixedApplicationConcurrentTime() {
         File testFile = TestUtil.getFile("dataset135.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1516,7 +1516,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testCmsScavengeBeforeRemarkJdk8MixedHeapAtGc() {
+    void testCmsScavengeBeforeRemarkJdk8MixedHeapAtGc() {
         File testFile = TestUtil.getFile("dataset136.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1529,7 +1529,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testCmsScavengeBeforeRemarkJMixedHeapAtGc() {
+    void testCmsScavengeBeforeRemarkJMixedHeapAtGc() {
         File testFile = TestUtil.getFile("dataset140.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1542,7 +1542,7 @@ public class TestCmsPreprocessAction {
     }
 
     @Test
-    public void testParNewMixedHeapAtGc() {
+    void testParNewMixedHeapAtGc() {
         File testFile = TestUtil.getFile("dataset141.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestCmsPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestCmsPreprocessAction.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.PreprocessActionType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -46,8 +46,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -59,15 +58,12 @@ public class TestCmsPreprocessAction {
         String nextLogLine = ": 8943881K->8813432K(9412608K), 7.7851270 secs] 11797193K->9475525K(12265920K), [CMS "
                 + "Perm : 460344K->460331K(770956K)], 7.7854740 secs] [Times: user=7.79 sys=0.01, real=7.78 secs]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-03-21T16:02:23.633+0530: 53277.279: [GC 53277.279: [ParNew: 2853312K->2853312K(2853312K), "
-                        + "0.0000310 secs]53277.279: [CMS",
-                event.getLogEntry());
+        assertEquals("2017-03-21T16:02:23.633+0530: 53277.279: [GC 53277.279: [ParNew: 2853312K->2853312K(2853312K), "
+		+ "0.0000310 secs]53277.279: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -78,8 +74,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -89,8 +84,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -100,8 +94,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -111,8 +104,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -122,15 +114,13 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineMiddle() {
         String logLine = "1907.974: [CMS-concurrent-mark: 23.751/40.476 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -140,13 +130,11 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         Set<String> context = new HashSet<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "45.574: [GC (Allocation Failure) 45.574: [ParNew",
-                event.getLogEntry());
+        assertEquals("45.574: [GC (Allocation Failure) 45.574: [ParNew",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -157,8 +145,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -166,16 +153,14 @@ public class TestCmsPreprocessAction {
         String logLine = "2016-02-26T16:37:58.740+1100: 44.684: [Full GC2016-02-26T16:37:58.740+1100: 44.684: [CMS"
                 + "2016-02-26T16:37:58.933+1100: 44.877: [CMS-concurrent-mark: 1.508/2.428 secs] "
                 + "[Times: user=3.44 sys=0.49, real=2.42 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineCmsSerialOldMixedConcurrentAbortablePreclean() {
         String logLine = "85217.903: [Full GC 85217.903: [CMS85217.919: [CMS-concurrent-abortable-preclean: "
                 + "0.723/3.756 secs] [Times: user=2.54 sys=0.08, real=3.76 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -183,32 +168,28 @@ public class TestCmsPreprocessAction {
         String logLine = "2017-06-22T21:22:03.269-0400: 23.858: [Full GC 23.859: [CMS CMS: abort preclean due to "
                 + "time 2017-06-22T21:22:03.269-0400: 23.859: [CMS-concurrent-abortable-preclean: 0.338/5.115 secs] "
                 + "[Times: user=14.57 sys=0.83, real=5.11 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
         String nextLogLine = " (concurrent mode failure): 8156K->36298K(7864320K), 1.0166580 secs] "
                 + "89705K->36298K(8336192K), [CMS Perm : 34431K->34268K(34548K)], 1.0172840 secs] "
                 + "[Times: user=0.86 sys=0.14, real=1.02 secs]";
         Set<String> context = new HashSet<String>();
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "2017-06-22T21:22:03.269-0400: 23.858: [Full GC 23.859: [CMS",
-                event.getLogEntry());
+        assertEquals("2017-06-22T21:22:03.269-0400: 23.858: [Full GC 23.859: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineCmsSerialOldMixedConcurrentSpaceAfterGC() {
         String logLine = "85238.030: [Full GC 85238.030: [CMS85238.672: [CMS-concurrent-mark: 0.666/0.686 secs] "
                 + "[Times: user=1.40 sys=0.01, real=0.69 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineCmsSerialOldWithTriggerMixedConcurrent() {
         String logLine = "706.707: [Full GC (Allocation Failure) 706.708: [CMS709.137: [CMS-concurrent-mark: "
                 + "3.381/5.028 secs] [Times: user=23.92 sys=3.02, real=5.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -218,8 +199,7 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=1.33 sys=0.01, real=1.37 secs]";
         String priorLogLine = "44.684: [Full GC44.684: [CMS44.877: [CMS-concurrent-mark: 1.508/2.428 secs] "
                 + "[Times: user=3.44 sys=0.49, real=2.42 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -230,8 +210,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -243,8 +222,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -255,8 +233,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2542828K->2658278K(2658304K), 12.3447910 secs] "
                 + "3925228K->2702358K(4040704K), [Metaspace: 72175K->72175K(1118208K)] icms_dc=100 , 12.3480570 secs] "
                 + "[Times: user=15.38 sys=0.02, real=12.35 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -266,38 +243,33 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "46674.719: [GC (Allocation Failure)46674.719: [ParNew46674.749: "
                 + "[CMS-concurrent-abortable-preclean: 1.427/2.228 secs] "
                 + "[Times: user=1.56 sys=0.01, real=2.23 secs]   ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, null));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineSerialBailing() {
         String logLine = "4300.825: [Full GC 4300.825: [CMSbailing out to foreground collection";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineParNewBailing() {
         String logLine = "2137.769: [GC 2137.769: [ParNew (promotion failed): 242304K->242304K(242304K), "
                 + "8.4066690 secs]2146.176: [CMSbailing out to foreground collection";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, null));
+        assertTrue(CmsPreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineParNewHotspotBailing() {
         String logLine = "1901.217: [GC 1901.217: [ParNew: 261760K->261760K(261952K), 0.0000570 secs]1901.217: "
                 + "[CMSJava HotSpot(TM) Server VM warning: bailing out to foreground collection";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, ""));
+        assertTrue(CmsPreprocessAction.match(logLine, null, ""), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
     public void testLogLineParTriggerPromotionFailed() {
         String logLine = "182314.858: [GC 182314.859: [ParNew (promotion failed)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, ""));
+        assertTrue(CmsPreprocessAction.match(logLine, null, ""), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -308,8 +280,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2656311K->2658289K(2658304K), 9.3575580 secs] "
                 + "4011734K->2725109K(4040704K), [Metaspace: 72111K->72111K(1118208K)], 9.3610080 secs] "
                 + "[Times: user=9.35 sys=0.01, real=9.36 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -319,8 +290,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2658303K->2658303K(2658304K), 9.1546180 secs] "
                 + "4040703K->2750110K(4040704K), [Metaspace: 72113K->72113K(1118208K)], 9.1581450 secs] "
                 + "[Times: user=9.15 sys=0.00, real=9.16 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -330,8 +300,7 @@ public class TestCmsPreprocessAction {
         String nextLogLine = " (concurrent mode failure): 2658304K->2658303K(2658304K), 9.4908960 secs] "
                 + "4040703K->2996946K(4040704K), [Metaspace: 72191K->72191K(1118208K)], 9.4942330 secs] "
                 + "[Times: user=9.49 sys=0.00, real=9.49 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -341,8 +310,7 @@ public class TestCmsPreprocessAction {
                 + "0.043/0.144 secs] [Times: user=0.58 sys=0.03, real=0.14 secs]";
         String nextLogLine = ": 212981K->3156K(242304K), 0.0364435 secs] 4712182K->4502357K(4971420K), "
                 + "0.0368807 secs] [Times: user=0.18 sys=0.02, real=0.04 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -352,8 +320,7 @@ public class TestCmsPreprocessAction {
         String logLine = ": 212981K->3156K(242304K), 0.0364435 secs] 4712182K->4502357K(4971420K), "
                 + "0.0368807 secs] [Times: user=0.18 sys=0.02, real=0.04 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -363,8 +330,7 @@ public class TestCmsPreprocessAction {
                 + "42.841/48.076 secs] [Times: user=19.45 sys=0.45, real=48.06 secs]";
         String nextLogLine = ": 36500K->3770K(38336K), 0.1767060 secs] 408349K->375618K(2092928K), "
                 + "0.1769190 secs] [Times: user=0.05 sys=0.00, real=0.18 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -374,8 +340,7 @@ public class TestCmsPreprocessAction {
                 + "1045947K->904027K(2047232K), [CMS Perm : 252246K->252202K(262144K)], 42.9070278 secs] "
                 + "[Times: user=43.11 sys=0.18, real=42.91 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -383,8 +348,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "28282.075: [Full GC {Heap before gc invocations=528:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -392,8 +356,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "27067.966: [GC {Heap before gc invocations=498:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -402,8 +365,7 @@ public class TestCmsPreprocessAction {
         String logLine = "2017-04-03T08:55:45.544-0500: 20653.796: [GC (CMS Final Remark) {Heap before GC "
                 + "invocations=686 (full 15):";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -412,8 +374,7 @@ public class TestCmsPreprocessAction {
         String logLine = "2017-06-18T05:23:16.634-0500: 15.364: [GC (CMS Final Remark) [YG occupancy: 576424 K "
                 + "(1677760 K)]{Heap before GC invocations=8 (full 2):";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -421,8 +382,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "28282.075: [CMS28284.687: [CMS-concurrent-preclean: 3.706/3.706 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -431,8 +391,7 @@ public class TestCmsPreprocessAction {
         String logLine = "27067.966: [ParNew: 261760K->261760K(261952K), 0.0000160 secs]27067.966: [CMS"
                 + "27067.966: [CMS-concurrent-abortable-preclean: 2.272/29.793 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -441,8 +400,7 @@ public class TestCmsPreprocessAction {
         String logLine = "28308.701: [ParNew (promotion failed): 261951K->261951K(261952K), 0.7470390 secs]28309.448: "
                 + "[CMS28312.544: [CMS-concurrent-mark: 5.114/5.863 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -452,8 +410,7 @@ public class TestCmsPreprocessAction {
                 + "[CMS2017-02-15T16:22:06.001+0900: 1223922.832: [CMS-concurrent-mark: 3.589/4.431 secs] "
                 + "[Times: user=6.13 sys=0.89, real=4.43 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -463,8 +420,7 @@ public class TestCmsPreprocessAction {
                 + "1951125K->1616248K(4193600K), [CMS Perm : 507386K->499194K(786432K)]"
                 + "Heap after gc invocations=147:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -472,8 +428,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "11700.930: [CMS: 2844387K->635365K(7331840K), 46.4488813 secs]11747.379: [Class Histogram";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -482,8 +437,7 @@ public class TestCmsPreprocessAction {
         String logLine = " (concurrent mode failure): 1179601K->1179648K(1179648K), 10.7510650 secs] "
                 + "1441361K->1180553K(1441600K), [CMS Perm : 71172K->71171K(262144K)]Heap after gc invocations=529:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -492,8 +446,7 @@ public class TestCmsPreprocessAction {
         String logLine = " (concurrent mode failure): 1147900K->1155037K(1179648K), 7.3953900 secs] "
                 + "1409660K->1155037K(1441600K)Heap after gc invocations=499:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -501,8 +454,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = ", 10.7515460 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -510,8 +462,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "1662.232: [Full GC 11662.233: [Class Histogram:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -519,8 +470,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "2017-04-24T21:07:32.713+0100: 669928.617: [Full GC 669928.619: [Class Histogram:";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -528,8 +478,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = ": 516864K->516864K(516864K), 2.0947428 secs]182316.954: [Class Histogram: ";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -538,8 +487,7 @@ public class TestCmsPreprocessAction {
         String logLine = " 3863904K->756393K(7848704K), [CMS Perm : 682507K->442221K(1048576K)], 107.6553710 secs]"
                 + " [Times: user=112.83 sys=0.28, real=107.66 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -548,8 +496,7 @@ public class TestCmsPreprocessAction {
         String logLine = " (concurrent mode failure): 5355855K->991044K(7331840K), 58.3748587 secs]639860.666: "
                 + "[Class Histogram";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -558,8 +505,7 @@ public class TestCmsPreprocessAction {
         String logLine = ": 917504K->917504K(917504K), 5.5887120 secs]877375.047: [CMS877378.691: "
                 + "[CMS-concurrent-mark: 5.714/11.380 secs] [Times: user=14.72 sys=4.81, real=11.38 secs]";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -567,8 +513,7 @@ public class TestCmsPreprocessAction {
         String priorLogLine = "";
         String logLine = "12.891: [GC12.891: [ParNew";
         String nextLogLine = "";
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
     }
 
     @Test
@@ -579,13 +524,10 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=0.09 sys=0.00, real=0.06 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.",
-                "833918.729: [GC (Allocation Failure) 833918.729: [ParNew: 595103K->12118K(619008K), 0.0559019 secs] "
-                        + "1247015K->664144K(4157952K), 0.0561698 secs] [Times: user=0.09 sys=0.00, real=0.06 secs]",
-                event.getLogEntry());
+        assertEquals("833918.729: [GC (Allocation Failure) 833918.729: [ParNew: 595103K->12118K(619008K), 0.0559019 secs] "
+		+ "1247015K->664144K(4157952K), 0.0561698 secs] [Times: user=0.09 sys=0.00, real=0.06 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -595,12 +537,10 @@ public class TestCmsPreprocessAction {
                 + "[CMS-concurrent-mark: 0.082/0.083 secs] [Times: user=0.08 sys=0.00, real=0.09 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "262372.344: [Full GC (JvmtiEnv ForceGarbageCollection) 262372.344: [CMS", event.getLogEntry());
+        assertEquals("262372.344: [Full GC (JvmtiEnv ForceGarbageCollection) 262372.344: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -610,12 +550,10 @@ public class TestCmsPreprocessAction {
                 + "[CMS-concurrent-mark: 0.082/0.082 secs] [Times: user=0.08 sys=0.00, real=0.08 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "262375.122: [Full GC (Metadata GC Threshold) 262375.122: [CMS",
-                event.getLogEntry());
+        assertEquals("262375.122: [Full GC (Metadata GC Threshold) 262375.122: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -626,12 +564,10 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=107.27 sys=5.82, real=33.85 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "5026.107: [Full GC (Allocation Failure)5026.108: [CMS",
-                event.getLogEntry());
+        assertEquals("5026.107: [Full GC (Allocation Failure)5026.108: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -641,12 +577,10 @@ public class TestCmsPreprocessAction {
                 + "58630.075: [CMS-concurrent-sweep: 3.220/3.228 secs] [Times: user=3.38 sys=0.01, real=3.22 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "58626.878: [Full GC (GCLocker Initiated GC)58626.878: [CMS",
-                event.getLogEntry());
+        assertEquals("58626.878: [Full GC (GCLocker Initiated GC)58626.878: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -655,11 +589,10 @@ public class TestCmsPreprocessAction {
         String logLine = "1.118: [GC Before GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "1.118: [GC ", event.getLogEntry());
+        assertEquals("1.118: [GC ",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -668,13 +601,10 @@ public class TestCmsPreprocessAction {
         String logLine = "1.118: [ParNew: 377487K->8426K(5505024K), 0.0535260 secs] 377487K->8426K(43253760K)After GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "1.118: [ParNew: 377487K->8426K(5505024K), 0.0535260 secs] 377487K->8426K(43253760K)",
-                event.getLogEntry());
+        assertEquals("1.118: [ParNew: 377487K->8426K(5505024K), 0.0535260 secs] 377487K->8426K(43253760K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -683,11 +613,10 @@ public class TestCmsPreprocessAction {
         String logLine = ", 0.0536040 secs] [Times: user=0.89 sys=0.01, real=0.06 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -698,14 +627,11 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=8.27 sys=0.17, real=4.16 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "36455.096: [GC 36455.096: [ParNew (promotion failed): 153344K->153344K(153344K), 0.6818450 secs]"
-                        + "36455.778: [CMS",
-                event.getLogEntry());
+        assertEquals("36455.096: [GC 36455.096: [ParNew (promotion failed): 153344K->153344K(153344K), 0.6818450 secs]"
+		+ "36455.778: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -716,14 +642,11 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=81.22 sys=2.02, real=47.63 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "65778.258: [GC65778.258: [ParNew (promotion failed): 8300210K->8088352K(8388608K), "
-                        + "1.4967400 secs]65779.755: [CMS",
-                event.getLogEntry());
+        assertEquals("65778.258: [GC65778.258: [ParNew (promotion failed): 8300210K->8088352K(8388608K), "
+		+ "1.4967400 secs]65779.755: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -733,11 +656,10 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=3.20 sys=0.03, real=1.73 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "3576157.596: [GC ", event.getLogEntry());
+        assertEquals("3576157.596: [GC ",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -749,14 +671,11 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=43.26 sys=1.66, real=9.08 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "73241.738: [GC (Allocation Failure)73241.738: [ParNew (promotion failed): "
-                        + "8205461K->8187503K(8388608K), 2.1449990 secs]73243.883: [CMS",
-                event.getLogEntry());
+        assertEquals("73241.738: [GC (Allocation Failure)73241.738: [ParNew (promotion failed): "
+		+ "8205461K->8187503K(8388608K), 2.1449990 secs]73243.883: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -766,12 +685,11 @@ public class TestCmsPreprocessAction {
                 + "2371401K->2244459K(6274432K), 0.0810030 secs] [Times: user=0.44 sys=0.00, real=0.08 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -781,12 +699,11 @@ public class TestCmsPreprocessAction {
                 + "2016-09-07T16:59:44.005-0400: 26536.943: [ParNew";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -798,15 +715,12 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=0.11 sys=0.03, real=0.15 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.",
-                "2016-10-10T19:17:37.771-0700: 2030.108: [GC (Allocation Failure) "
-                        + "2016-10-10T19:17:37.771-0700: 2030.108: [ParNew",
-                event.getLogEntry());
+        assertEquals("2016-10-10T19:17:37.771-0700: 2030.108: [GC (Allocation Failure) "
+		+ "2016-10-10T19:17:37.771-0700: 2030.108: [ParNew",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -815,13 +729,11 @@ public class TestCmsPreprocessAction {
         String logLine = "2017-02-27T14:29:54.533+0000: 2.730: [GC (Allocation Failure) Before GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", "2017-02-27T14:29:54.533+0000: 2.730: [GC (Allocation Failure) ",
-                event.getLogEntry());
+        assertEquals("2017-02-27T14:29:54.533+0000: 2.730: [GC (Allocation Failure) ",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -831,15 +743,12 @@ public class TestCmsPreprocessAction {
                 + "2048000K->191475K(7424000K)After GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-02-27T14:29:54.534+0000: 2.730: [ParNew: 2048000K->191475K(2304000K), 0.0366288 secs] "
-                        + "2048000K->191475K(7424000K)",
-                event.getLogEntry());
+        assertEquals("2017-02-27T14:29:54.534+0000: 2.730: [ParNew: 2048000K->191475K(2304000K), 0.0366288 secs] "
+		+ "2048000K->191475K(7424000K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -866,8 +775,7 @@ public class TestCmsPreprocessAction {
                 + "2017-02-28T00:43:56.037+0000: 36844.234: [CMSCMS: Large block 0x0000000730892bb8";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
@@ -890,7 +798,7 @@ public class TestCmsPreprocessAction {
                 + "(30: promotion failure size = 200)  (31: promotion failure size = 200)  "
                 + "(32: promotion failure size = 200)  (promotion failed): 2304000K->2304000K(2304000K), "
                 + "0.4501923 secs]2017-02-28T00:43:56.037+0000: 36844.234: [CMS";
-        assertEquals("Log line not parsed correctly.", logLinePreprocessed, event.getLogEntry());
+        assertEquals(logLinePreprocessed,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -900,15 +808,12 @@ public class TestCmsPreprocessAction {
                 + "[Metaspace: 18583K->18583K(1067008K)]After GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.",
-                ": 2818067K->2769354K(5120000K), 3.8341757 secs] 5094036K->2769354K(7424000K), "
-                        + "[Metaspace: 18583K->18583K(1067008K)]",
-                event.getLogEntry());
+        assertEquals(": 2818067K->2769354K(5120000K), 3.8341757 secs] 5094036K->2769354K(7424000K), "
+		+ "[Metaspace: 18583K->18583K(1067008K)]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -918,13 +823,11 @@ public class TestCmsPreprocessAction {
                 + "[CMS-concurrent-abortable-preclean: 1.046/3.949 secs] [Times: user=1.16 sys=0.05, real=3.95 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", "2017-03-19T11:48:55.207+0000: 356616.193: [ParNew",
-                event.getLogEntry());
+        assertEquals("2017-03-19T11:48:55.207+0000: 356616.193: [ParNew",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -933,13 +836,11 @@ public class TestCmsPreprocessAction {
         String logLine = ": 66097K->7194K(66368K), 0.0440189 secs] 5274098K->5219953K(10478400K)After GC:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.",
-                ": 66097K->7194K(66368K), 0.0440189 secs] 5274098K->5219953K(10478400K)", event.getLogEntry());
+        assertEquals(": 66097K->7194K(66368K), 0.0440189 secs] 5274098K->5219953K(10478400K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -948,12 +849,11 @@ public class TestCmsPreprocessAction {
         String logLine = " 1677988K(7992832K), 0.3055773 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 1677988K(7992832K), 0.3055773 secs]", event.getLogEntry());
+        assertEquals(" 1677988K(7992832K), 0.3055773 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -963,12 +863,11 @@ public class TestCmsPreprocessAction {
                 + "0.1223879 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -979,12 +878,11 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=39.81 sys=0.23, real=31.74 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", "471419.156: [CMS", event.getLogEntry());
+        assertEquals("471419.156: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -994,12 +892,11 @@ public class TestCmsPreprocessAction {
                 + "13.324/39.970 secs] [Times: user=124.31 sys=2.44, real=39.97 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", "669950.539: [CMS", event.getLogEntry());
+        assertEquals("669950.539: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1009,13 +906,11 @@ public class TestCmsPreprocessAction {
                 + "[CMS-concurrent-mark: 29.707/71.001 secs] [Times: user=121.03 sys=35.41, real=70.99 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", "2017-05-03T14:47:16.910-0400: 1801.570: [CMS",
-                event.getLogEntry());
+        assertEquals("2017-05-03T14:47:16.910-0400: 1801.570: [CMS",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1025,12 +920,11 @@ public class TestCmsPreprocessAction {
                 + "[Times: user=123.19 sys=0.18, real=123.03 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1040,12 +934,11 @@ public class TestCmsPreprocessAction {
                 + "516864K->516864K(516864K), 0.0001999 secs]466904.473: [Class Histogram:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1056,12 +949,11 @@ public class TestCmsPreprocessAction {
                 + "2017-05-03T14:47:00.075-0400: 1784.735: [Class Histogram:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1071,11 +963,10 @@ public class TestCmsPreprocessAction {
                 + "2017-05-03T14:48:13.002-0400: 1857.661: [Class Histogram";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1085,11 +976,10 @@ public class TestCmsPreprocessAction {
                 + "2017-05-03T14:51:32.680-0400: 2057.341: [Class Histogram:";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1099,13 +989,10 @@ public class TestCmsPreprocessAction {
                 + "[CMS-concurrent-preclean: 0.016/0.048 secs]2.182: Application time: 0.0055079 seconds";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-06-18T05:23:03.452-0500: 2.182: [CMS-concurrent-preclean: 0.016/0.048 secs]",
-                event.getLogEntry());
+        assertEquals("2017-06-18T05:23:03.452-0500: 2.182: [CMS-concurrent-preclean: 0.016/0.048 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1115,12 +1002,11 @@ public class TestCmsPreprocessAction {
         String logLine = " [Times: user=0.15 sys=0.02, real=0.05 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(priorLogLine, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1130,11 +1016,10 @@ public class TestCmsPreprocessAction {
                 + "15.364: [ParNew";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1144,11 +1029,10 @@ public class TestCmsPreprocessAction {
                 + "2016-09-23T09:05:18.745-0700: 2.372: [ParNew";
         String nextLogLine = "Desired survivor size 78643200 bytes, new threshold 15 (max 15)";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1157,12 +1041,10 @@ public class TestCmsPreprocessAction {
         String logLine = "4237.297: [GC[YG occupancy: 905227 K (4194240 K)]{Heap before GC invocations=85 (full 1):";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.CMS.toString() + ".",
-                CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(CmsPreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.CMS.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         CmsPreprocessAction event = new CmsPreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "4237.297: [GC[YG occupancy: 905227 K (4194240 K)]",
-                event.getLogEntry());
+        assertEquals("4237.297: [GC[YG occupancy: 905227 K (4194240 K)]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     /**
@@ -1175,11 +1057,9 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC), Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.");
     }
 
     /**
@@ -1192,15 +1072,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC), Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.");
     }
 
     /**
@@ -1213,15 +1089,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(JdkUtil.TriggerType.CMS_CONCURRENT_MODE_FAILURE.toString() + " trigger not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), JdkUtil.TriggerType.CMS_CONCURRENT_MODE_FAILURE.toString() + " trigger not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1234,15 +1106,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(JdkUtil.TriggerType.CMS_CONCURRENT_MODE_FAILURE.toString() + " trigger not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), JdkUtil.TriggerType.CMS_CONCURRENT_MODE_FAILURE.toString() + " trigger not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1255,13 +1123,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1275,13 +1140,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1294,15 +1156,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC), Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.");
     }
 
     @Test
@@ -1312,17 +1170,12 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue(Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED), Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis not identified.");
     }
 
     /**
@@ -1336,13 +1189,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(LogEventType.PAR_NEW.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue(LogEventType.CMS_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), LogEventType.PAR_NEW.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), LogEventType.CMS_CONCURRENT.toString() + " collector not identified.");
     }
 
     /**
@@ -1356,15 +1206,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(LogEventType.CMS_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), LogEventType.CMS_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1378,9 +1224,8 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
     }
 
     /**
@@ -1394,17 +1239,12 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(LogEventType.CMS_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), LogEventType.CMS_SERIAL_OLD.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), LogEventType.CMS_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INCREMENTAL_MODE), Analysis.WARN_CMS_INCREMENTAL_MODE + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1418,15 +1258,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue(JdkUtil.TriggerType.CMS_CONCURRENT_MODE_INTERRUPTED.toString() + " trigger not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED), JdkUtil.TriggerType.CMS_CONCURRENT_MODE_INTERRUPTED.toString() + " trigger not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1440,11 +1276,9 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
     }
 
     /**
@@ -1458,13 +1292,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue(Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_HEAP_AT_GC), Analysis.WARN_PRINT_HEAP_AT_GC + " analysis not identified.");
     }
 
     /**
@@ -1478,11 +1309,9 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
     }
 
     /**
@@ -1496,15 +1325,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED), Analysis.ERROR_CMS_CONCURRENT_MODE_INTERRUPTED + " analysis not identified.");
     }
 
     /**
@@ -1518,15 +1343,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1540,13 +1361,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue(Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS), Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.");
     }
 
     @Test
@@ -1556,19 +1374,13 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertFalse(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED));
-        assertFalse(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK), "Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED), Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED), Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis identified.");
     }
 
     @Test
@@ -1580,16 +1392,12 @@ public class TestCmsPreprocessAction {
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         String lastLogLineUnprocessed = "130454.251: [Full GC (Allocation Failure) 130454.251: [CMS130456.427: "
                 + "[CMS-concurrent-mark: 2.176/2.182 secs] [Times: user=2.18 sys=0.00, real=2.18 secs]";
-        assertEquals("Last unprocessed log line not correct.", lastLogLineUnprocessed,
-                gcManager.getLastLogLineUnprocessed());
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + LogEventType.UNKNOWN.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
+        assertEquals(lastLogLineUnprocessed,gcManager.getLastLogLineUnprocessed(),"Last unprocessed log line not correct.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), "Log line not recognized as " + LogEventType.UNKNOWN.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
         // Not the last preprocessed line, but part of last unpreprocessed line
-        assertTrue(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST), Analysis.INFO_UNIDENTIFIED_LOG_LINE_LAST + " analysis not identified.");
     }
 
     @Test
@@ -1599,13 +1407,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -1615,11 +1420,9 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 4, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue(Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED));
+        assertEquals(4,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED), Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis not identified.");
     }
 
     @Test
@@ -1629,13 +1432,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS), Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.");
     }
 
     @Test
@@ -1645,9 +1445,8 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 4, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
+        assertEquals(4,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
     }
 
     @Test
@@ -1657,13 +1456,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -1673,13 +1469,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -1689,13 +1482,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -1705,13 +1495,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE), Analysis.ERROR_CMS_CONCURRENT_MODE_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -1721,15 +1508,11 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_CONCURRENT), "Log line not recognized as " + LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_CONCURRENT_TIME.toString() + ".");
     }
 
     @Test
@@ -1739,13 +1522,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK), "Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".");
     }
 
     @Test
@@ -1755,13 +1535,10 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
-        assertTrue("Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.CMS_REMARK), "Log line not recognized as " + LogEventType.CMS_REMARK.toString() + ".");
     }
 
     @Test
@@ -1771,10 +1548,8 @@ public class TestCmsPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(LogEventType.PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.PAR_NEW), "Log line not recognized as " + LogEventType.PAR_NEW.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestDateStampPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestDateStampPreprocessAction.java
@@ -12,14 +12,14 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 import java.util.Date;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -31,8 +31,7 @@ public class TestDateStampPreprocessAction {
     public void testLogLine() {
         String logLine = "2010-02-26T09:32:12.486-0600: [GC [ParNew: 150784K->3817K(169600K), 0.0328800 secs]"
                 + " 150784K->3817K(1029760K), 0.0329790 secs] [Times: user=0.00 sys=0.00, real=0.03 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.DATE_STAMP.toString() + ".",
-                DateStampPreprocessAction.match(logLine));
+        assertTrue(DateStampPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.DATE_STAMP.toString() + ".");
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 2010);
         calendar.set(Calendar.MONTH, Calendar.FEBRUARY);
@@ -45,6 +44,6 @@ public class TestDateStampPreprocessAction {
         DateStampPreprocessAction preprocessAction = new DateStampPreprocessAction(logLine, jvmStartDate);
         String preprocessedLogLine = "34332.486: [GC [ParNew: 150784K->3817K(169600K), 0.0328800 secs]"
                 + " 150784K->3817K(1029760K), 0.0329790 secs] [Times: user=0.00 sys=0.00, real=0.03 secs]";
-        assertEquals("Log line not parsed correctly.", preprocessedLogLine, preprocessAction.getLogEntry());
+        assertEquals(preprocessedLogLine,preprocessAction.getLogEntry(),"Log line not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestDateStampPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestDateStampPreprocessAction.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestDateStampPreprocessAction {
+class TestDateStampPreprocessAction {
 
     @Test
-    public void testLogLine() {
+    void testLogLine() {
         String logLine = "2010-02-26T09:32:12.486-0600: [GC [ParNew: 150784K->3817K(169600K), 0.0328800 secs]"
                 + " 150784K->3817K(1029760K), 0.0329790 secs] [Times: user=0.00 sys=0.00, real=0.03 secs]";
         assertTrue(DateStampPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.DATE_STAMP.toString() + ".");

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestG1PreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestG1PreprocessAction.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.PreprocessActionType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,418 +42,359 @@ public class TestG1PreprocessAction {
     @Test
     public void testLogLineG1EvacuationPause() {
         String logLine = "2.192: [GC pause (G1 Evacuation Pause) (young)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRootRegionScanWaiting() {
         String logLine = "   [Root Region Scan Waiting: 112.3 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelTime() {
         String logLine = "   [Parallel Time: 12.6 ms, GC Workers: 6]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorker() {
         String logLine = "      [GC Worker (ms):  387,2  387,4  386,2  385,9  386,1  386,2  386,9  386,4  386,4  "
                 + "386,8  386,1  385,2  386,1";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerStart() {
         String logLine = "      [GC Worker Start Time (ms):  807.5  807.8  807.8  810.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerStartJdk8() {
         String logLine = "      [GC Worker Start (ms): Min: 2191.9, Avg: 2191.9, Max: 2191.9, Diff: 0.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerStartWithCommas() {
         String logLine = "      [GC Worker Start (ms): Min: 6349,9, Avg: 6353,8, Max: 6355,9, Diff: 6,0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineExtRootScanning() {
         String logLine = "      [Ext Root Scanning (ms): Min: 2.7, Avg: 3.0, Max: 3.5, Diff: 0.8, Sum: 18.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineUpdateRs() {
         String logLine = "      [Update RS (ms): Min: 0.0, Avg: 0.0, Max: 0.1, Diff: 0.1, Sum: 0.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineProcessedBuffers() {
         String logLine = "         [Processed Buffers : 2 1 0 0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineProcessedBuffersJdk8() {
         String logLine = "         [Processed Buffers: Min: 0, Avg: 8.0, Max: 39, Diff: 39, Sum: 48]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineScanRs() {
         String logLine = "      [Scan RS (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineObjectCopy() {
         String logLine = "      [Object Copy (ms): Min: 9.0, Avg: 9.4, Max: 9.8, Diff: 0.8, Sum: 56.7]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTermination() {
         String logLine = "      [Termination (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerOther() {
         String logLine = "      [GC Worker Other (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.2]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerTotal() {
         String logLine = "      [GC Worker Total (ms): Min: 12.5, Avg: 12.5, Max: 12.6, Diff: 0.1, Sum: 75.3]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerEnd() {
         String logLine = "      [GC Worker End Time (ms):  810.1  810.2  810.1  810.1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcWorkerEndJdk8() {
         String logLine = "      [GC Worker End (ms): Min: 2204.4, Avg: 2204.4, Max: 2204.4, Diff: 0.0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCodeRootFixup() {
         String logLine = "   [Code Root Fixup: 0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCodeRootPurge() {
         String logLine = "   [Code Root Purge: 0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCodeRootMigration() {
         String logLine = "   [Code Root Migration: 0.8 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCodeRootScanning() {
         String logLine = "      [Code Root Scanning (ms): Min: 0.0, Avg: 0.2, Max: 0.4, Diff: 0.4, Sum: 0.8]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCodeRootMarking() {
         String logLine = "      [Code Root Marking (ms): Min: 0.1, Avg: 1.8, Max: 3.7, Diff: 3.7, Sum: 7.2]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineClearCt() {
         String logLine = "   [Clear CT: 0.1 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineCompleteCsetMarking() {
         String logLine = "   [Complete CSet Marking:   0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineOther() {
         String logLine = "      [Other:   0.9 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineOtherJdk8() {
         String logLine = "   [Other: 8.2 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineChooseCSet() {
         String logLine = "      [Choose CSet: 0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRefProc() {
         String logLine = "      [Ref Proc: 7.9 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRefEnq() {
         String logLine = "      [Ref Enq: 0.1 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineFreeCSet() {
         String logLine = "      [Free CSet: 0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSum() {
         String logLine = "          Sum: 4, Avg: 1, Min: 1, Max: 1]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMarkStackScanning() {
         String logLine = "      [Mark Stack Scanning (ms):  0.0  0.0  0.0  0.0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTerminationAttempts() {
         String logLine = "         [Termination Attempts : 1 1 1 1";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTerminationAttemptsNoSpaceBeforeColon() {
         String logLine = "         [Termination Attempts: Min: 274, Avg: 618.2, Max: 918, Diff: 644, Sum: 11127]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineAvg() {
         String logLine = "       Avg:   1.1, Min:   0.0, Max:   1.5]   0.0, Min:   0.0, Max:   0.0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogEvacuationFailure() {
         String logLine = "      [Evacuation Failure: 2381.8 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRetainMiddleJdk8() {
         String logLine = "   [Eden: 128.0M(128.0M)->0.0B(112.0M) Survivors: 0.0B->16.0M "
                 + "Heap: 128.0M(30.0G)->24.9M(30.0G)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRetainMiddleYoung() {
         String logLine = "   [ 29M->2589K(59M)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRetainMiddleDuration() {
         String logLine = ", 0.0209631 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRetainMiddleDurationWithToSpaceExhaustedTrigger() {
         String logLine = " (to-space exhausted), 0.3857580 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRetainMiddleDurationWithToSpaceOverflowTrigger() {
         String logLine = " (to-space overflow), 0.77121400 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGCLockerInitiatedGC() {
         String logLine = "5.293: [GC pause (GCLocker Initiated GC) (young)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineToSpaceExhausted() {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineFullGC() {
         String logLine = "105.151: [Full GC (System.gc()) 5820M->1381M(30G), 5.5390169 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineYoungInitialMark() {
         String logLine = "2970.268: [GC pause (G1 Evacuation Pause) (young) (initial-mark)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSATBFiltering() {
         String logLine = "      [SATB Filtering (ms): Min: 0.0, Avg: 0.1, Max: 0.4, Diff: 0.4, Sum: 0.4]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogRemark() {
         String logLine = "2971.469: [GC remark 2972.470: [GC ref-proc, 0.1656600 secs], 0.2274544 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogMixed() {
         String logLine = "2973.338: [GC pause (G1 Evacuation Pause) (mixed)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogMixedNoTrigger() {
         String logLine = "3082.652: [GC pause (mixed), 0.0762060 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogCleanup() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
         String nextLogLine = " [Times: user=0.33 sys=0.04, real=0.17 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConcurrent() {
         String logLine = "27744.494: [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConcurrentWithBeginningColon() {
         String logLine = ": 16705.217: [GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineYoungPauseWithToSpaceExhaustedTrigger() {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineYoungPauseDoubleTriggerToSpaceExhausted() {
         String logLine = "6049.175: [GC pause (G1 Evacuation Pause) (young) (to-space exhausted), 3.1713585 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineFullGcNoTrigger() {
         String logLine = "27999.141: [Full GC 18G->4153M(26G), 10.1760410 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMixedYoungPauseWithConcurrentRootRegionScanEnd() {
         String logLine = "4969.943: [GC pause (young)4970.158: [GC concurrent-root-region-scan-end, 0.5703200 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMixedYoungPauseWithConcurrentWithDatestamps() {
         String logLine = "2016-02-09T06:17:15.619-0500: 27744.381: [GC pause (young)"
                 + "2016-02-09T06:17:15.732-0500: 27744.494: [GC concurrent-root-region-scan-end, 0.3550210 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMixedYoungPauseWithConcurrentCleanupEnd() {
         String logLine = "6554.823: [GC pause (young)6554.824: [GC concurrent-cleanup-end, 0.0029080 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -461,8 +402,7 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-11T17:26:43.599-0500:  12042.669: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 250438, predicted base time: 229.38 ms, remaining time: 270.62 ms, target "
                 + "pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -470,8 +410,7 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-11T18:50:24.070-0500 16705.217: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 273946, predicted base time: 242.44 ms, remaining time: 257.56 ms, target "
                 + "pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -479,8 +418,7 @@ public class TestG1PreprocessAction {
         String logLine = "72945.823: [GC pause (young) 72945.823: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 497394, predicted base time: 66.16 ms, remaining time: 433.84 ms, target "
                 + "pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -488,8 +426,7 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-16T01:02:06.283-0500: 16023.627: [GC pause (young)2016-02-16T01:02:06.338-0500:  "
                 + "16023.683: [G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: 36870, predicted "
                 + "base time: 143.96 ms, remaining time: 856.04 ms, target pause time: 1000.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -498,8 +435,7 @@ public class TestG1PreprocessAction {
                 + "2017-03-21T15:05:53.717+1100: 425001.630:  425001.630: [G1Ergonomics (CSet Construction) start "
                 + "choosing CSet, _pending_cards: 3, predicted base time: 45.72 ms, remaining time: 304.28 ms, target "
                 + "pause time: 350.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -510,21 +446,17 @@ public class TestG1PreprocessAction {
                 + "predicted base time: 129.61 ms, remaining time: 70.39 ms, target pause time: 200.00 ms]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2020-02-16T23:24:09.668+0000: 880272.698: [GC pause (G1 Humongous Allocation) (young)",
-                event.getLogEntry());
+        assertEquals("2020-02-16T23:24:09.668+0000: 880272.698: [GC pause (G1 Humongous Allocation) (young)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineYoungInitialMarkWithDatestamp() {
         String logLine = "2017-01-20T23:18:29.561-0500: 1513296.434: [GC pause (young) (initial-mark), "
                 + "0.0225230 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -532,8 +464,7 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-11T15:22:23.213-0500: 4582.283: [GC pause (young) (initial-mark) 4582.283: "
                 + "[G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: 6084, predicted base time: "
                 + "41.16 ms, remaining time: 458.84 ms, target pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -541,8 +472,7 @@ public class TestG1PreprocessAction {
         String logLine = "2017-02-02T01:55:56.661-0500: 860.367: [GC pause (G1 Humongous Allocation) (young) "
                 + "(initial-mark) 860.367: [G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: "
                 + "3305091, predicted base time: 457.90 ms, remaining time: 42.10 ms, target pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -550,59 +480,51 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-11T16:06:59.987-0500: 7259.058: [GC pause (mixed) 7259.058: [G1Ergonomics (CSet "
                 + "Construction) start choosing CSet, _pending_cards: 273214, predicted base time: 74.01 ms, "
                 + "remaining time: 425.99 ms, target pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMixedHumongousAllocationToSpaceExhausted() {
         String logLine = "2017-06-22T12:25:26.515+0530: 66155.261: [GC pause (G1 Humongous Allocation) (mixed) "
                 + "(to-space exhausted), 0.2466797 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConcurrentCleanupEndWithDatestamp() {
         String logLine = "2016-02-11T18:15:35.431-0500: 14974.501: [GC concurrent-cleanup-end, 0.0033880 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSingleConcurrentMarkStartBlock() {
         String logLine = "[GC concurrent-mark-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineGcConcurrentRootRegionScanEndMissingTimestamp() {
         String logLine = "[GC concurrent-root-region-scan-end, 0.6380480 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineBeginningYoungConcurrent() {
         String logLine = "2016-02-16T01:05:36.945-0500: 16233.809: [GC pause (young)2016-02-16T01:05:37.046-0500: "
                 + "16233.910: [GC concurrent-root-region-scan-end, 0.5802520 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTimesBlock() {
         String logLine = " [Times: user=0.33 sys=0.04, real=0.17 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTimesBlockWithSpaceAtEnd() {
         String logLine = " [Times: user=0.33 sys=0.04, real=0.17 secs] ";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -610,320 +532,276 @@ public class TestG1PreprocessAction {
         String logLine = "1.515: [GC cleanup 165M->165M(110G), 0.0028925 secs]";
         String nextLogLine = "2.443: [GC pause (GCLocker Initiated GC) (young) (initial-mark) 1061M->52M(110G), "
                 + "0.0280096 secs]";
-        assertFalse("Log line recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, nextLogLine));
+        assertFalse(G1PreprocessAction.match(logLine, null, nextLogLine), "Log line recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineStringDedupFixup() {
         String logLine = "   [String Dedup Fixup: 1.6 ms, GC Workers: 18]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineStringDedupFixupQueueFixup() {
         String logLine = "      [Queue Fixup (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineStringDedupFixupTableFixup() {
         String logLine = "      [Table Fixup (ms): Min: 0.0, Avg: 0.1, Max: 1.3, Diff: 1.3, Sum: 1.3]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRedirtyCards() {
         String logLine = "      [Redirty Cards: 0.6 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineHumongousRegister() {
         String logLine = "      [Humongous Register: 0.1 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineHumongousReclaim() {
         String logLine = "      [Humongous Reclaim: 0.0 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRemarkWithFinalizeMarkingAndUnloading() {
         String logLine = "5.745: [GC remark 5.746: [Finalize Marking, 0.0068506 secs] 5.752: "
                 + "[GC ref-proc, 0.0014064 secs] 5.754: [Unloading, 0.0057674 secs], 0.0157938 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineLastExec() {
         String logLine = "   [Last Exec: 0.0118158 secs, Idle: 0.9330710 secs, Blocked: 0/0.0000000 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineInspected() {
         String logLine = "      [Inspected:           10116]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSkipped() {
         String logLine = "         [Skipped:              0(  0.0%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineHashed() {
         String logLine = "         [Hashed:            3088( 30.5%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineKnown() {
         String logLine = "         [Known:             3404( 33.6%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineNew() {
         String logLine = "         [New:               6712( 66.4%)    526.1K]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineDuplicated() {
         String logLine = "      [Deduplicated:         3304( 49.2%)    197.2K( 37.5%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineYoung() {
         String logLine = "         [Young:             3101( 93.9%)    173.8K( 88.1%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineOld() {
         String logLine = "         [Old:                203(  6.1%)     23.4K( 11.9%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTotalExec() {
         String logLine = "   [Total Exec: 2/0.0281081 secs, Idle: 2/9.1631547 secs, Blocked: 2/0.0266213 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineTable() {
         String logLine = "   [Table]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMemoryUsage() {
         String logLine = "      [Memory Usage: 745.2K]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSize() {
         String logLine = "      [Size: 16384, Min: 1024, Max: 16777216]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineEntries() {
         String logLine = "      [Entries: 26334, Load: 160.7%, Cached: 0, Added: 26334, Removed: 0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineResizeCount() {
         String logLine = "      [Resize Count: 4, Shrink Threshold: 10922(66.7%), Grow Threshold: 32768(200.0%)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineRehashCount() {
         String logLine = "      [Rehash Count: 0, Rehash Threshold: 120, Hash Seed: 0x0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineAgeThreshold() {
         String logLine = "      [Age Threshold: 3]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineQueue() {
         String logLine = "   [Queue]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineDropped() {
         String logLine = "      [Dropped: 0]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSpaceDetailsWithPerm() {
         String logLine = "   [Eden: 143.0M(1624.0M)->0.0B(1843.0M) Survivors: 219.0M->0.0B "
                 + "Heap: 999.5M(3072.0M)->691.1M(3072.0M)], [Perm: 175031K->175031K(175104K)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSpaceNoDetailsWithoutPerm() {
         String logLine = "   [Eden: 4096M(4096M)->0B(3528M) Survivors: 0B->568M Heap: 4096M(16384M)->567M(16384M)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullCombinedConcurrentRootRegionScanStart() {
         String logLine = "88.123: [Full GC (Metadata GC Threshold) 88.123: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineFullCombinedConcurrentRootRegionScanEndWithDuration() {
         String logLine = "93.315: [Full GC (Metadata GC Threshold) 93.315: "
                 + "[GC concurrent-root-region-scan-end, 0.0003872 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineEndOfFullCollection() {
         String logLine = " 1831M->1213M(5120M), 5.1353878 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineSpaceDetailsWithMetaspace() {
         String logLine = "   [Eden: 0.0B(1522.0M)->0.0B(2758.0M) Survivors: 244.0M->0.0B "
                 + "Heap: 1831.0M(5120.0M)->1213.5M(5120.0M)], [Metaspace: 396834K->324903K(1511424K)]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungInitialMarkTriggerMetaGcThreshold() {
         String logLine = "87.830: [GC pause (Metadata GC Threshold) (young) (initial-mark), 0.2932700 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineMiddleG1FullWithSizeInformation() {
         String logLine = " 1831M->1213M(5120M), 5.1353878 secs]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         G1PreprocessAction action = new G1PreprocessAction(null, logLine, null, null, context);
         String preprocessedLine = "1831M->1213M(5120M), 5.1353878 secs]";
-        assertEquals("Preprocessing failed.", preprocessedLine, action.getLogEntry());
+        assertEquals(preprocessedLine,action.getLogEntry(),"Preprocessing failed.");
     }
 
     @Test
     public void testLogLineG1FullTriggerLastDitchCollection2SpacesAfterTrigger() {
         String logLine = "98.150: [Full GC (Last ditch collection)  1196M->1118M(5120M), 4.4628626 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullTriggerJvmTiForcedGarbageCollection() {
         String logLine = "102.621: [Full GC (JvmtiEnv ForceGarbageCollection)  1124M->1118M(5120M), 3.8954775 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEnd() {
         String logLine = "290.944: [Full GC (Metadata GC Threshold) 290.944: "
                 + "[GC concurrent-root-region-scan-end, 0.0003793 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEndPrependedColon() {
         String logLine = ": 7688.541: [Full GC (Metadata GC Threshold) 2016-10-12T11:56:49.416+0200: "
                 + "7688.541: [GC concurrent-root-region-scan-end, 0.0003847 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullCombinedConcurrentRootRegionScanStartMissingTimestamp() {
         String logLine = "298.027: [Full GC (Metadata GC Threshold) [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullTriggerMetaDataGcThreshold() {
         String logLine = "4708.816: [Full GC (Metadata GC Threshold)  801M->801M(5120M), 3.5048336 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungInitialMarkTriggerGcLockerInitiatedGc() {
         String logLine = "6896.482: [GC pause (GCLocker Initiated GC) (young) (initial-mark), 0.0525160 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungConcurrentTriggerG1HumongousAllocation() {
         String logLine = "2017-06-22T13:55:45.753+0530: 71574.499: [GC pause (G1 Humongous Allocation) (young)"
                 + "2017-06-22T13:55:45.771+0530: 71574.517: [GC concurrent-root-region-scan-end, 0.0181265 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1ConcurrentWithDatestamp() {
         String logLine = "2016-02-09T06:17:15.377-0500: 27744.139: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -932,12 +810,10 @@ public class TestG1PreprocessAction {
         String logLine = "49689.217: [Full GC49689.217: [Class Histogram (before full gc):";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "49689.217: [Full GC49689.217: [Class Histogram (before full gc):", event.getLogEntry());
+        assertEquals("49689.217: [Full GC49689.217: [Class Histogram (before full gc):",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -946,12 +822,10 @@ public class TestG1PreprocessAction {
         String logLine = "49709.036: [Class Histogram (after full gc): ";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "49709.036: [Class Histogram (after full gc):",
-                event.getLogEntry());
+        assertEquals("49709.036: [Class Histogram (after full gc):",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -960,11 +834,10 @@ public class TestG1PreprocessAction {
         String logLine = "785,047: [GC pause (young), 0,73936800 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -974,12 +847,10 @@ public class TestG1PreprocessAction {
                 + "188935.321: [GC concurrent-mark-end, 0.4777427 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "188935.313: [GC pause (G1 Evacuation Pause) (young)",
-                event.getLogEntry());
+        assertEquals("188935.313: [GC pause (G1 Evacuation Pause) (young)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -989,12 +860,10 @@ public class TestG1PreprocessAction {
                 + "537.123: [GC concurrent-root-region-scan-start]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "537.122: [GC pause (G1 Evacuation Pause) (young)",
-                event.getLogEntry());
+        assertEquals("537.122: [GC pause (G1 Evacuation Pause) (young)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1005,16 +874,13 @@ public class TestG1PreprocessAction {
                 + "3038.7M(3072.0M)->3038.7M(3072.0M)] [Times: user=0.20 sys=0.00, real=0.33 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                " (to-space exhausted), 0.3314995 secs][Eden: 0.0B(151.0M)->0.0B(153.0M) "
-                        + "Survivors: 2048.0K->0.0B Heap: 3038.7M(3072.0M)->3038.7M(3072.0M)] "
-                        + "[Times: user=0.20 sys=0.00, real=0.33 secs]" + Constants.LINE_SEPARATOR
-                        + "537.142: [GC concurrent-root-region-scan-end, 0.0189841 secs]",
-                event.getLogEntry());
+        assertEquals(" (to-space exhausted), 0.3314995 secs][Eden: 0.0B(151.0M)->0.0B(153.0M) "
+		+ "Survivors: 2048.0K->0.0B Heap: 3038.7M(3072.0M)->3038.7M(3072.0M)] "
+		+ "[Times: user=0.20 sys=0.00, real=0.33 secs]" + Constants.LINE_SEPARATOR
+		+ "537.142: [GC concurrent-root-region-scan-end, 0.0189841 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1025,15 +891,12 @@ public class TestG1PreprocessAction {
                 + "[Times: user=0.09 sys=0.00, real=0.11 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, priorLogLine, nextLogLine));
+        assertTrue(G1PreprocessAction.match(logLine, priorLogLine, nextLogLine), "Log line not recognized as " + PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                ", 0.1083307 secs]" + "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B "
-                        + "Heap: 3035.6M(3072.0M)->3035.6M(3072.0M)] [Times: user=0.09 sys=0.00, real=0.11 secs]"
-                        + Constants.LINE_SEPARATOR + "2132.962: [GC concurrent-root-region-scan-end, 0.0001111 secs]",
-                event.getLogEntry());
+        assertEquals(", 0.1083307 secs]" + "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B "
+		+ "Heap: 3035.6M(3072.0M)->3035.6M(3072.0M)] [Times: user=0.09 sys=0.00, real=0.11 secs]"
+		+ Constants.LINE_SEPARATOR + "2132.962: [GC concurrent-root-region-scan-end, 0.0001111 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1041,16 +904,14 @@ public class TestG1PreprocessAction {
         String logLine = "2016-02-12T00:05:06.348-0500: 35945.418:  35945.418: [G1Ergonomics (CSet Construction) "
                 + "start choosing CSet, _pending_cards: 279876, predicted base time: 236.99 ms, remaining time: "
                 + "263.01 ms, target pause time: 500.00 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineErgonomicsDoubleTimestamp() {
         String logLine = "16023.683:  16023.683: [G1Ergonomics (CSet Construction) add young regions to CSet, "
                 + "eden: 76 regions, survivors: 7 regions, predicted young region time: 123.54 ms]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -1058,48 +919,42 @@ public class TestG1PreprocessAction {
         String logLine = "2016-03-14T16:06:13.991-0700: 5.745: [GC remark 2016-03-14T16:06:13.991-0700: 5.746: "
                 + "[Finalize Marking, 0.0068506 secs] 2016-03-14T16:06:13.998-0700: 5.752: [GC ref-proc, "
                 + "0.0014064 secs] 2016-03-14T16:06:14.000-0700: 5.754: [Unloading, 0.0057674 secs], 0.0157938 secs]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullDoubleDatestamps() {
         String logLine = "2016-10-12T09:53:38.901+0200: 2016-10-12T09:53:38.901+0200: 298.027: 298.027: "
                 + "[Full GC (Metadata GC Threshold) [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConsurrentDatestampTimestampDatestamp() {
         String logLine = "2016-10-12T11:56:49.415+0200: 7688.541: 2016-10-12T11:56:49.415+0200"
                 + "[GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConsurrentDatestampDatestampTimestampTimestamp() {
         String logLine = "2016-10-12T11:37:28.396+0200: 2016-10-12T11:37:28.396+0200: 6527.522: "
                 + "6527.522: [GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineConsurrentDatestampDatestampTimestampTimestampNoColonNoSpace() {
         String logLine = "2016-10-12T11:39:07.893+0200: 2016-10-12T11:39:07.893+0200: "
                 + "6627.019: 6627.019[GC concurrent-root-region-scan-start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1FullDatestamp() {
         String logLine = "2016-10-31T14:09:15.030-0700: 49689.217: [Full GC"
                 + "2016-10-31T14:09:15.030-0700: 49689.217: [Class Histogram (before full gc):";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
@@ -1108,12 +963,10 @@ public class TestG1PreprocessAction {
                 + "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-root-region-scan-end, 0.0127300 secs]";
         String nextLogLine = "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-02-27T02:55:32.523+0300: 35911.404: [Full GC (Allocation Failure)", event.getLogEntry());
+        assertEquals("2017-02-27T02:55:32.523+0300: 35911.404: [Full GC (Allocation Failure)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1123,12 +976,10 @@ public class TestG1PreprocessAction {
         String nextLogLine = "2017-06-22T16:03:36.126+0530: 79244.872: [GC concurrent-root-region-scan-end, "
                 + "0.0002076 secs]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-06-22T16:03:36.126+0530: 79244.872: [Full GC (Metadata GC Threshold) ", event.getLogEntry());
+        assertEquals("2017-06-22T16:03:36.126+0530: 79244.872: [Full GC (Metadata GC Threshold) ",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1138,12 +989,10 @@ public class TestG1PreprocessAction {
         String nextLogLine = "2017-06-22T16:35:58.033+0530: 81186.778: [GC concurrent-root-region-scan-end, "
                 + "0.0008790 secs]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-06-22T16:35:58.032+0530: 81186.777: [Full GC (Metadata GC Threshold) ", event.getLogEntry());
+        assertEquals("2017-06-22T16:35:58.032+0530: 81186.777: [Full GC (Metadata GC Threshold) ",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1155,16 +1004,13 @@ public class TestG1PreprocessAction {
         String nextLogLine = "2132.960: [GC pause (G1 Evacuation Pause) (young)2132.962: "
                 + "[GC concurrent-root-region-scan-start]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "35420.674: [Full GC (Allocation Failure) 3035M->3030M(3072M), 21.7552521 secs]"
-                        + "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B"
-                        + " Heap: 3035.5M(3072.0M)->3030.4M(3072.0M)], [Metaspace: 93308K->93308K(352256K)] "
-                        + "[Times: user=16.39 sys=0.04, real=21.75 secs]",
-                event.getLogEntry());
+        assertEquals("35420.674: [Full GC (Allocation Failure) 3035M->3030M(3072M), 21.7552521 secs]"
+		+ "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B"
+		+ " Heap: 3035.5M(3072.0M)->3030.4M(3072.0M)], [Metaspace: 93308K->93308K(352256K)] "
+		+ "[Times: user=16.39 sys=0.04, real=21.75 secs]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1172,12 +1018,10 @@ public class TestG1PreprocessAction {
         String logLine = "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]", event.getLogEntry());
+        assertEquals("2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1186,12 +1030,10 @@ public class TestG1PreprocessAction {
                 + "2018-12-06T21:56:32.691-0500: : 18.973[GC concurrent-root-region-scan-start]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2018-12-06T21:56:32.691-0500: 18.973: [GC concurrent-root-region-scan-start]", event.getLogEntry());
+        assertEquals("2018-12-06T21:56:32.691-0500: 18.973: [GC concurrent-root-region-scan-start]",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1199,11 +1041,10 @@ public class TestG1PreprocessAction {
         String logLine = " (initial-mark), 0.12895600 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1212,13 +1053,10 @@ public class TestG1PreprocessAction {
                 + "2017-06-01T03:09:18.081-0400: 3978.888: [GC concurrent-root-region-scan-end, 0.0059070 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-06-01T03:09:18.078-0400: 3978.886: [GC pause (GCLocker Initiated GC) (young)",
-                event.getLogEntry());
+        assertEquals("2017-06-01T03:09:18.078-0400: 3978.886: [GC pause (GCLocker Initiated GC) (young)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1226,12 +1064,10 @@ public class TestG1PreprocessAction {
         String logLine = "0.449: [GC pause (G1 Evacuation Pause) (young)Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "0.449: [GC pause (G1 Evacuation Pause) (young)",
-                event.getLogEntry());
+        assertEquals("0.449: [GC pause (G1 Evacuation Pause) (young)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1239,12 +1075,10 @@ public class TestG1PreprocessAction {
         String logLine = "1.738: [GC pause (Metadata GC Threshold) (young) (initial-mark)Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "1.738: [GC pause (Metadata GC Threshold) (young) (initial-mark)", event.getLogEntry());
+        assertEquals("1.738: [GC pause (Metadata GC Threshold) (young) (initial-mark)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1252,11 +1086,10 @@ public class TestG1PreprocessAction {
         String logLine = "73.164: [Full GC (System.gc()) Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "73.164: [Full GC (System.gc())", event.getLogEntry());
+        assertEquals("73.164: [Full GC (System.gc())",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1264,11 +1097,10 @@ public class TestG1PreprocessAction {
         String logLine = " 390M->119M(512M)After GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.", "390M->119M(512M)", event.getLogEntry());
+        assertEquals("390M->119M(512M)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -1277,302 +1109,258 @@ public class TestG1PreprocessAction {
                 + "Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         G1PreprocessAction event = new G1PreprocessAction(null, logLine, nextLogLine, entangledLogLines, context);
-        assertEquals("Log line not parsed correctly.",
-                "2017-06-28T18:24:40.453-0400: 12289.351: [GC pause (G1 Evacuation Pause) (mixed)",
-                event.getLogEntry());
+        assertEquals("2017-06-28T18:24:40.453-0400: 12289.351: [GC pause (G1 Evacuation Pause) (mixed)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRecentRefinementStats() {
         String logLine = " Recent concurrent refinement statistics";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsProcessedCards() {
         String logLine = "  Processed 0 cards";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCompletedBuffersHeading() {
         String logLine = "  Of 2736 completed buffers:";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCompletedBuffersHeadingDigits3() {
         String logLine = "  Of 170 completed buffers:";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRsThreads() {
         String logLine = "         2736 ( 94.3%) by concurrent RS threads.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRsThreadsPercent100() {
         String logLine = "          170 (100.0%) by concurrent RS threads.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsMutatorThreads() {
         String logLine = "            0 (  0.0%) by mutator threads.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCoarsenings() {
         String logLine = "  Did 0 coarsenings.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCoarseningsDigits3() {
         String logLine = "  Did 239 coarsenings.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRsThreadTimesHeading() {
         String logLine = "  Concurrent RS threads times (s)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRsThreadTimesOutput() {
         String logLine = "          0.00     0.00     0.00     0.00     0.00     0.00     0.00     0.00";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesHeading() {
         String logLine = "  Concurrent sampling threads times (s)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutput() {
         String logLine = "          0.00";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutputDigits2() {
         String logLine = "         13.33";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetHeading() {
         String logLine = " Current rem set statistics";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetTotalKMaxB() {
         String logLine = "  Total per region rem sets sizes = 1513K. Max = 6336B.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetTotalMMaxK() {
         String logLine = "  Total per region rem sets sizes = 38M. Max = 25K.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetTotalKMaxK() {
         String logLine = "  Total per region rem sets sizes = 1606K. Max = 14K.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetYoung() {
         String logLine = "          78K (  5.2%) by 25 Young regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetHumongous() {
         String logLine = "           0B (  0.0%) by 0 Humonguous regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetFree() {
         String logLine = "        1434K ( 94.8%) by 487 Free regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetFreeMDigits4() {
         String logLine = "          36M ( 94.9%) by 3709 Free regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRSetOld() {
         String logLine = "           0B (  0.0%) by 0 Old regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsStaticStructures() {
         String logLine = "   Static structures = 64K, free_lists = 0B.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCards() {
         String logLine = "    0 occupied cards represented.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsDigits9() {
         String logLine = "    122457800 occupied cards represented.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsYoung() {
         String logLine = "            0 (  0.0%) entries by 25 Young regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsHumongous() {
         String logLine = "            0 (  0.0%) entries by 0 Humonguous regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsFree() {
         String logLine = "            0 (  0.0%) entries by 487 Free regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsOld() {
         String logLine = "            0 (  0.0%) entries by 0 Old regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsOccupiedCardsOldDigits9() {
         String logLine = "     122327000 (100.0%) entries by 1171 Old regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRegionLargestRset() {
         String logLine = "    Region with largest rem set = 511:(E)[0x00000000dff00000,0x00000000e0000000,"
                 + "0x00000000e0000000], size = 6336B, occupied = 0B.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsHeapTotal() {
         String logLine = "  Total heap region code root sets sizes = 13K.  Max = 3336B.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRoots() {
         String logLine = "    205 code roots represented.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRootsDigits5() {
         String logLine = "    12153 code roots represented.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRootsYoung() {
         String logLine = "            7 (  2.8%) elements by 4 Young regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRootsHumongous() {
         String logLine = "            0 (  0.0%) elements by 0 Humonguous regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRootsFree() {
         String logLine = "            0 (  0.0%) elements by 493 Free regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsCodeRootsOld() {
         String logLine = "          242 ( 97.2%) elements by 15 Old regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsRegionLargestCodeRoots() {
         String logLine = "    Region with largest amount of code roots = 511:(E)[0x00000000dff00000,"
                 + "0x00000000e0000000,0x00000000e0000000], size = 3336B, num_elems = 136.";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SummarizeRSetStatsAfterRsSummaryHeading() {
         String logLine = "After GC RS summary";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".",
-                G1PreprocessAction.match(logLine, null, null));
+        assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     /**
@@ -1586,10 +1374,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertEquals("Inverted parallelism event count not correct.", 0, jvmRun.getInvertedParallelismCount());
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertEquals((long) 0,jvmRun.getInvertedParallelismCount(),"Inverted parallelism event count not correct.");
     }
 
     /**
@@ -1603,9 +1390,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     /**
@@ -1619,12 +1405,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertEquals("Inverted parallelism event count not correct.", 1, jvmRun.getInvertedParallelismCount());
-        assertTrue(Analysis.WARN_PARALLELISM_INVERTED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PARALLELISM_INVERTED));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertEquals((long) 1,jvmRun.getInvertedParallelismCount(),"Inverted parallelism event count not correct.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PARALLELISM_INVERTED), Analysis.WARN_PARALLELISM_INVERTED + " analysis not identified.");
     }
 
     /**
@@ -1638,13 +1422,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1));
-        assertFalse(Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_G1), Analysis.ERROR_EXPLICIT_GC_SERIAL_G1 + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.");
     }
 
     /**
@@ -1658,9 +1439,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     /**
@@ -1674,9 +1454,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     /**
@@ -1690,9 +1469,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_REMARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_REMARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
     }
 
     /**
@@ -1706,9 +1484,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_MIXED_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_MIXED_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
     }
 
     /**
@@ -1722,9 +1499,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CLEANUP));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CLEANUP), "Log line not recognized as " + JdkUtil.LogEventType.G1_CLEANUP.toString() + ".");
     }
 
     /**
@@ -1738,11 +1514,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     /**
@@ -1756,11 +1530,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1774,9 +1546,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_MIXED_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_MIXED_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_MIXED_PAUSE.toString() + ".");
     }
 
     /**
@@ -1790,11 +1561,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     /**
@@ -1808,11 +1577,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1826,9 +1593,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
     }
 
     /**
@@ -1842,11 +1608,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1860,11 +1624,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1878,11 +1640,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1896,11 +1656,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     /**
@@ -1914,11 +1672,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1932,11 +1688,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -1950,15 +1704,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK), JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 
     /**
@@ -1972,13 +1722,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.G1_CLEANUP.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CLEANUP));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK));
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CLEANUP), JdkUtil.LogEventType.G1_CLEANUP.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK), JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.");
     }
 
     /**
@@ -1992,9 +1739,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_REMARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_REMARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_REMARK.toString() + ".");
     }
 
     /**
@@ -2008,9 +1754,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2024,13 +1769,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED));
-        assertFalse(Analysis.WARN_PRINT_GC_CAUSE_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_MISSING));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED), Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_MISSING), Analysis.WARN_PRINT_GC_CAUSE_MISSING + " analysis incorrectly identified.");
     }
 
     /**
@@ -2044,13 +1786,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue(JdkUtil.TriggerType.LAST_DITCH_COLLECTION.toString() + " trigger not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_METASPACE_ALLOCATION_FAILURE));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_METASPACE_ALLOCATION_FAILURE), JdkUtil.TriggerType.LAST_DITCH_COLLECTION.toString() + " trigger not identified.");
     }
 
     /**
@@ -2064,15 +1803,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue(JdkUtil.TriggerType.JVMTI_FORCED_GARBAGE_COLLECTION.toString() + " trigger not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_JVMTI));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_JVMTI), JdkUtil.TriggerType.JVMTI_FORCED_GARBAGE_COLLECTION.toString() + " trigger not identified.");
     }
 
     /**
@@ -2086,15 +1821,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2108,15 +1839,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2130,15 +1857,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2152,15 +1875,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2174,15 +1893,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
     }
 
     /**
@@ -2196,18 +1911,13 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CLASS_HISTOGRAM));
-        assertTrue(Analysis.WARN_CLASS_HISTOGRAM + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CLASS_HISTOGRAM));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CLASS_HISTOGRAM), "Log line not recognized as " + JdkUtil.LogEventType.CLASS_HISTOGRAM.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CLASS_HISTOGRAM), Analysis.WARN_CLASS_HISTOGRAM + " analysis not identified.");
         // G1_FULL is caused by CLASS_HISTOGRAM
-        assertFalse(Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis incorrectly identified.");
     }
 
     /**
@@ -2221,11 +1931,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
     }
 
     /**
@@ -2239,13 +1947,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_YOUNG_PAUSE), "Log line not recognized as " + JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_EVACUATION_FAILURE), Analysis.ERROR_G1_EVACUATION_FAILURE + " analysis not identified.");
     }
 
     @Test
@@ -2255,17 +1960,12 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 3, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME));
-        assertTrue(Analysis.ERROR_SERIAL_GC_G1 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertEquals(3,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_FULL_GC), "Log line not recognized as " + JdkUtil.LogEventType.G1_FULL_GC.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.G1_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.G1_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.APPLICATION_STOPPED_TIME), "Log line not recognized as " + JdkUtil.LogEventType.APPLICATION_STOPPED_TIME.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis not identified.");
     }
 
     @Test
@@ -2275,9 +1975,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_INITIAL_MARK), JdkUtil.LogEventType.G1_YOUNG_INITIAL_MARK.toString() + " collector not identified.");
     }
 
     @Test
@@ -2287,15 +1986,11 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC));
-        assertTrue(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_G1 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC), JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_G1), Analysis.ERROR_SERIAL_GC_G1 + " analysis not identified.");
     }
 
     @Test
@@ -2305,13 +2000,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 4, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT));
+        assertEquals(4,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT), Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT + " analysis not identified.");
     }
 
     @Test
@@ -2321,11 +2013,9 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 
     @Test
@@ -2335,13 +2025,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
-        assertTrue(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.");
     }
 
     @Test
@@ -2351,13 +2038,10 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC));
-        assertTrue(JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_FULL_GC), JdkUtil.LogEventType.G1_FULL_GC.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_CONCURRENT), JdkUtil.LogEventType.G1_CONCURRENT.toString() + " collector not identified.");
     }
 
     @Test
@@ -2367,10 +2051,8 @@ public class TestG1PreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE), JdkUtil.LogEventType.G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestG1PreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestG1PreprocessAction.java
@@ -37,368 +37,368 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestG1PreprocessAction {
+class TestG1PreprocessAction {
 
     @Test
-    public void testLogLineG1EvacuationPause() {
+    void testLogLineG1EvacuationPause() {
         String logLine = "2.192: [GC pause (G1 Evacuation Pause) (young)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRootRegionScanWaiting() {
+    void testLogLineRootRegionScanWaiting() {
         String logLine = "   [Root Region Scan Waiting: 112.3 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelTime() {
+    void testLogLineParallelTime() {
         String logLine = "   [Parallel Time: 12.6 ms, GC Workers: 6]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorker() {
+    void testLogLineGcWorker() {
         String logLine = "      [GC Worker (ms):  387,2  387,4  386,2  385,9  386,1  386,2  386,9  386,4  386,4  "
                 + "386,8  386,1  385,2  386,1";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerStart() {
+    void testLogLineGcWorkerStart() {
         String logLine = "      [GC Worker Start Time (ms):  807.5  807.8  807.8  810.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerStartJdk8() {
+    void testLogLineGcWorkerStartJdk8() {
         String logLine = "      [GC Worker Start (ms): Min: 2191.9, Avg: 2191.9, Max: 2191.9, Diff: 0.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerStartWithCommas() {
+    void testLogLineGcWorkerStartWithCommas() {
         String logLine = "      [GC Worker Start (ms): Min: 6349,9, Avg: 6353,8, Max: 6355,9, Diff: 6,0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineExtRootScanning() {
+    void testLogLineExtRootScanning() {
         String logLine = "      [Ext Root Scanning (ms): Min: 2.7, Avg: 3.0, Max: 3.5, Diff: 0.8, Sum: 18.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineUpdateRs() {
+    void testLogLineUpdateRs() {
         String logLine = "      [Update RS (ms): Min: 0.0, Avg: 0.0, Max: 0.1, Diff: 0.1, Sum: 0.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineProcessedBuffers() {
+    void testLogLineProcessedBuffers() {
         String logLine = "         [Processed Buffers : 2 1 0 0";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineProcessedBuffersJdk8() {
+    void testLogLineProcessedBuffersJdk8() {
         String logLine = "         [Processed Buffers: Min: 0, Avg: 8.0, Max: 39, Diff: 39, Sum: 48]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineScanRs() {
+    void testLogLineScanRs() {
         String logLine = "      [Scan RS (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineObjectCopy() {
+    void testLogLineObjectCopy() {
         String logLine = "      [Object Copy (ms): Min: 9.0, Avg: 9.4, Max: 9.8, Diff: 0.8, Sum: 56.7]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTermination() {
+    void testLogLineTermination() {
         String logLine = "      [Termination (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerOther() {
+    void testLogLineGcWorkerOther() {
         String logLine = "      [GC Worker Other (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.2]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerTotal() {
+    void testLogLineGcWorkerTotal() {
         String logLine = "      [GC Worker Total (ms): Min: 12.5, Avg: 12.5, Max: 12.6, Diff: 0.1, Sum: 75.3]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerEnd() {
+    void testLogLineGcWorkerEnd() {
         String logLine = "      [GC Worker End Time (ms):  810.1  810.2  810.1  810.1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcWorkerEndJdk8() {
+    void testLogLineGcWorkerEndJdk8() {
         String logLine = "      [GC Worker End (ms): Min: 2204.4, Avg: 2204.4, Max: 2204.4, Diff: 0.0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCodeRootFixup() {
+    void testLogLineCodeRootFixup() {
         String logLine = "   [Code Root Fixup: 0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCodeRootPurge() {
+    void testLogLineCodeRootPurge() {
         String logLine = "   [Code Root Purge: 0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCodeRootMigration() {
+    void testLogLineCodeRootMigration() {
         String logLine = "   [Code Root Migration: 0.8 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCodeRootScanning() {
+    void testLogLineCodeRootScanning() {
         String logLine = "      [Code Root Scanning (ms): Min: 0.0, Avg: 0.2, Max: 0.4, Diff: 0.4, Sum: 0.8]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCodeRootMarking() {
+    void testLogLineCodeRootMarking() {
         String logLine = "      [Code Root Marking (ms): Min: 0.1, Avg: 1.8, Max: 3.7, Diff: 3.7, Sum: 7.2]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineClearCt() {
+    void testLogLineClearCt() {
         String logLine = "   [Clear CT: 0.1 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineCompleteCsetMarking() {
+    void testLogLineCompleteCsetMarking() {
         String logLine = "   [Complete CSet Marking:   0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineOther() {
+    void testLogLineOther() {
         String logLine = "      [Other:   0.9 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineOtherJdk8() {
+    void testLogLineOtherJdk8() {
         String logLine = "   [Other: 8.2 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineChooseCSet() {
+    void testLogLineChooseCSet() {
         String logLine = "      [Choose CSet: 0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRefProc() {
+    void testLogLineRefProc() {
         String logLine = "      [Ref Proc: 7.9 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRefEnq() {
+    void testLogLineRefEnq() {
         String logLine = "      [Ref Enq: 0.1 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFreeCSet() {
+    void testLogLineFreeCSet() {
         String logLine = "      [Free CSet: 0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSum() {
+    void testLogLineSum() {
         String logLine = "          Sum: 4, Avg: 1, Min: 1, Max: 1]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMarkStackScanning() {
+    void testLogLineMarkStackScanning() {
         String logLine = "      [Mark Stack Scanning (ms):  0.0  0.0  0.0  0.0";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTerminationAttempts() {
+    void testLogLineTerminationAttempts() {
         String logLine = "         [Termination Attempts : 1 1 1 1";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTerminationAttemptsNoSpaceBeforeColon() {
+    void testLogLineTerminationAttemptsNoSpaceBeforeColon() {
         String logLine = "         [Termination Attempts: Min: 274, Avg: 618.2, Max: 918, Diff: 644, Sum: 11127]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineAvg() {
+    void testLogLineAvg() {
         String logLine = "       Avg:   1.1, Min:   0.0, Max:   1.5]   0.0, Min:   0.0, Max:   0.0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogEvacuationFailure() {
+    void testLogEvacuationFailure() {
         String logLine = "      [Evacuation Failure: 2381.8 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRetainMiddleJdk8() {
+    void testLogLineRetainMiddleJdk8() {
         String logLine = "   [Eden: 128.0M(128.0M)->0.0B(112.0M) Survivors: 0.0B->16.0M "
                 + "Heap: 128.0M(30.0G)->24.9M(30.0G)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRetainMiddleYoung() {
+    void testLogLineRetainMiddleYoung() {
         String logLine = "   [ 29M->2589K(59M)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRetainMiddleDuration() {
+    void testLogLineRetainMiddleDuration() {
         String logLine = ", 0.0209631 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRetainMiddleDurationWithToSpaceExhaustedTrigger() {
+    void testLogLineRetainMiddleDurationWithToSpaceExhaustedTrigger() {
         String logLine = " (to-space exhausted), 0.3857580 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRetainMiddleDurationWithToSpaceOverflowTrigger() {
+    void testLogLineRetainMiddleDurationWithToSpaceOverflowTrigger() {
         String logLine = " (to-space overflow), 0.77121400 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGCLockerInitiatedGC() {
+    void testLogLineGCLockerInitiatedGC() {
         String logLine = "5.293: [GC pause (GCLocker Initiated GC) (young)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineToSpaceExhausted() {
+    void testLogLineToSpaceExhausted() {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFullGC() {
+    void testLogLineFullGC() {
         String logLine = "105.151: [Full GC (System.gc()) 5820M->1381M(30G), 5.5390169 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineYoungInitialMark() {
+    void testLogLineYoungInitialMark() {
         String logLine = "2970.268: [GC pause (G1 Evacuation Pause) (young) (initial-mark)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSATBFiltering() {
+    void testLogLineSATBFiltering() {
         String logLine = "      [SATB Filtering (ms): Min: 0.0, Avg: 0.1, Max: 0.4, Diff: 0.4, Sum: 0.4]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogRemark() {
+    void testLogRemark() {
         String logLine = "2971.469: [GC remark 2972.470: [GC ref-proc, 0.1656600 secs], 0.2274544 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogMixed() {
+    void testLogMixed() {
         String logLine = "2973.338: [GC pause (G1 Evacuation Pause) (mixed)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogMixedNoTrigger() {
+    void testLogMixedNoTrigger() {
         String logLine = "3082.652: [GC pause (mixed), 0.0762060 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogCleanup() {
+    void testLogCleanup() {
         String logLine = "2972.698: [GC cleanup 13G->12G(30G), 0.0358748 secs]";
         String nextLogLine = " [Times: user=0.33 sys=0.04, real=0.17 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, nextLogLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConcurrent() {
+    void testLogLineConcurrent() {
         String logLine = "27744.494: [GC concurrent-mark-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConcurrentWithBeginningColon() {
+    void testLogLineConcurrentWithBeginningColon() {
         String logLine = ": 16705.217: [GC concurrent-mark-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineYoungPauseWithToSpaceExhaustedTrigger() {
+    void testLogLineYoungPauseWithToSpaceExhaustedTrigger() {
         String logLine = "27997.968: [GC pause (young) (to-space exhausted), 0.1208740 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineYoungPauseDoubleTriggerToSpaceExhausted() {
+    void testLogLineYoungPauseDoubleTriggerToSpaceExhausted() {
         String logLine = "6049.175: [GC pause (G1 Evacuation Pause) (young) (to-space exhausted), 3.1713585 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFullGcNoTrigger() {
+    void testLogLineFullGcNoTrigger() {
         String logLine = "27999.141: [Full GC 18G->4153M(26G), 10.1760410 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMixedYoungPauseWithConcurrentRootRegionScanEnd() {
+    void testLogLineMixedYoungPauseWithConcurrentRootRegionScanEnd() {
         String logLine = "4969.943: [GC pause (young)4970.158: [GC concurrent-root-region-scan-end, 0.5703200 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMixedYoungPauseWithConcurrentWithDatestamps() {
+    void testLogLineMixedYoungPauseWithConcurrentWithDatestamps() {
         String logLine = "2016-02-09T06:17:15.619-0500: 27744.381: [GC pause (young)"
                 + "2016-02-09T06:17:15.732-0500: 27744.494: [GC concurrent-root-region-scan-end, 0.3550210 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMixedYoungPauseWithConcurrentCleanupEnd() {
+    void testLogLineMixedYoungPauseWithConcurrentCleanupEnd() {
         String logLine = "6554.823: [GC pause (young)6554.824: [GC concurrent-cleanup-end, 0.0029080 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1ErgonomicsWithDatestamp() {
+    void testLogLineG1ErgonomicsWithDatestamp() {
         String logLine = "2016-02-11T17:26:43.599-0500:  12042.669: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 250438, predicted base time: 229.38 ms, remaining time: 270.62 ms, target "
                 + "pause time: 500.00 ms]";
@@ -406,7 +406,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1ErgonomicsWithDatestampNoSemiColon() {
+    void testLogLineG1ErgonomicsWithDatestampNoSemiColon() {
         String logLine = "2016-02-11T18:50:24.070-0500 16705.217: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 273946, predicted base time: 242.44 ms, remaining time: 257.56 ms, target "
                 + "pause time: 500.00 ms]";
@@ -414,7 +414,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseWithG1Ergonomics() {
+    void testLogLineYoungPauseWithG1Ergonomics() {
         String logLine = "72945.823: [GC pause (young) 72945.823: [G1Ergonomics (CSet Construction) start choosing "
                 + "CSet, _pending_cards: 497394, predicted base time: 66.16 ms, remaining time: 433.84 ms, target "
                 + "pause time: 500.00 ms]";
@@ -422,7 +422,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseWithG1ErgonomicsAndDateStamps() {
+    void testLogLineYoungPauseWithG1ErgonomicsAndDateStamps() {
         String logLine = "2016-02-16T01:02:06.283-0500: 16023.627: [GC pause (young)2016-02-16T01:02:06.338-0500:  "
                 + "16023.683: [G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: 36870, predicted "
                 + "base time: 143.96 ms, remaining time: 856.04 ms, target pause time: 1000.00 ms]";
@@ -430,7 +430,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseWithTriggerWithG1ErgonomicsDoubleTimestampAndDateStamps() {
+    void testLogLineYoungPauseWithTriggerWithG1ErgonomicsDoubleTimestampAndDateStamps() {
         String logLine = "2017-03-21T15:05:53.717+1100: 425001.630: [GC pause (G1 Evacuation Pause) (young)"
                 + "2017-03-21T15:05:53.717+1100: 425001.630:  425001.630: [G1Ergonomics (CSet Construction) start "
                 + "choosing CSet, _pending_cards: 3, predicted base time: 45.72 ms, remaining time: 304.28 ms, target "
@@ -439,7 +439,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseTriggerHumongousAllocationWithG1Ergonomics() {
+    void testLogLineYoungPauseTriggerHumongousAllocationWithG1Ergonomics() {
         String priorLogLine = "";
         String logLine = "2020-02-16T23:24:09.668+0000: 880272.698: [GC pause (G1 Humongous Allocation) (young) "
                 + "880272.699: [G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: 241090, "
@@ -453,14 +453,14 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungInitialMarkWithDatestamp() {
+    void testLogLineYoungInitialMarkWithDatestamp() {
         String logLine = "2017-01-20T23:18:29.561-0500: 1513296.434: [GC pause (young) (initial-mark), "
                 + "0.0225230 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineYoungInitialMarkWithG1Ergonomics() {
+    void testLogLineYoungInitialMarkWithG1Ergonomics() {
         String logLine = "2016-02-11T15:22:23.213-0500: 4582.283: [GC pause (young) (initial-mark) 4582.283: "
                 + "[G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: 6084, predicted base time: "
                 + "41.16 ms, remaining time: 458.84 ms, target pause time: 500.00 ms]";
@@ -468,7 +468,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungInitialMarkTriggerG1HumongousAllocationWithG1Ergonomics() {
+    void testLogLineYoungInitialMarkTriggerG1HumongousAllocationWithG1Ergonomics() {
         String logLine = "2017-02-02T01:55:56.661-0500: 860.367: [GC pause (G1 Humongous Allocation) (young) "
                 + "(initial-mark) 860.367: [G1Ergonomics (CSet Construction) start choosing CSet, _pending_cards: "
                 + "3305091, predicted base time: 457.90 ms, remaining time: 42.10 ms, target pause time: 500.00 ms]";
@@ -476,7 +476,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineMixedWithG1Ergonomics() {
+    void testLogLineMixedWithG1Ergonomics() {
         String logLine = "2016-02-11T16:06:59.987-0500: 7259.058: [GC pause (mixed) 7259.058: [G1Ergonomics (CSet "
                 + "Construction) start choosing CSet, _pending_cards: 273214, predicted base time: 74.01 ms, "
                 + "remaining time: 425.99 ms, target pause time: 500.00 ms]";
@@ -484,51 +484,51 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineMixedHumongousAllocationToSpaceExhausted() {
+    void testLogLineMixedHumongousAllocationToSpaceExhausted() {
         String logLine = "2017-06-22T12:25:26.515+0530: 66155.261: [GC pause (G1 Humongous Allocation) (mixed) "
                 + "(to-space exhausted), 0.2466797 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConcurrentCleanupEndWithDatestamp() {
+    void testLogLineConcurrentCleanupEndWithDatestamp() {
         String logLine = "2016-02-11T18:15:35.431-0500: 14974.501: [GC concurrent-cleanup-end, 0.0033880 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSingleConcurrentMarkStartBlock() {
+    void testLogLineSingleConcurrentMarkStartBlock() {
         String logLine = "[GC concurrent-mark-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineGcConcurrentRootRegionScanEndMissingTimestamp() {
+    void testLogLineGcConcurrentRootRegionScanEndMissingTimestamp() {
         String logLine = "[GC concurrent-root-region-scan-end, 0.6380480 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineBeginningYoungConcurrent() {
+    void testLogLineBeginningYoungConcurrent() {
         String logLine = "2016-02-16T01:05:36.945-0500: 16233.809: [GC pause (young)2016-02-16T01:05:37.046-0500: "
                 + "16233.910: [GC concurrent-root-region-scan-end, 0.5802520 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTimesBlock() {
+    void testLogLineTimesBlock() {
         String logLine = " [Times: user=0.33 sys=0.04, real=0.17 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTimesBlockWithSpaceAtEnd() {
+    void testLogLineTimesBlockWithSpaceAtEnd() {
         String logLine = " [Times: user=0.33 sys=0.04, real=0.17 secs] ";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Cleanup() {
+    void testLogLineG1Cleanup() {
         String logLine = "1.515: [GC cleanup 165M->165M(110G), 0.0028925 secs]";
         String nextLogLine = "2.443: [GC pause (GCLocker Initiated GC) (young) (initial-mark) 1061M->52M(110G), "
                 + "0.0280096 secs]";
@@ -536,209 +536,209 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineStringDedupFixup() {
+    void testLogLineStringDedupFixup() {
         String logLine = "   [String Dedup Fixup: 1.6 ms, GC Workers: 18]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineStringDedupFixupQueueFixup() {
+    void testLogLineStringDedupFixupQueueFixup() {
         String logLine = "      [Queue Fixup (ms): Min: 0.0, Avg: 0.0, Max: 0.0, Diff: 0.0, Sum: 0.0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineStringDedupFixupTableFixup() {
+    void testLogLineStringDedupFixupTableFixup() {
         String logLine = "      [Table Fixup (ms): Min: 0.0, Avg: 0.1, Max: 1.3, Diff: 1.3, Sum: 1.3]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRedirtyCards() {
+    void testLogLineRedirtyCards() {
         String logLine = "      [Redirty Cards: 0.6 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineHumongousRegister() {
+    void testLogLineHumongousRegister() {
         String logLine = "      [Humongous Register: 0.1 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineHumongousReclaim() {
+    void testLogLineHumongousReclaim() {
         String logLine = "      [Humongous Reclaim: 0.0 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRemarkWithFinalizeMarkingAndUnloading() {
+    void testLogLineRemarkWithFinalizeMarkingAndUnloading() {
         String logLine = "5.745: [GC remark 5.746: [Finalize Marking, 0.0068506 secs] 5.752: "
                 + "[GC ref-proc, 0.0014064 secs] 5.754: [Unloading, 0.0057674 secs], 0.0157938 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineLastExec() {
+    void testLogLineLastExec() {
         String logLine = "   [Last Exec: 0.0118158 secs, Idle: 0.9330710 secs, Blocked: 0/0.0000000 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineInspected() {
+    void testLogLineInspected() {
         String logLine = "      [Inspected:           10116]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSkipped() {
+    void testLogLineSkipped() {
         String logLine = "         [Skipped:              0(  0.0%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineHashed() {
+    void testLogLineHashed() {
         String logLine = "         [Hashed:            3088( 30.5%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineKnown() {
+    void testLogLineKnown() {
         String logLine = "         [Known:             3404( 33.6%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineNew() {
+    void testLogLineNew() {
         String logLine = "         [New:               6712( 66.4%)    526.1K]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineDuplicated() {
+    void testLogLineDuplicated() {
         String logLine = "      [Deduplicated:         3304( 49.2%)    197.2K( 37.5%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineYoung() {
+    void testLogLineYoung() {
         String logLine = "         [Young:             3101( 93.9%)    173.8K( 88.1%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineOld() {
+    void testLogLineOld() {
         String logLine = "         [Old:                203(  6.1%)     23.4K( 11.9%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTotalExec() {
+    void testLogLineTotalExec() {
         String logLine = "   [Total Exec: 2/0.0281081 secs, Idle: 2/9.1631547 secs, Blocked: 2/0.0266213 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineTable() {
+    void testLogLineTable() {
         String logLine = "   [Table]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMemoryUsage() {
+    void testLogLineMemoryUsage() {
         String logLine = "      [Memory Usage: 745.2K]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSize() {
+    void testLogLineSize() {
         String logLine = "      [Size: 16384, Min: 1024, Max: 16777216]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineEntries() {
+    void testLogLineEntries() {
         String logLine = "      [Entries: 26334, Load: 160.7%, Cached: 0, Added: 26334, Removed: 0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineResizeCount() {
+    void testLogLineResizeCount() {
         String logLine = "      [Resize Count: 4, Shrink Threshold: 10922(66.7%), Grow Threshold: 32768(200.0%)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineRehashCount() {
+    void testLogLineRehashCount() {
         String logLine = "      [Rehash Count: 0, Rehash Threshold: 120, Hash Seed: 0x0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineAgeThreshold() {
+    void testLogLineAgeThreshold() {
         String logLine = "      [Age Threshold: 3]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineQueue() {
+    void testLogLineQueue() {
         String logLine = "   [Queue]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineDropped() {
+    void testLogLineDropped() {
         String logLine = "      [Dropped: 0]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSpaceDetailsWithPerm() {
+    void testLogLineSpaceDetailsWithPerm() {
         String logLine = "   [Eden: 143.0M(1624.0M)->0.0B(1843.0M) Survivors: 219.0M->0.0B "
                 + "Heap: 999.5M(3072.0M)->691.1M(3072.0M)], [Perm: 175031K->175031K(175104K)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSpaceNoDetailsWithoutPerm() {
+    void testLogLineSpaceNoDetailsWithoutPerm() {
         String logLine = "   [Eden: 4096M(4096M)->0B(3528M) Survivors: 0B->568M Heap: 4096M(16384M)->567M(16384M)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullCombinedConcurrentRootRegionScanStart() {
+    void testLogLineG1FullCombinedConcurrentRootRegionScanStart() {
         String logLine = "88.123: [Full GC (Metadata GC Threshold) 88.123: [GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFullCombinedConcurrentRootRegionScanEndWithDuration() {
+    void testLogLineFullCombinedConcurrentRootRegionScanEndWithDuration() {
         String logLine = "93.315: [Full GC (Metadata GC Threshold) 93.315: "
                 + "[GC concurrent-root-region-scan-end, 0.0003872 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineEndOfFullCollection() {
+    void testLogLineEndOfFullCollection() {
         String logLine = " 1831M->1213M(5120M), 5.1353878 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineSpaceDetailsWithMetaspace() {
+    void testLogLineSpaceDetailsWithMetaspace() {
         String logLine = "   [Eden: 0.0B(1522.0M)->0.0B(2758.0M) Survivors: 244.0M->0.0B "
                 + "Heap: 1831.0M(5120.0M)->1213.5M(5120.0M)], [Metaspace: 396834K->324903K(1511424K)]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungInitialMarkTriggerMetaGcThreshold() {
+    void testLogLineG1YoungInitialMarkTriggerMetaGcThreshold() {
         String logLine = "87.830: [GC pause (Metadata GC Threshold) (young) (initial-mark), 0.2932700 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineMiddleG1FullWithSizeInformation() {
+    void testLogLineMiddleG1FullWithSizeInformation() {
         String logLine = " 1831M->1213M(5120M), 5.1353878 secs]";
         Set<String> context = new HashSet<String>();
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
@@ -748,64 +748,64 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1FullTriggerLastDitchCollection2SpacesAfterTrigger() {
+    void testLogLineG1FullTriggerLastDitchCollection2SpacesAfterTrigger() {
         String logLine = "98.150: [Full GC (Last ditch collection)  1196M->1118M(5120M), 4.4628626 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullTriggerJvmTiForcedGarbageCollection() {
+    void testLogLineG1FullTriggerJvmTiForcedGarbageCollection() {
         String logLine = "102.621: [Full GC (JvmtiEnv ForceGarbageCollection)  1124M->1118M(5120M), 3.8954775 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEnd() {
+    void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEnd() {
         String logLine = "290.944: [Full GC (Metadata GC Threshold) 290.944: "
                 + "[GC concurrent-root-region-scan-end, 0.0003793 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEndPrependedColon() {
+    void testLogLineG1FullTriggerMetaDataGcThresholdMixedConcurrentRootRegionScanEndPrependedColon() {
         String logLine = ": 7688.541: [Full GC (Metadata GC Threshold) 2016-10-12T11:56:49.416+0200: "
                 + "7688.541: [GC concurrent-root-region-scan-end, 0.0003847 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullCombinedConcurrentRootRegionScanStartMissingTimestamp() {
+    void testLogLineG1FullCombinedConcurrentRootRegionScanStartMissingTimestamp() {
         String logLine = "298.027: [Full GC (Metadata GC Threshold) [GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullTriggerMetaDataGcThreshold() {
+    void testLogLineG1FullTriggerMetaDataGcThreshold() {
         String logLine = "4708.816: [Full GC (Metadata GC Threshold)  801M->801M(5120M), 3.5048336 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungInitialMarkTriggerGcLockerInitiatedGc() {
+    void testLogLineG1YoungInitialMarkTriggerGcLockerInitiatedGc() {
         String logLine = "6896.482: [GC pause (GCLocker Initiated GC) (young) (initial-mark), 0.0525160 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungConcurrentTriggerG1HumongousAllocation() {
+    void testLogLineG1YoungConcurrentTriggerG1HumongousAllocation() {
         String logLine = "2017-06-22T13:55:45.753+0530: 71574.499: [GC pause (G1 Humongous Allocation) (young)"
                 + "2017-06-22T13:55:45.771+0530: 71574.517: [GC concurrent-root-region-scan-end, 0.0181265 secs]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1ConcurrentWithDatestamp() {
+    void testLogLineG1ConcurrentWithDatestamp() {
         String logLine = "2016-02-09T06:17:15.377-0500: 27744.139: [GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFullGcPrintClassHistogram() {
+    void testLogLineFullGcPrintClassHistogram() {
         String priorLogLine = "";
         String logLine = "49689.217: [Full GC49689.217: [Class Histogram (before full gc):";
         String nextLogLine = "";
@@ -817,7 +817,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLinePrintClassHistogramSpaceAtEnd() {
+    void testLogLinePrintClassHistogramSpaceAtEnd() {
         String priorLogLine = "";
         String logLine = "49709.036: [Class Histogram (after full gc): ";
         String nextLogLine = "";
@@ -829,7 +829,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPause() {
+    void testLogLineYoungPause() {
         String priorLogLine = "";
         String logLine = "785,047: [GC pause (young), 0,73936800 secs]";
         String nextLogLine = "";
@@ -841,7 +841,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseMixedConcurrentMarkEnd() {
+    void testLogLineYoungPauseMixedConcurrentMarkEnd() {
         String priorLogLine = "";
         String logLine = "188935.313: [GC pause (G1 Evacuation Pause) (young)"
                 + "188935.321: [GC concurrent-mark-end, 0.4777427 secs]";
@@ -854,7 +854,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineYoungPauseMixedConcurrentRootRegionScanStart() {
+    void testLogLineYoungPauseMixedConcurrentRootRegionScanStart() {
         String priorLogLine = "";
         String logLine = "537.122: [GC pause (G1 Evacuation Pause) (young)"
                 + "537.123: [GC concurrent-root-region-scan-start]";
@@ -867,7 +867,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentMixedYoungPauseToSpaceExhaustedEnd() {
+    void testLogLineConcurrentMixedYoungPauseToSpaceExhaustedEnd() {
         String priorLogLine = "";
         String logLine = "537.142: [GC concurrent-root-region-scan-end, 0.0189841 secs] (to-space exhausted), "
                 + "0.3314995 secs][Eden: 0.0B(151.0M)->0.0B(153.0M) Survivors: 2048.0K->0.0B Heap: "
@@ -884,7 +884,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentMixedYoungPauseEndNoToSpaceExhausted() {
+    void testLogLineConcurrentMixedYoungPauseEndNoToSpaceExhausted() {
         String priorLogLine = "";
         String logLine = "2132.962: [GC concurrent-root-region-scan-end, 0.0001111 secs], 0.1083307 secs]"
                 + "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B Heap: 3035.6M(3072.0M)->3035.6M(3072.0M)] "
@@ -900,7 +900,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineErgonomicsDatestampDoubleTimestamp() {
+    void testLogLineErgonomicsDatestampDoubleTimestamp() {
         String logLine = "2016-02-12T00:05:06.348-0500: 35945.418:  35945.418: [G1Ergonomics (CSet Construction) "
                 + "start choosing CSet, _pending_cards: 279876, predicted base time: 236.99 ms, remaining time: "
                 + "263.01 ms, target pause time: 500.00 ms]";
@@ -908,14 +908,14 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineErgonomicsDoubleTimestamp() {
+    void testLogLineErgonomicsDoubleTimestamp() {
         String logLine = "16023.683:  16023.683: [G1Ergonomics (CSet Construction) add young regions to CSet, "
                 + "eden: 76 regions, survivors: 7 regions, predicted young region time: 123.54 ms]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1RemarkDatestamps() {
+    void testLogLineG1RemarkDatestamps() {
         String logLine = "2016-03-14T16:06:13.991-0700: 5.745: [GC remark 2016-03-14T16:06:13.991-0700: 5.746: "
                 + "[Finalize Marking, 0.0068506 secs] 2016-03-14T16:06:13.998-0700: 5.752: [GC ref-proc, "
                 + "0.0014064 secs] 2016-03-14T16:06:14.000-0700: 5.754: [Unloading, 0.0057674 secs], 0.0157938 secs]";
@@ -923,42 +923,42 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1FullDoubleDatestamps() {
+    void testLogLineG1FullDoubleDatestamps() {
         String logLine = "2016-10-12T09:53:38.901+0200: 2016-10-12T09:53:38.901+0200: 298.027: 298.027: "
                 + "[Full GC (Metadata GC Threshold) [GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConsurrentDatestampTimestampDatestamp() {
+    void testLogLineConsurrentDatestampTimestampDatestamp() {
         String logLine = "2016-10-12T11:56:49.415+0200: 7688.541: 2016-10-12T11:56:49.415+0200"
                 + "[GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConsurrentDatestampDatestampTimestampTimestamp() {
+    void testLogLineConsurrentDatestampDatestampTimestampTimestamp() {
         String logLine = "2016-10-12T11:37:28.396+0200: 2016-10-12T11:37:28.396+0200: 6527.522: "
                 + "6527.522: [GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineConsurrentDatestampDatestampTimestampTimestampNoColonNoSpace() {
+    void testLogLineConsurrentDatestampDatestampTimestampTimestampNoColonNoSpace() {
         String logLine = "2016-10-12T11:39:07.893+0200: 2016-10-12T11:39:07.893+0200: "
                 + "6627.019: 6627.019[GC concurrent-root-region-scan-start]";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1FullDatestamp() {
+    void testLogLineG1FullDatestamp() {
         String logLine = "2016-10-31T14:09:15.030-0700: 49689.217: [Full GC"
                 + "2016-10-31T14:09:15.030-0700: 49689.217: [Class Histogram (before full gc):";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineFullMixedConcurrentNoSpaceAfterTrigger() {
+    void testLogLineFullMixedConcurrentNoSpaceAfterTrigger() {
         String logLine = "2017-02-27T02:55:32.523+0300: 35911.404: [Full GC (Allocation Failure)"
                 + "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-root-region-scan-end, 0.0127300 secs]";
         String nextLogLine = "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]";
@@ -970,7 +970,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineFullMixedConcurrentDatestampDatestampTimestampTimestamp() {
+    void testLogLineFullMixedConcurrentDatestampDatestampTimestampTimestamp() {
         String logLine = "2017-06-22T16:03:36.126+0530: 2017-06-22T16:03:36.126+0530: 79244.87279244.872: : "
                 + "[Full GC (Metadata GC Threshold) [GC concurrent-root-region-scan-start]";
         String nextLogLine = "2017-06-22T16:03:36.126+0530: 79244.872: [GC concurrent-root-region-scan-end, "
@@ -983,7 +983,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineFullMixedConcurrentScrambledDateTimeStamps() {
+    void testLogLineFullMixedConcurrentScrambledDateTimeStamps() {
         String logLine = "2017-06-22T16:35:58.032+0530: 81186.777: 2017-06-22T16:35:58.032+0530: "
                 + "[Full GC (Metadata GC Threshold) 81186.777: [GC concurrent-root-region-scan-start]";
         String nextLogLine = "2017-06-22T16:35:58.033+0530: 81186.778: [GC concurrent-root-region-scan-end, "
@@ -996,7 +996,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineFullMixedConcurrentMiddle() {
+    void testLogLineFullMixedConcurrentMiddle() {
         String logLine = "35420.674: [Full GC (Allocation Failure) 35420.734: "
                 + "[GC concurrent-mark-start]3035M->3030M(3072M), 21.7552521 secs]"
                 + "[Eden: 0.0B(153.0M)->0.0B(153.0M) Survivors: 0.0B->0.0B Heap: 3035.5M(3072.0M)->3030.4M(3072.0M)], "
@@ -1014,7 +1014,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentWithDatestamp() {
+    void testLogLineConcurrentWithDatestamp() {
         String logLine = "2017-02-27T02:55:32.524+0300: 35911.405: [GC concurrent-mark-start]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1025,7 +1025,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentDoubleDatestamp() {
+    void testLogLineConcurrentDoubleDatestamp() {
         String logLine = "2018-12-06T21:56:32.691-0500: 18.973"
                 + "2018-12-06T21:56:32.691-0500: : 18.973[GC concurrent-root-region-scan-start]";
         String nextLogLine = "";
@@ -1037,7 +1037,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleInitialMark() {
+    void testLogLineMiddleInitialMark() {
         String logLine = " (initial-mark), 0.12895600 secs]";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1048,7 +1048,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineMixedYoungPauseWithConcurrentRootRegionScanEndWithDatestamps() {
+    void testLogLineMixedYoungPauseWithConcurrentRootRegionScanEndWithDatestamps() {
         String logLine = "2017-06-01T03:09:18.078-0400: 3978.886: [GC pause (GCLocker Initiated GC) (young)"
                 + "2017-06-01T03:09:18.081-0400: 3978.888: [GC concurrent-root-region-scan-end, 0.0059070 secs]";
         String nextLogLine = "";
@@ -1060,7 +1060,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1YoungPauseMixedG1SummarizeRSetStatsBeforeRsSummary() {
+    void testLogLineG1YoungPauseMixedG1SummarizeRSetStatsBeforeRsSummary() {
         String logLine = "0.449: [GC pause (G1 Evacuation Pause) (young)Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1071,7 +1071,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1YoungInitialMarkMixedG1SummarizeRSetStatsBeforeRsSummary() {
+    void testLogLineG1YoungInitialMarkMixedG1SummarizeRSetStatsBeforeRsSummary() {
         String logLine = "1.738: [GC pause (Metadata GC Threshold) (young) (initial-mark)Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1082,7 +1082,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningG1FullMixedG1SummarizeRSetStatsBeforeRsSummary() {
+    void testLogLineBeginningG1FullMixedG1SummarizeRSetStatsBeforeRsSummary() {
         String logLine = "73.164: [Full GC (System.gc()) Before GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1093,7 +1093,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineMiddleG1FullMixedG1SummarizeRSetStatsAfterRsSummary() {
+    void testLogLineMiddleG1FullMixedG1SummarizeRSetStatsAfterRsSummary() {
         String logLine = " 390M->119M(512M)After GC RS summary";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -1104,7 +1104,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1MixedPauseMixedG1SummarizeRSetStatsBeforeRsSummary() {
+    void testLogLineG1MixedPauseMixedG1SummarizeRSetStatsBeforeRsSummary() {
         String logLine = "2017-06-28T18:24:40.453-0400: 12289.351: [GC pause (G1 Evacuation Pause) (mixed)"
                 + "Before GC RS summary";
         String nextLogLine = "";
@@ -1116,249 +1116,249 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRecentRefinementStats() {
+    void testLogLineG1SummarizeRSetStatsRecentRefinementStats() {
         String logLine = " Recent concurrent refinement statistics";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsProcessedCards() {
+    void testLogLineG1SummarizeRSetStatsProcessedCards() {
         String logLine = "  Processed 0 cards";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCompletedBuffersHeading() {
+    void testLogLineG1SummarizeRSetStatsCompletedBuffersHeading() {
         String logLine = "  Of 2736 completed buffers:";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCompletedBuffersHeadingDigits3() {
+    void testLogLineG1SummarizeRSetStatsCompletedBuffersHeadingDigits3() {
         String logLine = "  Of 170 completed buffers:";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRsThreads() {
+    void testLogLineG1SummarizeRSetStatsRsThreads() {
         String logLine = "         2736 ( 94.3%) by concurrent RS threads.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRsThreadsPercent100() {
+    void testLogLineG1SummarizeRSetStatsRsThreadsPercent100() {
         String logLine = "          170 (100.0%) by concurrent RS threads.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsMutatorThreads() {
+    void testLogLineG1SummarizeRSetStatsMutatorThreads() {
         String logLine = "            0 (  0.0%) by mutator threads.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCoarsenings() {
+    void testLogLineG1SummarizeRSetStatsCoarsenings() {
         String logLine = "  Did 0 coarsenings.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCoarseningsDigits3() {
+    void testLogLineG1SummarizeRSetStatsCoarseningsDigits3() {
         String logLine = "  Did 239 coarsenings.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRsThreadTimesHeading() {
+    void testLogLineG1SummarizeRSetStatsRsThreadTimesHeading() {
         String logLine = "  Concurrent RS threads times (s)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRsThreadTimesOutput() {
+    void testLogLineG1SummarizeRSetStatsRsThreadTimesOutput() {
         String logLine = "          0.00     0.00     0.00     0.00     0.00     0.00     0.00     0.00";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesHeading() {
+    void testLogLineG1SummarizeRSetStatsSamplingThreadTimesHeading() {
         String logLine = "  Concurrent sampling threads times (s)";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutput() {
+    void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutput() {
         String logLine = "          0.00";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutputDigits2() {
+    void testLogLineG1SummarizeRSetStatsSamplingThreadTimesOutputDigits2() {
         String logLine = "         13.33";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetHeading() {
+    void testLogLineG1SummarizeRSetStatsRSetHeading() {
         String logLine = " Current rem set statistics";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetTotalKMaxB() {
+    void testLogLineG1SummarizeRSetStatsRSetTotalKMaxB() {
         String logLine = "  Total per region rem sets sizes = 1513K. Max = 6336B.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetTotalMMaxK() {
+    void testLogLineG1SummarizeRSetStatsRSetTotalMMaxK() {
         String logLine = "  Total per region rem sets sizes = 38M. Max = 25K.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetTotalKMaxK() {
+    void testLogLineG1SummarizeRSetStatsRSetTotalKMaxK() {
         String logLine = "  Total per region rem sets sizes = 1606K. Max = 14K.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetYoung() {
+    void testLogLineG1SummarizeRSetStatsRSetYoung() {
         String logLine = "          78K (  5.2%) by 25 Young regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetHumongous() {
+    void testLogLineG1SummarizeRSetStatsRSetHumongous() {
         String logLine = "           0B (  0.0%) by 0 Humonguous regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetFree() {
+    void testLogLineG1SummarizeRSetStatsRSetFree() {
         String logLine = "        1434K ( 94.8%) by 487 Free regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetFreeMDigits4() {
+    void testLogLineG1SummarizeRSetStatsRSetFreeMDigits4() {
         String logLine = "          36M ( 94.9%) by 3709 Free regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRSetOld() {
+    void testLogLineG1SummarizeRSetStatsRSetOld() {
         String logLine = "           0B (  0.0%) by 0 Old regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsStaticStructures() {
+    void testLogLineG1SummarizeRSetStatsStaticStructures() {
         String logLine = "   Static structures = 64K, free_lists = 0B.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCards() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCards() {
         String logLine = "    0 occupied cards represented.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsDigits9() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsDigits9() {
         String logLine = "    122457800 occupied cards represented.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsYoung() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsYoung() {
         String logLine = "            0 (  0.0%) entries by 25 Young regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsHumongous() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsHumongous() {
         String logLine = "            0 (  0.0%) entries by 0 Humonguous regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsFree() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsFree() {
         String logLine = "            0 (  0.0%) entries by 487 Free regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsOld() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsOld() {
         String logLine = "            0 (  0.0%) entries by 0 Old regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsOccupiedCardsOldDigits9() {
+    void testLogLineG1SummarizeRSetStatsOccupiedCardsOldDigits9() {
         String logLine = "     122327000 (100.0%) entries by 1171 Old regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRegionLargestRset() {
+    void testLogLineG1SummarizeRSetStatsRegionLargestRset() {
         String logLine = "    Region with largest rem set = 511:(E)[0x00000000dff00000,0x00000000e0000000,"
                 + "0x00000000e0000000], size = 6336B, occupied = 0B.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsHeapTotal() {
+    void testLogLineG1SummarizeRSetStatsHeapTotal() {
         String logLine = "  Total heap region code root sets sizes = 13K.  Max = 3336B.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRoots() {
+    void testLogLineG1SummarizeRSetStatsCodeRoots() {
         String logLine = "    205 code roots represented.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRootsDigits5() {
+    void testLogLineG1SummarizeRSetStatsCodeRootsDigits5() {
         String logLine = "    12153 code roots represented.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRootsYoung() {
+    void testLogLineG1SummarizeRSetStatsCodeRootsYoung() {
         String logLine = "            7 (  2.8%) elements by 4 Young regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRootsHumongous() {
+    void testLogLineG1SummarizeRSetStatsCodeRootsHumongous() {
         String logLine = "            0 (  0.0%) elements by 0 Humonguous regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRootsFree() {
+    void testLogLineG1SummarizeRSetStatsCodeRootsFree() {
         String logLine = "            0 (  0.0%) elements by 493 Free regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsCodeRootsOld() {
+    void testLogLineG1SummarizeRSetStatsCodeRootsOld() {
         String logLine = "          242 ( 97.2%) elements by 15 Old regions";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsRegionLargestCodeRoots() {
+    void testLogLineG1SummarizeRSetStatsRegionLargestCodeRoots() {
         String logLine = "    Region with largest amount of code roots = 511:(E)[0x00000000dff00000,"
                 + "0x00000000e0000000,0x00000000e0000000], size = 3336B, num_elems = 136.";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SummarizeRSetStatsAfterRsSummaryHeading() {
+    void testLogLineG1SummarizeRSetStatsAfterRsSummaryHeading() {
         String logLine = "After GC RS summary";
         assertTrue(G1PreprocessAction.match(logLine, null, null), "Log line not recognized as " + JdkUtil.PreprocessActionType.G1.toString() + ".");
     }
@@ -1368,7 +1368,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseLogging() {
+    void testG1PreprocessActionG1YoungPauseLogging() {
         File testFile = TestUtil.getFile("dataset32.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1384,7 +1384,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1EvacuationPauseLogging() {
+    void testG1PreprocessActionG1EvacuationPauseLogging() {
         File testFile = TestUtil.getFile("dataset34.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1399,7 +1399,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithGCLockerInitiatedGCLogging() {
+    void testG1PreprocessActionG1YoungPauseWithGCLockerInitiatedGCLogging() {
         File testFile = TestUtil.getFile("dataset35.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1416,7 +1416,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1FullGCLogging() {
+    void testG1PreprocessActionG1FullGCLogging() {
         File testFile = TestUtil.getFile("dataset36.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1433,7 +1433,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionYoungInitialMarkLogging() {
+    void testG1PreprocessActionYoungInitialMarkLogging() {
         File testFile = TestUtil.getFile("dataset37.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1448,7 +1448,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1InitialMarkWithCodeRootLogging() {
+    void testG1PreprocessActionG1InitialMarkWithCodeRootLogging() {
         File testFile = TestUtil.getFile("dataset43.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1463,7 +1463,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionRemarkLogging() {
+    void testG1PreprocessActionRemarkLogging() {
         File testFile = TestUtil.getFile("dataset38.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1478,7 +1478,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionMixedPauseLogging() {
+    void testG1PreprocessActionMixedPauseLogging() {
         File testFile = TestUtil.getFile("dataset39.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1493,7 +1493,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionCleanupLogging() {
+    void testG1PreprocessActionCleanupLogging() {
         File testFile = TestUtil.getFile("dataset40.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1508,7 +1508,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionConcurrentLogging() {
+    void testG1PreprocessActionConcurrentLogging() {
         File testFile = TestUtil.getFile("dataset44.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1524,7 +1524,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionToSpaceExhaustedLogging() {
+    void testG1PreprocessActionToSpaceExhaustedLogging() {
         File testFile = TestUtil.getFile("dataset45.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1540,7 +1540,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionMixedPauseNoTriggerLogging() {
+    void testG1PreprocessActionMixedPauseNoTriggerLogging() {
         File testFile = TestUtil.getFile("dataset46.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1555,7 +1555,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionYoungConcurrentLogging() {
+    void testG1PreprocessActionYoungConcurrentLogging() {
         File testFile = TestUtil.getFile("dataset47.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1571,7 +1571,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging() {
         File testFile = TestUtil.getFile("dataset48.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1587,7 +1587,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungInitialMarkWithG1ErgonomicsLogging() {
+    void testG1PreprocessActionG1YoungInitialMarkWithG1ErgonomicsLogging() {
         File testFile = TestUtil.getFile("dataset49.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1602,7 +1602,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseTriggerToSpaceExhaustedWithG1ErgonomicsLogging() {
+    void testG1PreprocessActionG1YoungPauseTriggerToSpaceExhaustedWithG1ErgonomicsLogging() {
         File testFile = TestUtil.getFile("dataset50.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1618,7 +1618,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging2() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging2() {
         File testFile = TestUtil.getFile("dataset51.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1634,7 +1634,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging3() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging3() {
         File testFile = TestUtil.getFile("dataset52.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1650,7 +1650,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungInitialMarkWithTriggerAndG1ErgonomicsLogging() {
+    void testG1PreprocessActionG1YoungInitialMarkWithTriggerAndG1ErgonomicsLogging() {
         File testFile = TestUtil.getFile("dataset53.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1666,7 +1666,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging4() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging4() {
         File testFile = TestUtil.getFile("dataset54.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1682,7 +1682,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging5() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging5() {
         File testFile = TestUtil.getFile("dataset55.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1698,7 +1698,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging6() {
+    void testG1PreprocessActionG1YoungPauseWithG1ErgonomicsLogging6() {
         File testFile = TestUtil.getFile("dataset57.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1716,7 +1716,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1CleanupG1InitialMark() {
+    void testG1CleanupG1InitialMark() {
         File testFile = TestUtil.getFile("dataset62.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1733,7 +1733,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testRemarkWithFinalizeMarkingAndUnloading() {
+    void testRemarkWithFinalizeMarkingAndUnloading() {
         File testFile = TestUtil.getFile("dataset63.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1748,7 +1748,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testConcurrentStringDeduplicatonLogging() {
+    void testConcurrentStringDeduplicatonLogging() {
         File testFile = TestUtil.getFile("dataset64.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1763,7 +1763,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1Full3Lines() {
+    void testG1Full3Lines() {
         File testFile = TestUtil.getFile("dataset65.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1780,7 +1780,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullLastDitchCollectionTrigger() {
+    void testG1FullLastDitchCollectionTrigger() {
         File testFile = TestUtil.getFile("dataset74.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1797,7 +1797,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullJvmTiForcedGarbageCollectionTrigger() {
+    void testG1FullJvmTiForcedGarbageCollectionTrigger() {
         File testFile = TestUtil.getFile("dataset75.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1815,7 +1815,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1ConcurrentMissingTimestamp() {
+    void testG1ConcurrentMissingTimestamp() {
         File testFile = TestUtil.getFile("dataset76.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1833,7 +1833,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1ConcurrentMissingTimestampExceptColon() {
+    void testG1ConcurrentMissingTimestampExceptColon() {
         File testFile = TestUtil.getFile("dataset77.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1851,7 +1851,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullMissingTimestamp() {
+    void testG1FullMissingTimestamp() {
         File testFile = TestUtil.getFile("dataset78.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1869,7 +1869,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullMissingTimestampExceptColon() {
+    void testG1FullMissingTimestampExceptColon() {
         File testFile = TestUtil.getFile("dataset79.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1887,7 +1887,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullPrependedColon() {
+    void testG1FullPrependedColon() {
         File testFile = TestUtil.getFile("dataset80.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1905,7 +1905,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1FullWithPrintClassHistogram() {
+    void testG1FullWithPrintClassHistogram() {
         File testFile = TestUtil.getFile("dataset93.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1925,7 +1925,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1YoungPauseNoSizeDetails() {
+    void testG1YoungPauseNoSizeDetails() {
         File testFile = TestUtil.getFile("dataset97.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1941,7 +1941,7 @@ public class TestG1PreprocessAction {
      * 
      */
     @Test
-    public void testG1YoungPauseEvacuationFailure() {
+    void testG1YoungPauseEvacuationFailure() {
         File testFile = TestUtil.getFile("dataset100.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1954,7 +1954,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testFullGcMixedConcurrent() {
+    void testFullGcMixedConcurrent() {
         File testFile = TestUtil.getFile("dataset116.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1969,7 +1969,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testG1YoungInitialMark() {
+    void testG1YoungInitialMark() {
         File testFile = TestUtil.getFile("dataset127.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1980,7 +1980,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testFullMixedConcurrentScrambledDateTimestamps() {
+    void testFullMixedConcurrentScrambledDateTimestamps() {
         File testFile = TestUtil.getFile("dataset134.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1994,7 +1994,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testSummarizeRSetStatsPreprocessing() {
+    void testSummarizeRSetStatsPreprocessing() {
         File testFile = TestUtil.getFile("dataset139.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -2007,7 +2007,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testPreprocessingWithCommas() {
+    void testPreprocessingWithCommas() {
         File testFile = TestUtil.getFile("dataset143.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -2019,7 +2019,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testPreprocessingYoungMixedConcurrent() {
+    void testPreprocessingYoungMixedConcurrent() {
         File testFile = TestUtil.getFile("dataset144.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -2032,7 +2032,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testPreprocessingFullMixedConcurrent() {
+    void testPreprocessingFullMixedConcurrent() {
         File testFile = TestUtil.getFile("dataset145.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -2045,7 +2045,7 @@ public class TestG1PreprocessAction {
     }
 
     @Test
-    public void testPreprocessingYoungMixedErgonomics() {
+    void testPreprocessingYoungMixedErgonomics() {
         File testFile = TestUtil.getFile("dataset180.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestParallelPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestParallelPreprocessAction.java
@@ -34,10 +34,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestParallelPreprocessAction {
+class TestParallelPreprocessAction {
 
     @Test
-    public void testLogLineEndFull() {
+    void testLogLineEndFull() {
         String logLine = " [PSYoungGen: 32064K->0K(819840K)] [PSOldGen: 355405K->387085K(699072K)] "
                 + "387470K->387085K(1518912K) [PSPermGen: 115215K->115215K(238912K)], 1.5692400 secs]";
         String nextLogLine = null;
@@ -48,7 +48,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndTimes() {
+    void testLogLineEndTimes() {
         String logLine = ", 33.6887649 secs] [Times: user=33.68 sys=0.02, real=33.69 secs]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -58,7 +58,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineClassUnloading() {
+    void testLogLineClassUnloading() {
         String logLine = "65.343: [Full GC[Unloading class $Proxy111]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -68,7 +68,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineGcTimeLimitExceedLineExceed() {
+    void testLogLineGcTimeLimitExceedLineExceed() {
         String logLine = "3743.645: [Full GC [PSYoungGen: 419840K->415020K(839680K)] [PSOldGen: "
                 + "5008922K->5008922K(5033984K)] 5428762K->5423942K(5873664K) [PSPermGen: "
                 + "193275K->193275K(262144K)]      GC time would exceed GCTimeLimit of 98%";
@@ -76,7 +76,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineGcTimeLimitExceeding() {
+    void testLogLineGcTimeLimitExceeding() {
         String logLine = "3924.453: [Full GC [PSYoungGen: 419840K->418436K(839680K)] [PSOldGen: "
                 + "5008601K->5008601K(5033984K)] 5428441K->5427038K(5873664K) [PSPermGen: "
                 + "193278K->193278K(262144K)]      GC time is exceeding GCTimeLimit of 98%";
@@ -84,7 +84,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineGcTimeLimitExceedMoreSpaces() {
+    void testLogLineGcTimeLimitExceedMoreSpaces() {
         String logLine = "52843.722: [Full GC [PSYoungGen: 109696K->95191K(184960K)] [ParOldGen: "
                 + "1307240K->1307182K(1310720K)] 1416936K->1402374K(1495680K) [PSPermGen: "
                 + "113631K->113623K(196608K)]\tGC time is exceeding GCTimeLimit of 98%";
@@ -92,7 +92,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineGcTimeLimitExceedWithDatestamp() {
+    void testLogLineGcTimeLimitExceedWithDatestamp() {
         String logLine = "2017-06-02T11:11:29.244+0530: 165944.630: [Full GC [PSYoungGen: 230400K->217423K(268800K)] "
                 + "[PSOldGen: 1789951K->1789951K(1789952K)] 2020351K->2007375K(2058752K) "
                 + "[PSPermGen: 188837K->188837K(524288K)]      GC time would exceed GCTimeLimit of 98%";
@@ -100,7 +100,7 @@ public class TestParallelPreprocessAction {
     }
 
     @Test
-    public void testLogLineBeginningParallelScavenge() {
+    void testLogLineBeginningParallelScavenge() {
         String logLine = "10.392: [GC";
         assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
@@ -109,7 +109,7 @@ public class TestParallelPreprocessAction {
      * Test preprocessing <code>GcTimeLimitExceededEvent</code>.
      */
     @Test
-    public void testSplitParallelSerialOldEventLogging() {
+    void testSplitParallelSerialOldEventLogging() {
         File testFile = TestUtil.getFile("dataset9.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -127,7 +127,7 @@ public class TestParallelPreprocessAction {
      * <code>ParallelSerialOldEvent</code>.
      */
     @Test
-    public void testUnloadingClassPreprocessActionParallelSerialOldEventLogging() {
+    void testUnloadingClassPreprocessActionParallelSerialOldEventLogging() {
         File testFile = TestUtil.getFile("dataset24.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -142,7 +142,7 @@ public class TestParallelPreprocessAction {
      * <code>ParallelScavengeEvent</code>.
      */
     @Test
-    public void testSplitParallelScavengeEventLogging() {
+    void testSplitParallelScavengeEventLogging() {
         File testFile = TestUtil.getFile("dataset30.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -157,7 +157,7 @@ public class TestParallelPreprocessAction {
      * Test preprocessing <code>GcTimeLimitExceededEvent</code> with logging mixed across multiple lines.
      */
     @Test
-    public void testParallelSerialOldAcrossMultipleLinesMixedGcTimeLimitLogging() {
+    void testParallelSerialOldAcrossMultipleLinesMixedGcTimeLimitLogging() {
         File testFile = TestUtil.getFile("dataset132.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestParallelPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestParallelPreprocessAction.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.Analysis;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -42,10 +42,9 @@ public class TestParallelPreprocessAction {
                 + "387470K->387085K(1518912K) [PSPermGen: 115215K->115215K(238912K)], 1.5692400 secs]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
         ParallelPreprocessAction event = new ParallelPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -53,10 +52,9 @@ public class TestParallelPreprocessAction {
         String logLine = ", 33.6887649 secs] [Times: user=33.68 sys=0.02, real=33.69 secs]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
         ParallelPreprocessAction event = new ParallelPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -64,10 +62,9 @@ public class TestParallelPreprocessAction {
         String logLine = "65.343: [Full GC[Unloading class $Proxy111]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
         ParallelPreprocessAction event = new ParallelPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", "65.343: [Full GC", event.getLogEntry());
+        assertEquals("65.343: [Full GC",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -75,8 +72,7 @@ public class TestParallelPreprocessAction {
         String logLine = "3743.645: [Full GC [PSYoungGen: 419840K->415020K(839680K)] [PSOldGen: "
                 + "5008922K->5008922K(5033984K)] 5428762K->5423942K(5873664K) [PSPermGen: "
                 + "193275K->193275K(262144K)]      GC time would exceed GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
 
     @Test
@@ -84,8 +80,7 @@ public class TestParallelPreprocessAction {
         String logLine = "3924.453: [Full GC [PSYoungGen: 419840K->418436K(839680K)] [PSOldGen: "
                 + "5008601K->5008601K(5033984K)] 5428441K->5427038K(5873664K) [PSPermGen: "
                 + "193278K->193278K(262144K)]      GC time is exceeding GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
 
     @Test
@@ -93,8 +88,7 @@ public class TestParallelPreprocessAction {
         String logLine = "52843.722: [Full GC [PSYoungGen: 109696K->95191K(184960K)] [ParOldGen: "
                 + "1307240K->1307182K(1310720K)] 1416936K->1402374K(1495680K) [PSPermGen: "
                 + "113631K->113623K(196608K)]\tGC time is exceeding GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
 
     @Test
@@ -102,15 +96,13 @@ public class TestParallelPreprocessAction {
         String logLine = "2017-06-02T11:11:29.244+0530: 165944.630: [Full GC [PSYoungGen: 230400K->217423K(268800K)] "
                 + "[PSOldGen: 1789951K->1789951K(1789952K)] 2020351K->2007375K(2058752K) "
                 + "[PSPermGen: 188837K->188837K(524288K)]      GC time would exceed GCTimeLimit of 98%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
 
     @Test
     public void testLogLineBeginningParallelScavenge() {
         String logLine = "10.392: [GC";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".",
-                ParallelPreprocessAction.match(logLine));
+        assertTrue(ParallelPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.PARALLEL.toString() + ".");
     }
 
     /**
@@ -123,15 +115,11 @@ public class TestParallelPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT));
-        assertTrue(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED), Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.");
     }
 
     /**
@@ -145,9 +133,8 @@ public class TestParallelPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
     }
 
     /**
@@ -161,11 +148,9 @@ public class TestParallelPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SCAVENGE));
-        assertTrue(Analysis.WARN_PRINT_TENURING_DISTRIBUTION + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_TENURING_DISTRIBUTION));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SCAVENGE), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_TENURING_DISTRIBUTION), Analysis.WARN_PRINT_TENURING_DISTRIBUTION + " analysis not identified.");
     }
 
     /**
@@ -178,14 +163,10 @@ public class TestParallelPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT));
-        assertTrue(Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL));
-        assertTrue(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.GC_OVERHEAD_LIMIT), "Log line not recognized as " + JdkUtil.LogEventType.GC_OVERHEAD_LIMIT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL), Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED), Analysis.ERROR_GC_TIME_LIMIT_EXCEEEDED + " analysis not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestSerialPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestSerialPreprocessAction.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestSerialPreprocessAction {
+class TestSerialPreprocessAction {
 
     @Test
-    public void testLogLineBeginSerialNew() {
+    void testLogLineBeginSerialNew() {
         String logLine = "10.204: [GC 10.204: [DefNew";
         Set<String> context = new HashSet<String>();
         assertTrue(SerialPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".");
@@ -43,7 +43,7 @@ public class TestSerialPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndSerialNew() {
+    void testLogLineEndSerialNew() {
         String logLine = ": 36825K->4352K(39424K), 0.0224830 secs] 44983K->14441K(126848K), 0.0225800 secs]";
         Set<String> context = new HashSet<String>();
         assertTrue(SerialPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".");
@@ -52,7 +52,7 @@ public class TestSerialPreprocessAction {
     }
 
     @Test
-    public void testSerialNewPrintTenuringDistributionPreprocessing() {
+    void testSerialNewPrintTenuringDistributionPreprocessing() {
         File testFile = TestUtil.getFile("dataset17.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestSerialPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestSerialPreprocessAction.java
@@ -12,8 +12,8 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -25,7 +25,7 @@ import org.eclipselabs.garbagecat.service.GcManager;
 import org.eclipselabs.garbagecat.util.Constants;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -37,20 +37,18 @@ public class TestSerialPreprocessAction {
     public void testLogLineBeginSerialNew() {
         String logLine = "10.204: [GC 10.204: [DefNew";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".",
-                SerialPreprocessAction.match(logLine));
+        assertTrue(SerialPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".");
         SerialPreprocessAction event = new SerialPreprocessAction(null, logLine, null, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineEndSerialNew() {
         String logLine = ": 36825K->4352K(39424K), 0.0224830 secs] 44983K->14441K(126848K), 0.0225800 secs]";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".",
-                SerialPreprocessAction.match(logLine));
+        assertTrue(SerialPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SERIAL.toString() + ".");
         SerialPreprocessAction event = new SerialPreprocessAction(null, logLine, null, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -60,8 +58,7 @@ public class TestSerialPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.SERIAL_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.SERIAL_NEW), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestShenandoahPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestShenandoahPreprocessAction.java
@@ -33,549 +33,549 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestShenandoahPreprocessAction {
+class TestShenandoahPreprocessAction {
 
     @Test
-    public void testLogLineUnifiedInitMarkStartUpdateRefsProcessWeakrefs() {
+    void testLogLineUnifiedInitMarkStartUpdateRefsProcessWeakrefs() {
         String logLine = "[41.893s][info][gc,start     ] GC(1500) Pause Init Mark (update refs) (process weakrefs)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitMarkStartUpdateRefs() {
+    void testLogLineUnifiedInitMarkStartUpdateRefs() {
         String logLine = "[41.918s][info][gc,start     ] GC(1501) Pause Init Mark (update refs)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8InitMarkStartProcessWeakrefsUptimeMillis() {
+    void testLogLineJdk8InitMarkStartProcessWeakrefsUptimeMillis() {
         String logLine = "2020-03-11T07:00:00.999-0400: 0.496: [Pause Init Mark (process weakrefs), start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitMarkStartProcessWeakrefsUptimeMillis() {
+    void testLogLineUnifiedInitMarkStartProcessWeakrefsUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Pause Init Mark (process weakrefs)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitMarkStart() {
+    void testLogLineUnifiedInitMarkStart() {
         String logLine = "[69.704s][info][gc,start     ] GC(2583) Pause Init Mark";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitMarkUnloadClasses() {
+    void testLogLineUnifiedInitMarkUnloadClasses() {
         String logLine = "[5.593s][info][gc,start     ] GC(99) Pause Init Mark (unload classes)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedDegeneratedGc() {
+    void testLogLineUnifiedDegeneratedGc() {
         String logLine = "[52.883s][info][gc,start     ] GC(1632) Pause Degenerated GC (Mark)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedDegeneratedGcOutsideOfCycle() {
+    void testLogLineUnifiedDegeneratedGcOutsideOfCycle() {
         String logLine = "[8.061s] GC(136) Pause Degenerated GC (Outside of Cycle)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUsingWorkersInitMark() {
+    void testLogLineUsingWorkersInitMark() {
         String logLine = "    Using 2 of 2 workers for init marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersInitMark() {
+    void testLogLineUnifiedUsingWorkersInitMark() {
         String logLine = "[41.893s][info][gc,task      ] GC(1500) Using 2 of 4 workers for init marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersInitMarkUptimeMillis() {
+    void testLogLineUnifiedUsingWorkersInitMarkUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Using 4 of 4 workers for init marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersDegeneratedGc() {
+    void testLogLineUnifiedUsingWorkersDegeneratedGc() {
         String logLine = "[52.883s][info][gc,task      ] GC(1632) Using 2 of 2 workers for stw degenerated gc";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedGoodProgressFreeSpaceDegeneratedGc() {
+    void testLogLineUnifiedGoodProgressFreeSpaceDegeneratedGc() {
         String logLine = "[52.937s][info][gc,ergo      ] GC(1632) Good progress for free space: 31426K, need 655K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedGoodProgressUsedSpaceDegeneratedGc() {
+    void testLogLineUnifiedGoodProgressUsedSpaceDegeneratedGc() {
         String logLine = "[52.937s][info][gc,ergo      ] GC(1632) Good progress for used space: 31488K, need 256K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLinePacerForMark() {
+    void testLogLinePacerForMark() {
         String logLine = "    Pacer for Mark. Expected Live: 6553K, Free: 44512K, Non-Taxable: 4451K, "
                 + "Alloc Tax Rate: 0.5x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedPacerForMark() {
+    void testLogLineUnifiedPacerForMark() {
         String logLine = "[41.893s][info][gc,ergo      ] GC(1500) Pacer for Mark. Expected Live: 22M, Free: 9M, "
                 + "Non-Taxable: 0M, Alloc Tax Rate: 8.5x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedPacerForMarkUptimeMillis() {
+    void testLogLineUnifiedPacerForMarkUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.178-0200][3090ms] GC(0) Pacer for Mark. Expected Live: 130M, "
                 + "Free: 911M, Non-Taxable: 91M, Alloc Tax Rate: 0.5x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedPacerForMaxkPercent2Digit() {
+    void testLogLineUnifiedPacerForMaxkPercent2Digit() {
         String logLine = "[42.019s][info][gc,ergo      ] GC(1505) Pacer for Mark. Expected Live: 22M, Free: 7M, "
                 + "Non-Taxable: 0M, Alloc Tax Rate: 11.5x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedPacerForMarkPercentInf() {
+    void testLogLineUnifiedPacerForMarkPercentInf() {
         String logLine = "[52.875s][info][gc,ergo      ] GC(1631) Pacer for Mark. Expected Live: 19163K, Free: 0B, "
                 + "Non-Taxable: 0B, Alloc Tax Rate: infx";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8FinalMarkStart() {
+    void testLogLineJdk8FinalMarkStart() {
         String logLine = "2020-03-11T07:00:01.015-0400: 0.512: [Pause Final Mark (process weakrefs), start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkStart() {
+    void testLogLineUnifiedFinalMarkStart() {
         String logLine = "[41.911s][info][gc,start     ] GC(1500) Pause Final Mark (update refs) (process weakrefs)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFinalMarkUsingWorkers() {
+    void testLogLineFinalMarkUsingWorkers() {
         String logLine = "    Using 2 of 2 workers for final marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkUsingWorkers() {
+    void testLogLineUnifiedFinalMarkUsingWorkers() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 2 of 4 workers for final marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFinalMarkAdaptiveCSet() {
+    void testLogLineFinalMarkAdaptiveCSet() {
         String logLine = "    Adaptive CSet Selection. Target Free: 6553K, Actual Free: 52224K, Max CSet: 2730K, Min "
                 + "Garbage: 0B";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkAdaptiveCSet() {
+    void testLogLineUnifiedFinalMarkAdaptiveCSet() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Adaptive CSet Selection. Target Free: 6M, Actual "
                 + "Free: 14M, Max CSet: 2M, Min Garbage: 0M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkAdaptiveCSetUptimeMillis() {
+    void testLogLineUnifiedFinalMarkAdaptiveCSetUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Adaptive CSet Selection. Target Free: 130M, "
                 + "Actual Free: 1084M, Max CSet: 54M, Min Garbage: 0M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFinalMarkCollectableGarbage() {
+    void testLogLineFinalMarkCollectableGarbage() {
         String logLine = "    Collectable Garbage: 6237K (44% of total), 1430K CSet, 30 CSet regions";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFinalMarkCollectableGarbageWithImmediateBlock() {
+    void testLogLineFinalMarkCollectableGarbageWithImmediateBlock() {
         String logLine = "    Collectable Garbage: 30279K (99%), Immediate: 16640K (54%), CSet: 13639K (44%)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkCollectableGarbage() {
+    void testLogLineUnifiedFinalMarkCollectableGarbage() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Collectable Garbage: 5M (18% of total), 0M CSet, "
                 + "21 CSet regions";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkCollectableGarbageUptimeMillis() {
+    void testLogLineUnifiedFinalMarkCollectableGarbageUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Collectable Garbage: 179M (61% of total), "
                 + "23M CSet, 407 CSet regions";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkImmediateGarbage() {
+    void testLogLineUnifiedFinalMarkImmediateGarbage() {
         String logLine = "[2019-02-05T14:47:52.726-0200][21638ms] GC(7) Immediate Garbage: 767M (97% of total), 1537 "
                 + "regions";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkImmediateGarbageUptimeMillis() {
+    void testLogLineUnifiedFinalMarkImmediateGarbageUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Immediate Garbage: 110M (37% of total), "
                 + "230 regions";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFinalMarkPacer() {
+    void testLogLineFinalMarkPacer() {
         String logLine = "    Pacer for Evacuation. Used CSet: 7668K, Free: 49107K, Non-Taxable: 4910K, "
                 + "Alloc Tax Rate: 1.1x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkPacer() {
+    void testLogLineUnifiedFinalMarkPacer() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Pacer for Evacuation. Used CSet: 5M, Free: 18M, "
                 + "Non-Taxable: 1M, Alloc Tax Rate: 1.1x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalMarkPacerUptimeMillis() {
+    void testLogLineUnifiedFinalMarkPacerUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.202-0200][3114ms] GC(0) Pacer for Evacuation. Used CSet: 203M, Free: "
                 + "1023M, Non-Taxable: 102M, Alloc Tax Rate: 1.1x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8FinalEvacStart() {
+    void testLogLineJdk8FinalEvacStart() {
         String logLine = "2020-03-11T07:00:50.985-0400: 50.482: [Pause Final Evac, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalEvacStart() {
+    void testLogLineUnifiedFinalEvacStart() {
         String logLine = "[41.912s][info][gc,start     ] GC(1500) Pause Final Evac";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8InitUpdateStart() {
+    void testLogLineJdk8InitUpdateStart() {
         String logLine = "2020-03-11T07:00:04.771-0400: 4.268: [Pause Init Update Refs, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitUpdateStart() {
+    void testLogLineUnifiedInitUpdateStart() {
         String logLine = "[69.612s][info][gc,start     ] GC(2582) Pause Init Update Refs";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitUpdateStartUptimeMillis() {
+    void testLogLineUnifiedInitUpdateStartUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pause Init Update Refs";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineInitUpdatePacer() {
+    void testLogLineInitUpdatePacer() {
         String logLine = "    Pacer for Update Refs. Used: 15015K, Free: 48702K, Non-Taxable: 4870K, "
                 + "Alloc Tax Rate: 1.1x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitUpdatePacer() {
+    void testLogLineUnifiedInitUpdatePacer() {
         String logLine = "[69.612s][info][gc,ergo      ] GC(2582) Pacer for Update Refs. Used: 49M, Free: 11M, "
                 + "Non-Taxable: 1M, Alloc Tax Rate: 5.4x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedInitUpdatePacerUpdateMillis() {
+    void testLogLineUnifiedInitUpdatePacerUpdateMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pacer for Update Refs. Used: 242M, Free: 1020M, "
                 + "Non-Taxable: 102M, Alloc Tax Rate: 1.1x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8FinalUpdateStart() {
+    void testLogLineJdk8FinalUpdateStart() {
         String logLine = "2020-03-11T07:00:04.856-0400: 4.353: [Pause Final Update Refs, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalUpdateStart() {
+    void testLogLineUnifiedFinalUpdateStart() {
         String logLine = "[69.644s][info][gc,start     ] GC(2582) Pause Final Update Refs";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFinalUpdateUsing() {
+    void testLogLineUnifiedFinalUpdateUsing() {
         String logLine = "[69.644s][info][gc,task      ] GC(2582) Using 2 of 4 workers for final reference update";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUsingWorkersConcurrentReset() {
+    void testLogLineUsingWorkersConcurrentReset() {
         String logLine = "    Using 1 of 2 workers for concurrent reset";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentReset() {
+    void testLogLineUnifiedUsingWorkersConcurrentReset() {
         String logLine = "[41.892s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent reset";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentResetUptimeMillis() {
+    void testLogLineUnifiedUsingWorkersConcurrentResetUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Using 4 of 4 workers for concurrent reset";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentMarking() {
+    void testLogLineUnifiedUsingWorkersConcurrentMarking() {
         String logLine = "[41.893s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent marking";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentPreclean() {
+    void testLogLineUnifiedUsingWorkersConcurrentPreclean() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 1 of 4 workers for concurrent preclean";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentEvacuation() {
+    void testLogLineUnifiedUsingWorkersConcurrentEvacuation() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent evacuation";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingWorkersConcurrentReferenceUpdate() {
+    void testLogLineUnifiedUsingWorkersConcurrentReferenceUpdate() {
         String logLine = "[69.612s][info][gc,task      ] GC(2582) Using 2 of 4 workers for concurrent reference "
                 + "update";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFree() {
+    void testLogLineFree() {
         String logLine = "Free: 48924K (192 regions), Max regular: 256K, Max humongous: 42496K, External frag: 14%, "
                 + "Internal frag: 0%";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFree() {
+    void testLogLineUnifiedFree() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Free: 18M (109 regions), Max regular: 256K, "
                 + "Max humongous: 1280K, External frag: 94%, Internal frag: 33%";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFreeUptimeMillis() {
+    void testLogLineUnifiedFreeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.203-0200][3115ms] GC(0) Free: 1022M (2045 regions), Max regular: 512K, "
                 + "Max humongous: 929280K, External frag: 12%, Internal frag: 0%";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFreeNoGcEventNumber() {
+    void testLogLineUnifiedFreeNoGcEventNumber() {
         String logLine = "[41.912s][info][gc,ergo      ] Free: 18M (109 regions), Max regular: 256K, Max humongous: "
                 + "1280K, External frag: 94%, Internal frag: 33%";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFreeExternalFrag3Digit() {
+    void testLogLineUnifiedFreeExternalFrag3Digit() {
         String logLine = "[42.421s][info][gc,ergo      ] Free: 8M (72 regions), Max regular: 256K, Max humongous: 0K, "
                 + "External frag: 100%, Internal frag: 51%";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedEvacuationReserve() {
+    void testLogLineUnifiedEvacuationReserve() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Evacuation Reserve: 3M (13 regions), "
                 + "Max regular: 256K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedEvacuationReserveUptimeMillis() {
+    void testLogLineUnifiedEvacuationReserveUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.203-0200][3115ms] GC(0) Evacuation Reserve: 65M (131 regions), "
                 + "Max regular: 512K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedEvacuationReserveNoGcEventNumber() {
+    void testLogLineUnifiedEvacuationReserveNoGcEventNumber() {
         String logLine = "[41.912s][info][gc,ergo      ] Evacuation Reserve: 3M (13 regions), Max regular: 256K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedPacerForIdle() {
+    void testLogLineUnifiedPacerForIdle() {
         String logLine = "[41.912s][info][gc,ergo      ] Pacer for Idle. Initial: 1M, Alloc Tax Rate: 1.0x";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFreeHeadroom() {
+    void testLogLineFreeHeadroom() {
         String logLine = "Free headroom: 16207K (free) - 3276K (spike) - 0B (penalties) = 12930K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFreeHeadroom() {
+    void testLogLineUnifiedFreeHeadroom() {
         String logLine = "[41.917s][info][gc,ergo      ] Free headroom: 11M (free) - 3M (spike) - 0M (penalties) = 8M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFreeHeadroomUptimeMillis() {
+    void testLogLineUnifiedFreeHeadroomUptimeMillis() {
         String logLine = "[2019-02-05T14:48:05.666-0200][34578ms] Free headroom: 132M (free) - 65M (spike) - 0M "
                 + "(penalties) = 67M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUncommittedUptimeMillis() {
+    void testLogLineUnifiedUncommittedUptimeMillis() {
         String logLine = "[2019-02-05T14:52:31.138-0200][300050ms] Uncommitted 140M. Heap: 1303M reserved, 1163M "
                 + "committed, 874M used";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedFailedToAllocate() {
+    void testLogLineUnifiedFailedToAllocate() {
         String logLine = "[52.872s][info][gc           ] Failed to allocate 256K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedCancellingGcAllocationFailure() {
+    void testLogLineUnifiedCancellingGcAllocationFailure() {
         String logLine = "[52.872s][info][gc           ] Cancelling GC: Allocation Failure";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedUsingParallel() {
+    void testLogLineUnifiedUsingParallel() {
         String logLine = "[0.003s][info][gc] Using Parallel";
         assertFalse(ShenandoahPreprocessAction.match(logLine), "Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ResetStart() {
+    void testLogLineJdk8ResetStart() {
         String logLine = "2020-03-11T07:00:00.997-0400: 0.494: [Concurrent reset, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8CleanupStart() {
+    void testLogLineJdk8CleanupStart() {
         String logLine = "2020-03-11T07:00:01.020-0400: 0.517: [Concurrent cleanup, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8PrecleaningStart() {
+    void testLogLineJdk8PrecleaningStart() {
         String logLine = "2020-03-11T07:00:01.014-0400: 0.512: [Concurrent precleaning, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8EvacuationStart() {
+    void testLogLineJdk8EvacuationStart() {
         String logLine = "2020-03-11T07:00:01.020-0400: 0.517: [Concurrent evacuation, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8UpdateReferencesStart() {
+    void testLogLineJdk8UpdateReferencesStart() {
         String logLine = "2020-03-11T07:00:01.023-0400: 0.520: [Concurrent update references, start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ConcurrentMarkingProcessWeakrefs() {
+    void testLogLineJdk8ConcurrentMarkingProcessWeakrefs() {
         String logLine = "2020-03-11T07:00:01.007-0400: 0.505: [Concurrent marking (process weakrefs), start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ConcurrentMarkingUpdateRefs() {
+    void testLogLineJdk8ConcurrentMarkingUpdateRefs() {
         String logLine = "2020-03-11T07:00:51.479-0400: 50.976: [Concurrent marking (update refs), start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineJdk8ConcurrentMarkingUpdateRefsProcessWeakrefs() {
+    void testLogLineJdk8ConcurrentMarkingUpdateRefsProcessWeakrefs() {
         String logLine = "2020-03-11T07:02:09.720-0400: 129.217: [Concurrent marking (update refs) (process weakrefs), "
                 + "start]";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineUnifiedConcurrentMarkingUnloadClasses() {
+    void testLogLineUnifiedConcurrentMarkingUnloadClasses() {
         String logLine = "[5.593s][info][gc,start     ] GC(99) Concurrent marking (unload classes)";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLinePacerForReset() {
+    void testLogLinePacerForReset() {
         String logLine = "[2020-06-26T15:30:31.303-0400] GC(0) Pacer for Reset. Non-Taxable: 98304K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLinePacerForResetNoDecorator() {
+    void testLogLinePacerForResetNoDecorator() {
         String logLine = "    Pacer for Reset. Non-Taxable: 128M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLinePacerForPrecleaning() {
+    void testLogLinePacerForPrecleaning() {
         String logLine = "[2020-06-26T15:30:31.311-0400] GC(0) Pacer for Precleaning. Non-Taxable: 98304K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLinePacerForPrecleaningNoDecorator() {
+    void testLogLinePacerForPrecleaningNoDecorator() {
         String logLine = "    Pacer for Precleaning. Non-Taxable: 128M";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineFailedToAllocateTlabNoDecorator() {
+    void testLogLineFailedToAllocateTlabNoDecorator() {
         String logLine = "    Failed to allocate TLAB, 4096K";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineCancellingGcAllocationFailureNoDecorator() {
+    void testLogLineCancellingGcAllocationFailureNoDecorator() {
         String logLine = "    Cancelling GC: Allocation Failure";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineCancellingGcStoppingVmNoDecorator() {
+    void testLogLineCancellingGcStoppingVmNoDecorator() {
         String logLine = "    Cancelling GC: Stopping VM";
         assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
-    public void testLogLineBeginConcurrentMarking() {
+    void testLogLineBeginConcurrentMarking() {
         String logLine = "2020-08-18T14:05:39.789+0000: 854865.439: [Concurrent marking";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -585,7 +585,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndDuration() {
+    void testLogLineEndDuration() {
         String logLine = ", 2714.003 ms]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -595,7 +595,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testLogLineConcurrentCleanup() {
+    void testLogLineConcurrentCleanup() {
         String logLine = "2020-08-21T09:40:29.929-0400: 0.467: [Concurrent cleanup 21278K->4701K(37888K), 0.048 ms]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -605,7 +605,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testLogLineEndMetaspace() {
+    void testLogLineEndMetaspace() {
         String logLine = ", [Metaspace: 6477K->6481K(1056768K)]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
@@ -615,7 +615,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testUnifiedPreprocessingInitialMark() {
+    void testUnifiedPreprocessingInitialMark() {
         File testFile = TestUtil.getFile("dataset160.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -627,7 +627,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testUnifiedPreprocessingFinalMark() {
+    void testUnifiedPreprocessingFinalMark() {
         File testFile = TestUtil.getFile("dataset161.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -639,7 +639,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testUnifiedPreprocessingFinalEvac() {
+    void testUnifiedPreprocessingFinalEvac() {
         File testFile = TestUtil.getFile("dataset162.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -651,7 +651,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testUnifiedPreprocessingInitUpdate() {
+    void testUnifiedPreprocessingInitUpdate() {
         File testFile = TestUtil.getFile("dataset163.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -663,7 +663,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testUnifiedPreprocessingFinalUpdate() {
+    void testUnifiedPreprocessingFinalUpdate() {
         File testFile = TestUtil.getFile("dataset164.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -675,7 +675,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingConcurrent() {
+    void testPreprocessingConcurrent() {
         File testFile = TestUtil.getFile("dataset190.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -687,7 +687,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingConcurrentWithMetaspace() {
+    void testPreprocessingConcurrentWithMetaspace() {
         File testFile = TestUtil.getFile("dataset191.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -699,7 +699,7 @@ public class TestShenandoahPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingConcurrentCancellingGc() {
+    void testPreprocessingConcurrentCancellingGc() {
         File testFile = TestUtil.getFile("dataset194.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestShenandoahPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/TestShenandoahPreprocessAction.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashSet;
@@ -27,7 +27,7 @@ import org.eclipselabs.garbagecat.util.Constants;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -38,625 +38,540 @@ public class TestShenandoahPreprocessAction {
     @Test
     public void testLogLineUnifiedInitMarkStartUpdateRefsProcessWeakrefs() {
         String logLine = "[41.893s][info][gc,start     ] GC(1500) Pause Init Mark (update refs) (process weakrefs)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitMarkStartUpdateRefs() {
         String logLine = "[41.918s][info][gc,start     ] GC(1501) Pause Init Mark (update refs)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8InitMarkStartProcessWeakrefsUptimeMillis() {
         String logLine = "2020-03-11T07:00:00.999-0400: 0.496: [Pause Init Mark (process weakrefs), start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitMarkStartProcessWeakrefsUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Pause Init Mark (process weakrefs)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitMarkStart() {
         String logLine = "[69.704s][info][gc,start     ] GC(2583) Pause Init Mark";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitMarkUnloadClasses() {
         String logLine = "[5.593s][info][gc,start     ] GC(99) Pause Init Mark (unload classes)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedDegeneratedGc() {
         String logLine = "[52.883s][info][gc,start     ] GC(1632) Pause Degenerated GC (Mark)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedDegeneratedGcOutsideOfCycle() {
         String logLine = "[8.061s] GC(136) Pause Degenerated GC (Outside of Cycle)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUsingWorkersInitMark() {
         String logLine = "    Using 2 of 2 workers for init marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersInitMark() {
         String logLine = "[41.893s][info][gc,task      ] GC(1500) Using 2 of 4 workers for init marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersInitMarkUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Using 4 of 4 workers for init marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersDegeneratedGc() {
         String logLine = "[52.883s][info][gc,task      ] GC(1632) Using 2 of 2 workers for stw degenerated gc";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedGoodProgressFreeSpaceDegeneratedGc() {
         String logLine = "[52.937s][info][gc,ergo      ] GC(1632) Good progress for free space: 31426K, need 655K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedGoodProgressUsedSpaceDegeneratedGc() {
         String logLine = "[52.937s][info][gc,ergo      ] GC(1632) Good progress for used space: 31488K, need 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLinePacerForMark() {
         String logLine = "    Pacer for Mark. Expected Live: 6553K, Free: 44512K, Non-Taxable: 4451K, "
                 + "Alloc Tax Rate: 0.5x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedPacerForMark() {
         String logLine = "[41.893s][info][gc,ergo      ] GC(1500) Pacer for Mark. Expected Live: 22M, Free: 9M, "
                 + "Non-Taxable: 0M, Alloc Tax Rate: 8.5x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedPacerForMarkUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.178-0200][3090ms] GC(0) Pacer for Mark. Expected Live: 130M, "
                 + "Free: 911M, Non-Taxable: 91M, Alloc Tax Rate: 0.5x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedPacerForMaxkPercent2Digit() {
         String logLine = "[42.019s][info][gc,ergo      ] GC(1505) Pacer for Mark. Expected Live: 22M, Free: 7M, "
                 + "Non-Taxable: 0M, Alloc Tax Rate: 11.5x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedPacerForMarkPercentInf() {
         String logLine = "[52.875s][info][gc,ergo      ] GC(1631) Pacer for Mark. Expected Live: 19163K, Free: 0B, "
                 + "Non-Taxable: 0B, Alloc Tax Rate: infx";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8FinalMarkStart() {
         String logLine = "2020-03-11T07:00:01.015-0400: 0.512: [Pause Final Mark (process weakrefs), start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkStart() {
         String logLine = "[41.911s][info][gc,start     ] GC(1500) Pause Final Mark (update refs) (process weakrefs)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFinalMarkUsingWorkers() {
         String logLine = "    Using 2 of 2 workers for final marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkUsingWorkers() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 2 of 4 workers for final marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFinalMarkAdaptiveCSet() {
         String logLine = "    Adaptive CSet Selection. Target Free: 6553K, Actual Free: 52224K, Max CSet: 2730K, Min "
                 + "Garbage: 0B";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkAdaptiveCSet() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Adaptive CSet Selection. Target Free: 6M, Actual "
                 + "Free: 14M, Max CSet: 2M, Min Garbage: 0M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkAdaptiveCSetUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Adaptive CSet Selection. Target Free: 130M, "
                 + "Actual Free: 1084M, Max CSet: 54M, Min Garbage: 0M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFinalMarkCollectableGarbage() {
         String logLine = "    Collectable Garbage: 6237K (44% of total), 1430K CSet, 30 CSet regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFinalMarkCollectableGarbageWithImmediateBlock() {
         String logLine = "    Collectable Garbage: 30279K (99%), Immediate: 16640K (54%), CSet: 13639K (44%)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkCollectableGarbage() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Collectable Garbage: 5M (18% of total), 0M CSet, "
                 + "21 CSet regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkCollectableGarbageUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Collectable Garbage: 179M (61% of total), "
                 + "23M CSet, 407 CSet regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkImmediateGarbage() {
         String logLine = "[2019-02-05T14:47:52.726-0200][21638ms] GC(7) Immediate Garbage: 767M (97% of total), 1537 "
                 + "regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkImmediateGarbageUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.201-0200][3113ms] GC(0) Immediate Garbage: 110M (37% of total), "
                 + "230 regions";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFinalMarkPacer() {
         String logLine = "    Pacer for Evacuation. Used CSet: 7668K, Free: 49107K, Non-Taxable: 4910K, "
                 + "Alloc Tax Rate: 1.1x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkPacer() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Pacer for Evacuation. Used CSet: 5M, Free: 18M, "
                 + "Non-Taxable: 1M, Alloc Tax Rate: 1.1x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalMarkPacerUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.202-0200][3114ms] GC(0) Pacer for Evacuation. Used CSet: 203M, Free: "
                 + "1023M, Non-Taxable: 102M, Alloc Tax Rate: 1.1x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8FinalEvacStart() {
         String logLine = "2020-03-11T07:00:50.985-0400: 50.482: [Pause Final Evac, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalEvacStart() {
         String logLine = "[41.912s][info][gc,start     ] GC(1500) Pause Final Evac";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8InitUpdateStart() {
         String logLine = "2020-03-11T07:00:04.771-0400: 4.268: [Pause Init Update Refs, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitUpdateStart() {
         String logLine = "[69.612s][info][gc,start     ] GC(2582) Pause Init Update Refs";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitUpdateStartUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pause Init Update Refs";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineInitUpdatePacer() {
         String logLine = "    Pacer for Update Refs. Used: 15015K, Free: 48702K, Non-Taxable: 4870K, "
                 + "Alloc Tax Rate: 1.1x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitUpdatePacer() {
         String logLine = "[69.612s][info][gc,ergo      ] GC(2582) Pacer for Update Refs. Used: 49M, Free: 11M, "
                 + "Non-Taxable: 1M, Alloc Tax Rate: 5.4x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedInitUpdatePacerUpdateMillis() {
         String logLine = "[2019-02-05T14:47:34.229-0200][3141ms] GC(0) Pacer for Update Refs. Used: 242M, Free: 1020M, "
                 + "Non-Taxable: 102M, Alloc Tax Rate: 1.1x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8FinalUpdateStart() {
         String logLine = "2020-03-11T07:00:04.856-0400: 4.353: [Pause Final Update Refs, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalUpdateStart() {
         String logLine = "[69.644s][info][gc,start     ] GC(2582) Pause Final Update Refs";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFinalUpdateUsing() {
         String logLine = "[69.644s][info][gc,task      ] GC(2582) Using 2 of 4 workers for final reference update";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUsingWorkersConcurrentReset() {
         String logLine = "    Using 1 of 2 workers for concurrent reset";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentReset() {
         String logLine = "[41.892s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent reset";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentResetUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.175-0200][3087ms] GC(0) Using 4 of 4 workers for concurrent reset";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentMarking() {
         String logLine = "[41.893s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentPreclean() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 1 of 4 workers for concurrent preclean";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentEvacuation() {
         String logLine = "[41.911s][info][gc,task      ] GC(1500) Using 2 of 4 workers for concurrent evacuation";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingWorkersConcurrentReferenceUpdate() {
         String logLine = "[69.612s][info][gc,task      ] GC(2582) Using 2 of 4 workers for concurrent reference "
                 + "update";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFree() {
         String logLine = "Free: 48924K (192 regions), Max regular: 256K, Max humongous: 42496K, External frag: 14%, "
                 + "Internal frag: 0%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFree() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Free: 18M (109 regions), Max regular: 256K, "
                 + "Max humongous: 1280K, External frag: 94%, Internal frag: 33%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFreeUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.203-0200][3115ms] GC(0) Free: 1022M (2045 regions), Max regular: 512K, "
                 + "Max humongous: 929280K, External frag: 12%, Internal frag: 0%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFreeNoGcEventNumber() {
         String logLine = "[41.912s][info][gc,ergo      ] Free: 18M (109 regions), Max regular: 256K, Max humongous: "
                 + "1280K, External frag: 94%, Internal frag: 33%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFreeExternalFrag3Digit() {
         String logLine = "[42.421s][info][gc,ergo      ] Free: 8M (72 regions), Max regular: 256K, Max humongous: 0K, "
                 + "External frag: 100%, Internal frag: 51%";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedEvacuationReserve() {
         String logLine = "[41.911s][info][gc,ergo      ] GC(1500) Evacuation Reserve: 3M (13 regions), "
                 + "Max regular: 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedEvacuationReserveUptimeMillis() {
         String logLine = "[2019-02-05T14:47:34.203-0200][3115ms] GC(0) Evacuation Reserve: 65M (131 regions), "
                 + "Max regular: 512K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedEvacuationReserveNoGcEventNumber() {
         String logLine = "[41.912s][info][gc,ergo      ] Evacuation Reserve: 3M (13 regions), Max regular: 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedPacerForIdle() {
         String logLine = "[41.912s][info][gc,ergo      ] Pacer for Idle. Initial: 1M, Alloc Tax Rate: 1.0x";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFreeHeadroom() {
         String logLine = "Free headroom: 16207K (free) - 3276K (spike) - 0B (penalties) = 12930K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFreeHeadroom() {
         String logLine = "[41.917s][info][gc,ergo      ] Free headroom: 11M (free) - 3M (spike) - 0M (penalties) = 8M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFreeHeadroomUptimeMillis() {
         String logLine = "[2019-02-05T14:48:05.666-0200][34578ms] Free headroom: 132M (free) - 65M (spike) - 0M "
                 + "(penalties) = 67M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUncommittedUptimeMillis() {
         String logLine = "[2019-02-05T14:52:31.138-0200][300050ms] Uncommitted 140M. Heap: 1303M reserved, 1163M "
                 + "committed, 874M used";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedFailedToAllocate() {
         String logLine = "[52.872s][info][gc           ] Failed to allocate 256K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedCancellingGcAllocationFailure() {
         String logLine = "[52.872s][info][gc           ] Cancelling GC: Allocation Failure";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedUsingParallel() {
         String logLine = "[0.003s][info][gc] Using Parallel";
-        assertFalse("Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertFalse(ShenandoahPreprocessAction.match(logLine), "Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ResetStart() {
         String logLine = "2020-03-11T07:00:00.997-0400: 0.494: [Concurrent reset, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8CleanupStart() {
         String logLine = "2020-03-11T07:00:01.020-0400: 0.517: [Concurrent cleanup, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8PrecleaningStart() {
         String logLine = "2020-03-11T07:00:01.014-0400: 0.512: [Concurrent precleaning, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8EvacuationStart() {
         String logLine = "2020-03-11T07:00:01.020-0400: 0.517: [Concurrent evacuation, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8UpdateReferencesStart() {
         String logLine = "2020-03-11T07:00:01.023-0400: 0.520: [Concurrent update references, start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ConcurrentMarkingProcessWeakrefs() {
         String logLine = "2020-03-11T07:00:01.007-0400: 0.505: [Concurrent marking (process weakrefs), start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ConcurrentMarkingUpdateRefs() {
         String logLine = "2020-03-11T07:00:51.479-0400: 50.976: [Concurrent marking (update refs), start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineJdk8ConcurrentMarkingUpdateRefsProcessWeakrefs() {
         String logLine = "2020-03-11T07:02:09.720-0400: 129.217: [Concurrent marking (update refs) (process weakrefs), "
                 + "start]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineUnifiedConcurrentMarkingUnloadClasses() {
         String logLine = "[5.593s][info][gc,start     ] GC(99) Concurrent marking (unload classes)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLinePacerForReset() {
         String logLine = "[2020-06-26T15:30:31.303-0400] GC(0) Pacer for Reset. Non-Taxable: 98304K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLinePacerForResetNoDecorator() {
         String logLine = "    Pacer for Reset. Non-Taxable: 128M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLinePacerForPrecleaning() {
         String logLine = "[2020-06-26T15:30:31.311-0400] GC(0) Pacer for Precleaning. Non-Taxable: 98304K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLinePacerForPrecleaningNoDecorator() {
         String logLine = "    Pacer for Precleaning. Non-Taxable: 128M";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineFailedToAllocateTlabNoDecorator() {
         String logLine = "    Failed to allocate TLAB, 4096K";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineCancellingGcAllocationFailureNoDecorator() {
         String logLine = "    Cancelling GC: Allocation Failure";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
     public void testLogLineCancellingGcStoppingVmNoDecorator() {
         String logLine = "    Cancelling GC: Stopping VM";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
     }
 
     @Test
@@ -664,10 +579,9 @@ public class TestShenandoahPreprocessAction {
         String logLine = "2020-08-18T14:05:39.789+0000: 854865.439: [Concurrent marking";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
         ShenandoahPreprocessAction event = new ShenandoahPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -675,10 +589,9 @@ public class TestShenandoahPreprocessAction {
         String logLine = ", 2714.003 ms]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
         ShenandoahPreprocessAction event = new ShenandoahPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -686,10 +599,9 @@ public class TestShenandoahPreprocessAction {
         String logLine = "2020-08-21T09:40:29.929-0400: 0.467: [Concurrent cleanup 21278K->4701K(37888K), 0.048 ms]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
         ShenandoahPreprocessAction event = new ShenandoahPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -697,10 +609,9 @@ public class TestShenandoahPreprocessAction {
         String logLine = ", [Metaspace: 6477K->6481K(1056768K)]";
         String nextLogLine = null;
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".",
-                ShenandoahPreprocessAction.match(logLine));
+        assertTrue(ShenandoahPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.SHENANDOAH.toString() + ".");
         ShenandoahPreprocessAction event = new ShenandoahPreprocessAction(null, logLine, nextLogLine, null, context);
-        assertEquals("Log line not parsed correctly.", logLine, event.getLogEntry());
+        assertEquals(logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -710,11 +621,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_INIT_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_INIT_MARK), JdkUtil.LogEventType.SHENANDOAH_INIT_MARK.toString() + " collector not identified.");
     }
 
     @Test
@@ -724,11 +633,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_MARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_MARK), JdkUtil.LogEventType.SHENANDOAH_FINAL_MARK.toString() + " collector not identified.");
     }
 
     @Test
@@ -738,11 +645,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_EVAC));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_EVAC), JdkUtil.LogEventType.SHENANDOAH_FINAL_EVAC.toString() + " collector not identified.");
     }
 
     @Test
@@ -752,11 +657,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_INIT_UPDATE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_INIT_UPDATE), JdkUtil.LogEventType.SHENANDOAH_INIT_UPDATE.toString() + " collector not identified.");
     }
 
     @Test
@@ -766,11 +669,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_UPDATE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_FINAL_UPDATE), JdkUtil.LogEventType.SHENANDOAH_FINAL_UPDATE.toString() + " collector not identified.");
     }
 
     @Test
@@ -780,11 +681,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.");
     }
 
     @Test
@@ -794,11 +693,9 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.");
     }
 
     @Test
@@ -808,10 +705,8 @@ public class TestShenandoahPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.SHENANDOAH_CONCURRENT), JdkUtil.LogEventType.SHENANDOAH_CONCURRENT.toString() + " collector not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/TestUnifiedPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/TestUnifiedPreprocessAction.java
@@ -12,10 +12,10 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk.unified;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.PreprocessActionType;
 import org.eclipselabs.garbagecat.util.jdk.Jvm;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -43,64 +43,55 @@ public class TestUnifiedPreprocessAction {
     @Test
     public void testLogLinePauseYoungStart() {
         String logLine = "[0.112s][info][gc,start       ] GC(3) Pause Young (Allocation Failure)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseMarkStart() {
         String logLine = "[4.057s][info][gc,phases,start] GC(2264) Phase 1: Mark live objects";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseMark() {
         String logLine = "[4.062s][info][gc,phases      ] GC(2264) Phase 1: Mark live objects 4.352ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseComputeStart() {
         String logLine = "[4.062s][info][gc,phases,start] GC(2264) Phase 2: Compute new object addresses";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseCompute() {
         String logLine = "[4.063s][info][gc,phases      ] GC(2264) Phase 2: Compute new object addresses 1.165ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseAdjustStart() {
         String logLine = "[4.063s][info][gc,phases,start] GC(2264) Phase 3: Adjust pointers";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseAdjust() {
         String logLine = "[4.065s][info][gc,phases      ] GC(2264) Phase 3: Adjust pointers 2.453ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseMoveStart() {
         String logLine = "[4.065s][info][gc,phases,start] GC(2264) Phase 4: Move objects";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLinePhaseMove() {
         String logLine = "[4.067s][info][gc,phases      ] GC(2264) Phase 4: Move objects 1.248ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -108,12 +99,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.112s][info][gc,heap        ] GC(3) DefNew: 1016K->128K(1152K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " DefNew: 1016K->128K(1152K)", event.getLogEntry());
+        assertEquals(" DefNew: 1016K->128K(1152K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -121,12 +111,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[32.636s][info][gc,heap        ] GC(9239) Tenured: 24193K->24195K(25240K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " Tenured: 24193K->24195K(25240K)", event.getLogEntry());
+        assertEquals(" Tenured: 24193K->24195K(25240K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -134,12 +123,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.032s][info][gc,heap      ] GC(0) PSYoungGen: 512K->464K(1024K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " PSYoungGen: 512K->464K(1024K)", event.getLogEntry());
+        assertEquals(" PSYoungGen: 512K->464K(1024K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -147,12 +135,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.053s][info][gc,heap      ] GC(0) ParNew: 974K->128K(1152K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " ParNew: 974K->128K(1152K)", event.getLogEntry());
+        assertEquals(" ParNew: 974K->128K(1152K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -160,12 +147,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.053s][info][gc,heap      ] GC(0) CMS: 0K->518K(960K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " CMS: 0K->518K(960K)", event.getLogEntry());
+        assertEquals(" CMS: 0K->518K(960K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -173,12 +159,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.032s][info][gc,heap      ] GC(0) PSOldGen: 0K->8K(512K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " PSOldGen: 0K->8K(512K)", event.getLogEntry());
+        assertEquals(" PSOldGen: 0K->8K(512K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -186,19 +171,17 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.032s][info][gc,metaspace ] GC(0) Metaspace: 120K->120K(1056768K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " Metaspace: 120K->120K(1056768K)", event.getLogEntry());
+        assertEquals(" Metaspace: 120K->120K(1056768K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineMetaspace2Spaces() {
         String logLine = "[16.072s][info][gc,metaspace  ] GC(971) Metaspace: 10793K->10793K(1058816K)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -206,19 +189,17 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.030s][info][gc,heap      ] GC(0) ParOldGen: 0K->8K(512K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " ParOldGen: 0K->8K(512K)", event.getLogEntry());
+        assertEquals(" ParOldGen: 0K->8K(512K)",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineMetaspaceDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Metaspace: 26116K->26116K(278528K)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -228,12 +209,11 @@ public class TestUnifiedPreprocessAction {
         Set<String> context = new HashSet<String>();
         context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
         context.add(UnifiedPreprocessAction.TOKEN);
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 1M->1M(2M) 0.700ms", event.getLogEntry());
+        assertEquals(" 1M->1M(2M) 0.700ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -242,12 +222,11 @@ public class TestUnifiedPreprocessAction {
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
         context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", Constants.LINE_SEPARATOR + logLine, event.getLogEntry());
+        assertEquals(Constants.LINE_SEPARATOR + logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -255,12 +234,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.337s][info][gc           ] GC(0) Pause Young (G1 Evacuation Pause) 25M->4M(254M) 3.523ms";
         String nextLogLine = "[0.337s][info][gc,cpu       ] GC(0) User=0.00s Sys=0.00s Real=0.00s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 25M->4M(254M) 3.523ms", event.getLogEntry());
+        assertEquals(" 25M->4M(254M) 3.523ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -269,12 +247,11 @@ public class TestUnifiedPreprocessAction {
                 + "15M->12M(31M) 1.202ms";
         String nextLogLine = "[16.630s][info][gc           ] GC(0) User=0.18s Sys=0.00s Real=0.11s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 15M->12M(31M) 1.202ms", event.getLogEntry());
+        assertEquals(" 15M->12M(31M) 1.202ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -283,12 +260,11 @@ public class TestUnifiedPreprocessAction {
                 + "65M->8M(1304M) 57.263ms";
         String nextLogLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) User=0.02s Sys=0.01s Real=0.06s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 65M->8M(1304M) 57.263ms", event.getLogEntry());
+        assertEquals(" 65M->8M(1304M) 57.263ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -297,19 +273,17 @@ public class TestUnifiedPreprocessAction {
                 + "78M->22M(1304M) 35.722ms";
         String nextLogLine = "[2019-05-09T01:39:07.172+0000][11764ms] GC(3) User=0.02s Sys=0.00s Real=0.04s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 78M->22M(1304M) 35.722ms", event.getLogEntry());
+        assertEquals(" 78M->22M(1304M) 35.722ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLinePauseYoungInfo11SpacesAfterGc() {
         String logLine = "[0.032s][info][gc           ] GC(0) Pause Young (Allocation Failure) 0M->0M(1M) 1.195ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -318,12 +292,11 @@ public class TestUnifiedPreprocessAction {
                 + "(Metadata GC Threshold) 733M->588M(1223M) 105.541ms";
         String nextLogLine = "[2020-06-24T18:11:52.781-0700][58776ms] GC(44) User=0.18s Sys=0.00s Real=0.11s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 733M->588M(1223M) 105.541ms", event.getLogEntry());
+        assertEquals(" 733M->588M(1223M) 105.541ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -332,12 +305,11 @@ public class TestUnifiedPreprocessAction {
                 + "(G1 Humongous Allocation) 882M->842M(1223M) 19.777ms";
         String nextLogLine = "[2020-06-24T19:24:56.395-0700][4442390ms] GC(126) User=0.04s Sys=0.00s Real=0.02s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 882M->842M(1223M) 19.777ms", event.getLogEntry());
+        assertEquals(" 882M->842M(1223M) 19.777ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -345,484 +317,417 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.112s][info][gc,cpu         ] GC(3) User=0.00s Sys=0.00s Real=0.00s";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " User=0.00s Sys=0.00s Real=0.00s", event.getLogEntry());
+        assertEquals(" User=0.00s Sys=0.00s Real=0.00s",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineTimesData8Spaces() {
         String logLine = "[16.053s][info][gc,cpu        ] GC(969) User=0.01s Sys=0.00s Real=0.00s";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineTimesDataDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) User=0.02s Sys=0.01s Real=0.06s";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNormal() {
         String logLine = "[0.099s][info][gc,start     ] GC(0) Pause Young (Normal) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNormal6Spaces() {
         String logLine = "[16.070s][info][gc,start      ] GC(971) Pause Young (Normal) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPrepareMixed() {
         String logLine = "[15.108s][info][gc,start      ] GC(1194) Pause Young (Prepare Mixed) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1MixedPause() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseConcurrentStart() {
         String logLine = "[16.600s][info][gc,start     ] GC(1032) Pause Young (Concurrent Start) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNoQualifier() {
         String logLine = "[0.333s][info][gc,start     ] GC(0) Pause Young (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNormalDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNormalTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.136+0000][11728ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineStartG1YoungPauseNormalMillis8Digits() {
         String logLine = "[2019-05-09T04:31:19.449+0000][10344041ms] GC(9) Pause Young (Normal) (G1 Evacuation Pause)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1UsingWorkersForEvacuation() {
         String logLine = "[0.100s][info][gc,task      ] GC(0) Using 2 workers of 4 for evacuation";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1UsingWorkersForEvacuation2Digits() {
         String logLine = "[0.333s][info][gc,task      ] GC(0) Using 10 workers of 10 for evacuation";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1UsingWorkersForEvacuation7Spaces() {
         String logLine = "[16.070s][info][gc,task       ] GC(971) Using 2 workers of 4 for evacuation";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1UsingWorkersForEvacuationDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Using 1 workers of 1 for evacuation";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1UsingWorkersForMarking() {
         String logLine = "[16.121s][info][gc,task       ] GC(974) Using 1 workers of 1 for marking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PreEvacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Pre Evacuate Collection Set: 0.0ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PreEvacuate5Spaces() {
         String logLine = "[16.071s][info][gc,phases     ] GC(971)   Pre Evacuate Collection Set: 0.0ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PreEvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Pre Evacuate Collection Set: 0.0ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Evacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Evacuate Collection Set: 1.0ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1EvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Evacuate Collection Set: 56.4ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PostEvacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Post Evacuate Collection Set: 0.2ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PostEvacuate5Spaces() {
         String logLine = "[16.072s][info][gc,phases     ] GC(971)   Post Evacuate Collection Set: 0.1ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PostEvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Post Evacuate Collection Set: 0.5ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Other() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Other: 0.2ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1OtherDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Other: 0.3ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Other5Spaces() {
         String logLine = "[16.072s][info][gc,phases     ] GC(971)   Other: 0.1ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Eden() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Eden regions: 1->0(1)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Eden3Digits() {
         String logLine = "[0.335s][info][gc,heap      ] GC(0) Eden regions: 24->0(149)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1EdenDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Eden regions: 65->0(56)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1EdenDatestampMillisRegions4Digits() {
         String logLine = "[2020-09-11T05:33:44.563+0000][1732868ms] GC(42) Eden regions: 307->0(1659)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Survivor() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Survivor regions: 0->1(1)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1SurvivorDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Survivor regions: 0->9(9)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Old() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Old regions: 0->0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Old2Digits() {
         String logLine = "[10.989s][info][gc,heap      ] GC(684) Old regions: 15->15";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Old7Spaces() {
         String logLine = "[17.728s][info][gc,heap       ] GC(1098) Old regions: 21->21";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1OldDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Old regions: 0->0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Humongous() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Humongous regions: 0->0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1HumongousDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Humongous regions: 0->0";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungPauseNormal() {
         String logLine = "[0.101s][info][gc           ] GC(0) Pause Young (Normal) "
                 + "(G1 Evacuation Pause) 0M->0M(2M) 1.371ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungPauseNormalDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "65M->8M(1304M) 57.263ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungPauseNormalTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.172+0000][11764ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC) "
                 + "78M->22M(1304M) 35.722ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1YoungPauseConcurrentStart() {
         String logLine = "[16.601s][info][gc           ] GC(1032) Pause Young (Concurrent Start) "
                 + "(G1 Evacuation Pause) 38M->20M(46M) 0.772ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogG1LineRemark() {
         String logLine = "[16.051s][info][gc,start     ] GC(969) Pause Remark";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1Remark6Spaces() {
         String logLine = "[16.175s][info][gc,start      ] GC(974) Pause Remark";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1StringTable() {
         String logLine = "[16.053s][info][gc,stringtable] GC(969) Cleaned string and symbol table, strings: "
                 + "5786 processed, 4 removed, symbols: 38663 processed, 11 removed";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1StringTableLargeNumbers() {
         String logLine = "[2020-06-24T18:15:29.817-0700][275812ms] GC(93) Cleaned string and symbol table, strings: "
                 + "94127 processed, 27 removed, symbols: 437573 processed, 2702 removed";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1StringTableRemoved5Digits() {
         String logLine = "[2020-09-11T08:23:37.353+0000][11925659ms] GC(194) Cleaned string and symbol table, "
                 + "strings: 368294 processed, 9531 removed, symbols: 1054532 processed, 18545 removed";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1PauseCleanup() {
         String logLine = "[16.081s][info][gc,start      ] GC(969) Pause Cleanup";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1MarkClosedArchiveRegions() {
         String logLine = "[0.004s][info][gc,cds       ] Mark closed archive regions in map: [0x00000000fff00000, "
                 + "0x00000000fff69ff8]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1MarkOpenArchiveRegions() {
         String logLine = "[0.004s][info][gc,cds       ] Mark open archive regions in map: [0x00000000ffe00000, "
                 + "0x00000000ffe46ff8]";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineG1MmuTargetViolated() {
         String logLine = "[2020-06-24T18:11:22.155-0700][28150ms] GC(24) MMU target violated: 201.0ms "
                 + "(200.0ms/201.0ms)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSerialNewStart() {
         String logLine = "[0.118s][info][gc,start       ] GC(4) Pause Young (Allocation Failure)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSerialOldStart() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSerialOldStart7SpacesAfterStart() {
         String logLine = "[0.119s][info][gc,start       ] GC(5) Pause Full (Allocation Failure)";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSerialOldInfo() {
         String logLine = "[0.076s][info][gc             ] GC(2) Pause Full (Allocation Failure) 0M->0M(2M) 1.699ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldMarkingPhaseStart() {
         String logLine = "[0.083s][info][gc,phases,start] GC(3) Marking Phase";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldMarkingPhase() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Marking Phase 1.032ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOlSummaryPhaseStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Summary Phase";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldSummaryPhase() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Summary Phase 0.005ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldAdjustRootsStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Adjust Roots";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldAdjustRoots() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Adjust Roots 0.666ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldCompactionPhaseStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Compaction Phase";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldCompactionPhase() {
         String logLine = "[0.087s][info][gc,phases      ] GC(3) Compaction Phase 2.540ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldPostStart() {
         String logLine = "[0.087s][info][gc,phases,start] GC(3) Post Compact";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineParallelCompactingOldPostCompact() {
         String logLine = "[0.087s][info][gc,phases      ] GC(3) Post Compact 0.012ms";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -830,12 +735,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.092s][info][gc             ] GC(3) Pause Full (Ergonomics) 0M->0M(3M) 1.849ms";
         String nextLogLine = "[0.092s][info][gc,cpu         ] GC(3) User=0.01s Sys=0.00s Real=0.00s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 0M->0M(3M) 1.849ms", event.getLogEntry());
+        assertEquals(" 0M->0M(3M) 1.849ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -844,12 +748,11 @@ public class TestUnifiedPreprocessAction {
                 + "3460.196ms";
         String nextLogLine = "[2020-06-24T18:13:51.155-0700][177150ms] GC(74) User=1.78s Sys=0.01s Real=3.46s";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", " 887M->583M(1223M) 3460.196ms", event.getLogEntry());
+        assertEquals(" 887M->583M(1223M) 3460.196ms",event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -857,19 +760,17 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[1.507s][info][gc] GC(77) Pause Young (Allocation Failure) 24M->4M(25M) 0.509ms";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertEquals("Log line not parsed correctly.", Constants.LINE_SEPARATOR + logLine, event.getLogEntry());
+        assertEquals(Constants.LINE_SEPARATOR + logLine,event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineUsingParallel() {
         String logLine = "[0.003s][info][gc] Using Parallel";
-        assertFalse("Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertFalse(UnifiedPreprocessAction.match(logLine), "Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -877,12 +778,11 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.053s][info][gc,start     ] GC(1) Pause Initial Mark";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertNull("Log line not parsed correctly.", event.getLogEntry());
+        assertNull(event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
@@ -890,33 +790,29 @@ public class TestUnifiedPreprocessAction {
         String logLine = "[0.056s][info][gc,heap      ] GC(1) Old: 518K->518K(960K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
-        assertTrue("Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + PreprocessActionType.UNIFIED.toString() + ".");
         List<String> entangledLogLines = new ArrayList<String>();
         UnifiedPreprocessAction event = new UnifiedPreprocessAction(null, logLine, nextLogLine, entangledLogLines,
                 context);
-        assertNull("Log line not parsed correctly.", event.getLogEntry());
+        assertNull(event.getLogEntry(),"Log line not parsed correctly.");
     }
 
     @Test
     public void testLogLineSafepointEnteringl() {
         String logLine = "[0.029s][info][safepoint    ] Entering safepoint region: EnableBiasedLocking";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSafepointLeaving() {
         String logLine = "[0.029s][info][safepoint    ] Leaving safepoint region";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
     public void testLogLineSafepointApplicationTime() {
         String logLine = "[0.030s][info][safepoint    ] Application time: 0.0012757 seconds";
-        assertTrue("Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".",
-                UnifiedPreprocessAction.match(logLine));
+        assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
@@ -926,11 +822,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 
     @Test
@@ -940,11 +834,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.");
     }
 
     @Test
@@ -954,11 +846,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_CLEANUP));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_CLEANUP), JdkUtil.LogEventType.UNIFIED_G1_CLEANUP.toString() + " collector not identified.");
     }
 
     @Test
@@ -968,11 +858,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 
     @Test
@@ -982,11 +870,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_NEW), JdkUtil.LogEventType.UNIFIED_SERIAL_NEW.toString() + " collector not identified.");
     }
 
     @Test
@@ -996,11 +882,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_OLD), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " collector not identified.");
     }
 
     @Test
@@ -1010,11 +894,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_SERIAL_OLD), JdkUtil.LogEventType.UNIFIED_SERIAL_OLD.toString() + " collector not identified.");
     }
 
     @Test
@@ -1024,11 +906,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_SCAVENGE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_SCAVENGE), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " collector not identified.");
     }
 
     @Test
@@ -1038,11 +918,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_SCAVENGE));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_SCAVENGE), JdkUtil.LogEventType.UNIFIED_PARALLEL_SCAVENGE.toString() + " collector not identified.");
     }
 
     @Test
@@ -1052,11 +930,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD), JdkUtil.LogEventType.UNIFIED_PARALLEL_COMPACTING_OLD.toString() + " collector not identified.");
     }
 
     @Test
@@ -1066,11 +942,9 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PAR_NEW));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PAR_NEW), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " collector not identified.");
     }
 
     @Test
@@ -1080,17 +954,12 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 4, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CMS_INITIAL_MARK));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CONCURRENT));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PAR_NEW));
+        assertEquals(4,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CMS_INITIAL_MARK), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_CONCURRENT), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_REMARK), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " collector not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_PAR_NEW), JdkUtil.LogEventType.UNIFIED_PAR_NEW.toString() + " collector not identified.");
     }
 
     /**
@@ -1103,10 +972,8 @@ public class TestUnifiedPreprocessAction {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue(JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.UNIFIED_G1_YOUNG_PAUSE), JdkUtil.LogEventType.UNIFIED_G1_YOUNG_PAUSE.toString() + " collector not identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/TestUnifiedPreprocessAction.java
+++ b/src/test/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/TestUnifiedPreprocessAction.java
@@ -38,64 +38,64 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedPreprocessAction {
+class TestUnifiedPreprocessAction {
 
     @Test
-    public void testLogLinePauseYoungStart() {
+    void testLogLinePauseYoungStart() {
         String logLine = "[0.112s][info][gc,start       ] GC(3) Pause Young (Allocation Failure)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseMarkStart() {
+    void testLogLinePhaseMarkStart() {
         String logLine = "[4.057s][info][gc,phases,start] GC(2264) Phase 1: Mark live objects";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseMark() {
+    void testLogLinePhaseMark() {
         String logLine = "[4.062s][info][gc,phases      ] GC(2264) Phase 1: Mark live objects 4.352ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseComputeStart() {
+    void testLogLinePhaseComputeStart() {
         String logLine = "[4.062s][info][gc,phases,start] GC(2264) Phase 2: Compute new object addresses";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseCompute() {
+    void testLogLinePhaseCompute() {
         String logLine = "[4.063s][info][gc,phases      ] GC(2264) Phase 2: Compute new object addresses 1.165ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseAdjustStart() {
+    void testLogLinePhaseAdjustStart() {
         String logLine = "[4.063s][info][gc,phases,start] GC(2264) Phase 3: Adjust pointers";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseAdjust() {
+    void testLogLinePhaseAdjust() {
         String logLine = "[4.065s][info][gc,phases      ] GC(2264) Phase 3: Adjust pointers 2.453ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseMoveStart() {
+    void testLogLinePhaseMoveStart() {
         String logLine = "[4.065s][info][gc,phases,start] GC(2264) Phase 4: Move objects";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePhaseMove() {
+    void testLogLinePhaseMove() {
         String logLine = "[4.067s][info][gc,phases      ] GC(2264) Phase 4: Move objects 1.248ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineDefNewData() {
+    void testLogLineDefNewData() {
         String logLine = "[0.112s][info][gc,heap        ] GC(3) DefNew: 1016K->128K(1152K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -107,7 +107,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineTenuredData() {
+    void testLogLineTenuredData() {
         String logLine = "[32.636s][info][gc,heap        ] GC(9239) Tenured: 24193K->24195K(25240K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -119,7 +119,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePsYoungGenData() {
+    void testLogLinePsYoungGenData() {
         String logLine = "[0.032s][info][gc,heap      ] GC(0) PSYoungGen: 512K->464K(1024K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -131,7 +131,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineParNewData() {
+    void testLogLineParNewData() {
         String logLine = "[0.053s][info][gc,heap      ] GC(0) ParNew: 974K->128K(1152K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -143,7 +143,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsData() {
+    void testLogLineCmsData() {
         String logLine = "[0.053s][info][gc,heap      ] GC(0) CMS: 0K->518K(960K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -155,7 +155,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePsOldGenData() {
+    void testLogLinePsOldGenData() {
         String logLine = "[0.032s][info][gc,heap      ] GC(0) PSOldGen: 0K->8K(512K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -167,7 +167,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineMetaspaceData() {
+    void testLogLineMetaspaceData() {
         String logLine = "[0.032s][info][gc,metaspace ] GC(0) Metaspace: 120K->120K(1056768K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -179,13 +179,13 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineMetaspace2Spaces() {
+    void testLogLineMetaspace2Spaces() {
         String logLine = "[16.072s][info][gc,metaspace  ] GC(971) Metaspace: 10793K->10793K(1058816K)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParOldGenData() {
+    void testLogLineParOldGenData() {
         String logLine = "[0.030s][info][gc,heap      ] GC(0) ParOldGen: 0K->8K(512K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -197,13 +197,13 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineMetaspaceDatestampMillis() {
+    void testLogLineMetaspaceDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Metaspace: 26116K->26116K(278528K)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePauseYoungInfo() {
+    void testLogLinePauseYoungInfo() {
         String logLine = "[0.112s][info][gc             ] GC(3) Pause Young (Allocation Failure) 1M->1M(2M) 0.700ms";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -217,7 +217,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePauseYoungInfoStandAlone() {
+    void testLogLinePauseYoungInfoStandAlone() {
         String logLine = "[1.507s][info][gc] GC(77) Pause Young (Allocation Failure) 24M->4M(25M) 0.509ms";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -230,7 +230,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineG1PauseYoungInfo() {
+    void testLogLineG1PauseYoungInfo() {
         String logLine = "[0.337s][info][gc           ] GC(0) Pause Young (G1 Evacuation Pause) 25M->4M(254M) 3.523ms";
         String nextLogLine = "[0.337s][info][gc,cpu       ] GC(0) User=0.00s Sys=0.00s Real=0.00s";
         Set<String> context = new HashSet<String>();
@@ -242,7 +242,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineG1MixedPauseInfo() {
+    void testLogLineG1MixedPauseInfo() {
         String logLine = "[16.630s][info][gc            ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause) "
                 + "15M->12M(31M) 1.202ms";
         String nextLogLine = "[16.630s][info][gc           ] GC(0) User=0.18s Sys=0.00s Real=0.11s";
@@ -255,7 +255,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePauseYoungInfoNormalWithDatestamp() {
+    void testLogLinePauseYoungInfoNormalWithDatestamp() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "65M->8M(1304M) 57.263ms";
         String nextLogLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) User=0.02s Sys=0.01s Real=0.06s";
@@ -268,7 +268,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePauseYoungInfoNormalTriggerGcLockerWithDatestamp() {
+    void testLogLinePauseYoungInfoNormalTriggerGcLockerWithDatestamp() {
         String logLine = "[2019-05-09T01:39:07.172+0000][11764ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC) "
                 + "78M->22M(1304M) 35.722ms";
         String nextLogLine = "[2019-05-09T01:39:07.172+0000][11764ms] GC(3) User=0.02s Sys=0.00s Real=0.04s";
@@ -281,13 +281,13 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePauseYoungInfo11SpacesAfterGc() {
+    void testLogLinePauseYoungInfo11SpacesAfterGc() {
         String logLine = "[0.032s][info][gc           ] GC(0) Pause Young (Allocation Failure) 0M->0M(1M) 1.195ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLinePauseYoungInfoConcurrentStartTriggerMetaGcThreshold() {
+    void testLogLinePauseYoungInfoConcurrentStartTriggerMetaGcThreshold() {
         String logLine = "[2020-06-24T18:11:52.781-0700][58776ms] GC(44) Pause Young (Concurrent Start) "
                 + "(Metadata GC Threshold) 733M->588M(1223M) 105.541ms";
         String nextLogLine = "[2020-06-24T18:11:52.781-0700][58776ms] GC(44) User=0.18s Sys=0.00s Real=0.11s";
@@ -300,7 +300,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLinePauseYoungInfoConcurrentStartTriggerG1HumongousAllocation() {
+    void testLogLinePauseYoungInfoConcurrentStartTriggerG1HumongousAllocation() {
         String logLine = "[2020-06-24T19:24:56.395-0700][4442390ms] GC(126) Pause Young (Concurrent Start) "
                 + "(G1 Humongous Allocation) 882M->842M(1223M) 19.777ms";
         String nextLogLine = "[2020-06-24T19:24:56.395-0700][4442390ms] GC(126) User=0.04s Sys=0.00s Real=0.02s";
@@ -313,7 +313,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineTimesData() {
+    void testLogLineTimesData() {
         String logLine = "[0.112s][info][gc,cpu         ] GC(3) User=0.00s Sys=0.00s Real=0.00s";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -325,413 +325,413 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineTimesData8Spaces() {
+    void testLogLineTimesData8Spaces() {
         String logLine = "[16.053s][info][gc,cpu        ] GC(969) User=0.01s Sys=0.00s Real=0.00s";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineTimesDataDatestampMillis() {
+    void testLogLineTimesDataDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) User=0.02s Sys=0.01s Real=0.06s";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNormal() {
+    void testLogLineStartG1YoungPauseNormal() {
         String logLine = "[0.099s][info][gc,start     ] GC(0) Pause Young (Normal) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNormal6Spaces() {
+    void testLogLineStartG1YoungPauseNormal6Spaces() {
         String logLine = "[16.070s][info][gc,start      ] GC(971) Pause Young (Normal) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPrepareMixed() {
+    void testLogLineStartG1YoungPrepareMixed() {
         String logLine = "[15.108s][info][gc,start      ] GC(1194) Pause Young (Prepare Mixed) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1MixedPause() {
+    void testLogLineStartG1MixedPause() {
         String logLine = "[16.629s][info][gc,start      ] GC(1355) Pause Young (Mixed) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseConcurrentStart() {
+    void testLogLineStartG1YoungPauseConcurrentStart() {
         String logLine = "[16.600s][info][gc,start     ] GC(1032) Pause Young (Concurrent Start) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNoQualifier() {
+    void testLogLineStartG1YoungPauseNoQualifier() {
         String logLine = "[0.333s][info][gc,start     ] GC(0) Pause Young (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNormalDatestampMillis() {
+    void testLogLineStartG1YoungPauseNormalDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNormalTriggerGcLocker() {
+    void testLogLineStartG1YoungPauseNormalTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.136+0000][11728ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineStartG1YoungPauseNormalMillis8Digits() {
+    void testLogLineStartG1YoungPauseNormalMillis8Digits() {
         String logLine = "[2019-05-09T04:31:19.449+0000][10344041ms] GC(9) Pause Young (Normal) (G1 Evacuation Pause)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1UsingWorkersForEvacuation() {
+    void testLogLineG1UsingWorkersForEvacuation() {
         String logLine = "[0.100s][info][gc,task      ] GC(0) Using 2 workers of 4 for evacuation";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1UsingWorkersForEvacuation2Digits() {
+    void testLogLineG1UsingWorkersForEvacuation2Digits() {
         String logLine = "[0.333s][info][gc,task      ] GC(0) Using 10 workers of 10 for evacuation";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1UsingWorkersForEvacuation7Spaces() {
+    void testLogLineG1UsingWorkersForEvacuation7Spaces() {
         String logLine = "[16.070s][info][gc,task       ] GC(971) Using 2 workers of 4 for evacuation";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1UsingWorkersForEvacuationDatestampMillis() {
+    void testLogLineG1UsingWorkersForEvacuationDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.763+0000][5355ms] GC(0) Using 1 workers of 1 for evacuation";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1UsingWorkersForMarking() {
+    void testLogLineG1UsingWorkersForMarking() {
         String logLine = "[16.121s][info][gc,task       ] GC(974) Using 1 workers of 1 for marking";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PreEvacuate() {
+    void testLogLineG1PreEvacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Pre Evacuate Collection Set: 0.0ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PreEvacuate5Spaces() {
+    void testLogLineG1PreEvacuate5Spaces() {
         String logLine = "[16.071s][info][gc,phases     ] GC(971)   Pre Evacuate Collection Set: 0.0ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PreEvacuateDatestampMillis() {
+    void testLogLineG1PreEvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Pre Evacuate Collection Set: 0.0ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Evacuate() {
+    void testLogLineG1Evacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Evacuate Collection Set: 1.0ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1EvacuateDatestampMillis() {
+    void testLogLineG1EvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Evacuate Collection Set: 56.4ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PostEvacuate() {
+    void testLogLineG1PostEvacuate() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Post Evacuate Collection Set: 0.2ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PostEvacuate5Spaces() {
+    void testLogLineG1PostEvacuate5Spaces() {
         String logLine = "[16.072s][info][gc,phases     ] GC(971)   Post Evacuate Collection Set: 0.1ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PostEvacuateDatestampMillis() {
+    void testLogLineG1PostEvacuateDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Post Evacuate Collection Set: 0.5ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Other() {
+    void testLogLineG1Other() {
         String logLine = "[0.101s][info][gc,phases    ] GC(0)   Other: 0.2ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1OtherDatestampMillis() {
+    void testLogLineG1OtherDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.820+0000][5412ms] GC(0)   Other: 0.3ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Other5Spaces() {
+    void testLogLineG1Other5Spaces() {
         String logLine = "[16.072s][info][gc,phases     ] GC(971)   Other: 0.1ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Eden() {
+    void testLogLineG1Eden() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Eden regions: 1->0(1)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Eden3Digits() {
+    void testLogLineG1Eden3Digits() {
         String logLine = "[0.335s][info][gc,heap      ] GC(0) Eden regions: 24->0(149)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1EdenDatestampMillis() {
+    void testLogLineG1EdenDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Eden regions: 65->0(56)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1EdenDatestampMillisRegions4Digits() {
+    void testLogLineG1EdenDatestampMillisRegions4Digits() {
         String logLine = "[2020-09-11T05:33:44.563+0000][1732868ms] GC(42) Eden regions: 307->0(1659)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Survivor() {
+    void testLogLineG1Survivor() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Survivor regions: 0->1(1)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1SurvivorDatestampMillis() {
+    void testLogLineG1SurvivorDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Survivor regions: 0->9(9)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Old() {
+    void testLogLineG1Old() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Old regions: 0->0";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Old2Digits() {
+    void testLogLineG1Old2Digits() {
         String logLine = "[10.989s][info][gc,heap      ] GC(684) Old regions: 15->15";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Old7Spaces() {
+    void testLogLineG1Old7Spaces() {
         String logLine = "[17.728s][info][gc,heap       ] GC(1098) Old regions: 21->21";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1OldDatestampMillis() {
+    void testLogLineG1OldDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Old regions: 0->0";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Humongous() {
+    void testLogLineG1Humongous() {
         String logLine = "[0.101s][info][gc,heap      ] GC(0) Humongous regions: 0->0";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1HumongousDatestampMillis() {
+    void testLogLineG1HumongousDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Humongous regions: 0->0";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungPauseNormal() {
+    void testLogLineG1YoungPauseNormal() {
         String logLine = "[0.101s][info][gc           ] GC(0) Pause Young (Normal) "
                 + "(G1 Evacuation Pause) 0M->0M(2M) 1.371ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungPauseNormalDatestampMillis() {
+    void testLogLineG1YoungPauseNormalDatestampMillis() {
         String logLine = "[2019-05-09T01:39:00.821+0000][5413ms] GC(0) Pause Young (Normal) (G1 Evacuation Pause) "
                 + "65M->8M(1304M) 57.263ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungPauseNormalTriggerGcLocker() {
+    void testLogLineG1YoungPauseNormalTriggerGcLocker() {
         String logLine = "[2019-05-09T01:39:07.172+0000][11764ms] GC(3) Pause Young (Normal) (GCLocker Initiated GC) "
                 + "78M->22M(1304M) 35.722ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1YoungPauseConcurrentStart() {
+    void testLogLineG1YoungPauseConcurrentStart() {
         String logLine = "[16.601s][info][gc           ] GC(1032) Pause Young (Concurrent Start) "
                 + "(G1 Evacuation Pause) 38M->20M(46M) 0.772ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogG1LineRemark() {
+    void testLogG1LineRemark() {
         String logLine = "[16.051s][info][gc,start     ] GC(969) Pause Remark";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1Remark6Spaces() {
+    void testLogLineG1Remark6Spaces() {
         String logLine = "[16.175s][info][gc,start      ] GC(974) Pause Remark";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1StringTable() {
+    void testLogLineG1StringTable() {
         String logLine = "[16.053s][info][gc,stringtable] GC(969) Cleaned string and symbol table, strings: "
                 + "5786 processed, 4 removed, symbols: 38663 processed, 11 removed";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1StringTableLargeNumbers() {
+    void testLogLineG1StringTableLargeNumbers() {
         String logLine = "[2020-06-24T18:15:29.817-0700][275812ms] GC(93) Cleaned string and symbol table, strings: "
                 + "94127 processed, 27 removed, symbols: 437573 processed, 2702 removed";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1StringTableRemoved5Digits() {
+    void testLogLineG1StringTableRemoved5Digits() {
         String logLine = "[2020-09-11T08:23:37.353+0000][11925659ms] GC(194) Cleaned string and symbol table, "
                 + "strings: 368294 processed, 9531 removed, symbols: 1054532 processed, 18545 removed";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1PauseCleanup() {
+    void testLogLineG1PauseCleanup() {
         String logLine = "[16.081s][info][gc,start      ] GC(969) Pause Cleanup";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1MarkClosedArchiveRegions() {
+    void testLogLineG1MarkClosedArchiveRegions() {
         String logLine = "[0.004s][info][gc,cds       ] Mark closed archive regions in map: [0x00000000fff00000, "
                 + "0x00000000fff69ff8]";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1MarkOpenArchiveRegions() {
+    void testLogLineG1MarkOpenArchiveRegions() {
         String logLine = "[0.004s][info][gc,cds       ] Mark open archive regions in map: [0x00000000ffe00000, "
                 + "0x00000000ffe46ff8]";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineG1MmuTargetViolated() {
+    void testLogLineG1MmuTargetViolated() {
         String logLine = "[2020-06-24T18:11:22.155-0700][28150ms] GC(24) MMU target violated: 201.0ms "
                 + "(200.0ms/201.0ms)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSerialNewStart() {
+    void testLogLineSerialNewStart() {
         String logLine = "[0.118s][info][gc,start       ] GC(4) Pause Young (Allocation Failure)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSerialOldStart() {
+    void testLogLineSerialOldStart() {
         String logLine = "[0.075s][info][gc,start     ] GC(2) Pause Full (Allocation Failure)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSerialOldStart7SpacesAfterStart() {
+    void testLogLineSerialOldStart7SpacesAfterStart() {
         String logLine = "[0.119s][info][gc,start       ] GC(5) Pause Full (Allocation Failure)";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSerialOldInfo() {
+    void testLogLineSerialOldInfo() {
         String logLine = "[0.076s][info][gc             ] GC(2) Pause Full (Allocation Failure) 0M->0M(2M) 1.699ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldMarkingPhaseStart() {
+    void testLogLineParallelCompactingOldMarkingPhaseStart() {
         String logLine = "[0.083s][info][gc,phases,start] GC(3) Marking Phase";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldMarkingPhase() {
+    void testLogLineParallelCompactingOldMarkingPhase() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Marking Phase 1.032ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOlSummaryPhaseStart() {
+    void testLogLineParallelCompactingOlSummaryPhaseStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Summary Phase";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldSummaryPhase() {
+    void testLogLineParallelCompactingOldSummaryPhase() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Summary Phase 0.005ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldAdjustRootsStart() {
+    void testLogLineParallelCompactingOldAdjustRootsStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Adjust Roots";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldAdjustRoots() {
+    void testLogLineParallelCompactingOldAdjustRoots() {
         String logLine = "[0.084s][info][gc,phases      ] GC(3) Adjust Roots 0.666ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldCompactionPhaseStart() {
+    void testLogLineParallelCompactingOldCompactionPhaseStart() {
         String logLine = "[0.084s][info][gc,phases,start] GC(3) Compaction Phase";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldCompactionPhase() {
+    void testLogLineParallelCompactingOldCompactionPhase() {
         String logLine = "[0.087s][info][gc,phases      ] GC(3) Compaction Phase 2.540ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldPostStart() {
+    void testLogLineParallelCompactingOldPostStart() {
         String logLine = "[0.087s][info][gc,phases,start] GC(3) Post Compact";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineParallelCompactingOldPostCompact() {
+    void testLogLineParallelCompactingOldPostCompact() {
         String logLine = "[0.087s][info][gc,phases      ] GC(3) Post Compact 0.012ms";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSerialOldInfoTriggerErgonomics() {
+    void testLogLineSerialOldInfoTriggerErgonomics() {
         String logLine = "[0.092s][info][gc             ] GC(3) Pause Full (Ergonomics) 0M->0M(3M) 1.849ms";
         String nextLogLine = "[0.092s][info][gc,cpu         ] GC(3) User=0.01s Sys=0.00s Real=0.00s";
         Set<String> context = new HashSet<String>();
@@ -743,7 +743,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineSerialOldInfoTriggerSystemGc() {
+    void testLogLineSerialOldInfoTriggerSystemGc() {
         String logLine = "[2020-06-24T18:13:51.155-0700][177150ms] GC(74) Pause Full (System.gc()) 887M->583M(1223M) "
                 + "3460.196ms";
         String nextLogLine = "[2020-06-24T18:13:51.155-0700][177150ms] GC(74) User=1.78s Sys=0.01s Real=3.46s";
@@ -756,7 +756,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineUnifiedYoungSingleLine() {
+    void testLogLineUnifiedYoungSingleLine() {
         String logLine = "[1.507s][info][gc] GC(77) Pause Young (Allocation Failure) 24M->4M(25M) 0.509ms";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -768,13 +768,13 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineUsingParallel() {
+    void testLogLineUsingParallel() {
         String logLine = "[0.003s][info][gc] Using Parallel";
         assertFalse(UnifiedPreprocessAction.match(logLine), "Log line incorrectly recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineCmsInitialMark() {
+    void testLogLineCmsInitialMark() {
         String logLine = "[0.053s][info][gc,start     ] GC(1) Pause Initial Mark";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -786,7 +786,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineCmsOld() {
+    void testLogLineCmsOld() {
         String logLine = "[0.056s][info][gc,heap      ] GC(1) Old: 518K->518K(960K)";
         String nextLogLine = "";
         Set<String> context = new HashSet<String>();
@@ -798,25 +798,25 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testLogLineSafepointEnteringl() {
+    void testLogLineSafepointEnteringl() {
         String logLine = "[0.029s][info][safepoint    ] Entering safepoint region: EnableBiasedLocking";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSafepointLeaving() {
+    void testLogLineSafepointLeaving() {
         String logLine = "[0.029s][info][safepoint    ] Leaving safepoint region";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testLogLineSafepointApplicationTime() {
+    void testLogLineSafepointApplicationTime() {
         String logLine = "[0.030s][info][safepoint    ] Application time: 0.0012757 seconds";
         assertTrue(UnifiedPreprocessAction.match(logLine), "Log line not recognized as " + JdkUtil.PreprocessActionType.UNIFIED.toString() + ".");
     }
 
     @Test
-    public void testPreprocessingG1YoungPauseNormalCollection() {
+    void testPreprocessingG1YoungPauseNormalCollection() {
         File testFile = TestUtil.getFile("dataset155.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -828,7 +828,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingG1Remark() {
+    void testPreprocessingG1Remark() {
         File testFile = TestUtil.getFile("dataset156.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -840,7 +840,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingG1Cleanup() {
+    void testPreprocessingG1Cleanup() {
         File testFile = TestUtil.getFile("dataset157.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -852,7 +852,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingG1YoungPauseNormalTriggerGcLockerWithDatestamps() {
+    void testPreprocessingG1YoungPauseNormalTriggerGcLockerWithDatestamps() {
         File testFile = TestUtil.getFile("dataset170.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -864,7 +864,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingSerialNew() {
+    void testPreprocessingSerialNew() {
         File testFile = TestUtil.getFile("dataset171.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -876,7 +876,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingSerialOld() {
+    void testPreprocessingSerialOld() {
         File testFile = TestUtil.getFile("dataset172.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -888,7 +888,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingSerialOldTriggerErgonomics() {
+    void testPreprocessingSerialOldTriggerErgonomics() {
         File testFile = TestUtil.getFile("dataset174.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -900,7 +900,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingParallelScavengeSerialOld() {
+    void testPreprocessingParallelScavengeSerialOld() {
         File testFile = TestUtil.getFile("dataset173.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -912,7 +912,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingParallelScavengeParallelCompactingOld() {
+    void testPreprocessingParallelScavengeParallelCompactingOld() {
         File testFile = TestUtil.getFile("dataset175.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -924,7 +924,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingParallelCompactingOld() {
+    void testPreprocessingParallelCompactingOld() {
         File testFile = TestUtil.getFile("dataset176.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -936,7 +936,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingParNew() {
+    void testPreprocessingParNew() {
         File testFile = TestUtil.getFile("dataset177.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -948,7 +948,7 @@ public class TestUnifiedPreprocessAction {
     }
 
     @Test
-    public void testPreprocessingCms() {
+    void testPreprocessingCms() {
         File testFile = TestUtil.getFile("dataset178.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -966,7 +966,7 @@ public class TestUnifiedPreprocessAction {
      * Verify that preprocessing logging that does not need preprocessing does not change logging.
      */
     @Test
-    public void testPreprocessingG1Unecessarily() {
+    void testPreprocessingG1Unecessarily() {
         File testFile = TestUtil.getFile("dataset186.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/service/TestGcManager.java
+++ b/src/test/java/org/eclipselabs/garbagecat/service/TestGcManager.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestGcManager {
+class TestGcManager {
 
     /**
      * Test for NullPointerException caused by Issue 17:
      * http://code.google.com/a/eclipselabs.org/p/garbagecat/issues/detail?id=17
      */
     @Test
-    public void testNullPointerExceptionNotRaised() {
+    void testNullPointerExceptionNotRaised() {
         File testFile = TestUtil.getFile("dataset31.txt");
         GcManager gcManager = new GcManager();
         gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/service/TestGcManager.java
+++ b/src/test/java/org/eclipselabs/garbagecat/service/TestGcManager.java
@@ -15,7 +15,7 @@ package org.eclipselabs.garbagecat.service;
 import java.io.File;
 
 import org.eclipselabs.garbagecat.TestUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>

--- a/src/test/java/org/eclipselabs/garbagecat/util/MemoryTest.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/MemoryTest.java
@@ -18,60 +18,60 @@ import static org.eclipselabs.garbagecat.util.Memory.megabytes;
 import static org.eclipselabs.garbagecat.util.Memory.memory;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.BYTES;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.KILOBYTES;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="https://github.com/pfichtner">Peter Fichtner</a>
  */
 public class MemoryTest {
 
-    @Test
-    public void canParse() {
-        Memory oneKilobyte = memory("1K");
-        assertThat(oneKilobyte.getValue(KILOBYTES), is(equalTo(1L)));
-        assertThat(oneKilobyte.getValue(BYTES), is(equalTo(1024L)));
-    }
+	@Test
+	public void canParse() {
+		Memory oneKilobyte = memory("1K");
+		assertEquals(oneKilobyte.getValue(KILOBYTES), 1L);
+		assertEquals(oneKilobyte.getValue(BYTES), 1024L);
+	}
 
-    @Test
-    public void parseIsCaseInsensitiv() {
-        String string = "8K";
-        assertThat(memory(string.toLowerCase()), is(equalTo(memory(string.toUpperCase()))));
-    }
+	@Test
+	public void parseIsCaseInsensitiv() {
+		String string = "8K";
+		assertEquals(memory(string.toLowerCase()), memory(string.toUpperCase()));
+	}
 
-    @Test
-    public void hasToString() {
-        assertThat(memory("32M").toString(), is(equalTo("32M")));
-        assertThat(memory("32M").convertTo(KILOBYTES).toString(), is(equalTo("32768K")));
-    }
+	@Test
+	public void hasToString() {
+		assertEquals(memory("32M").toString(), "32M");
+		assertEquals(memory("32M").convertTo(KILOBYTES).toString(), "32768K");
+	}
 
-    @Test
-    public void canEqualOnInstancesUsingDifferentUnits() {
-        assertThat(kilobytes(2048), is(equalTo(megabytes(2))));
-    }
+	@Test
+	public void canEqualOnInstancesUsingDifferentUnits() {
+		assertEquals(kilobytes(2048), megabytes(2));
+	}
 
-    @Test
-    public void canAdd() {
-        assertThat(megabytes(2).plus(kilobytes(1)), is(equalTo(kilobytes(2049))));
-    }
+	@Test
+	public void canAdd() {
+		assertEquals(megabytes(2).plus(kilobytes(1)), kilobytes(2049));
+	}
 
-    @Test
-    public void canSubtract() {
-        assertThat(megabytes(2).minus(kilobytes(1)), is(equalTo(kilobytes(2047))));
-    }
+	@Test
+	public void canSubtract() {
+		assertEquals(megabytes(2).minus(kilobytes(1)), kilobytes(2047));
+	}
 
-    @Test
-    public void canCompare() {
-        assertThat(bytes(1).greaterThan(bytes(2)), is(false));
-        assertThat(bytes(1).greaterThan(bytes(1)), is(false));
-        assertThat(bytes(2).greaterThan(bytes(1)), is(true));
+	@Test
+	public void canCompare() {
+		assertFalse(bytes(1).greaterThan(bytes(2)));
+		assertFalse(bytes(1).greaterThan(bytes(1)));
+		assertTrue(bytes(2).greaterThan(bytes(1)));
 
-        assertThat(bytes(1).lessThan(bytes(2)), is(true));
-        assertThat(bytes(1).lessThan(bytes(1)), is(false));
-        assertThat(bytes(2).lessThan(bytes(1)), is(false));
-    }
+		assertTrue(bytes(1).lessThan(bytes(2)));
+		assertFalse(bytes(1).lessThan(bytes(1)));
+		assertFalse(bytes(2).lessThan(bytes(1)));
+	}
 
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
@@ -12,17 +12,17 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
 import org.eclipselabs.garbagecat.util.jdk.Analysis;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,14 +33,14 @@ public class TestGcUtil {
     @Test
     public void testStartDateTime() {
         String startDateTime = "2009-09-18 00:00:08,172";
-        assertTrue("Start date/time not recognized as a valid format.", GcUtil.isValidStartDateTime(startDateTime));
+        assertTrue(GcUtil.isValidStartDateTime(startDateTime), "Start date/time not recognized as a valid format.");
     }
 
     @Test
     public void testInvalidStartDateTime() {
         // Replace comma with space
         String startDateTime = "2009-09-18 00:00:08 172";
-        assertFalse("Start date/time recognized as a valid format.", GcUtil.isValidStartDateTime(startDateTime));
+        assertFalse(GcUtil.isValidStartDateTime(startDateTime), "Start date/time recognized as a valid format.");
     }
 
     @Test
@@ -50,37 +50,37 @@ public class TestGcUtil {
         assertNotNull(date);
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
-        assertEquals("Start year not parsed correctly.", 2009, calendar.get(Calendar.YEAR));
-        assertEquals("Start month not parsed correctly.", 8, calendar.get(Calendar.MONTH));
-        assertEquals("Start day not parsed correctly.", 18, calendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals("Start hour not parsed correctly.", 16, calendar.get(Calendar.HOUR_OF_DAY));
-        assertEquals("Start minute not parsed correctly.", 24, calendar.get(Calendar.MINUTE));
-        assertEquals("Start second not parsed correctly.", 8, calendar.get(Calendar.SECOND));
-        assertEquals("Start millisecond not parsed correctly.", 172, calendar.get(Calendar.MILLISECOND));
+        assertEquals(2009,calendar.get(Calendar.YEAR),"Start year not parsed correctly.");
+        assertEquals(8,calendar.get(Calendar.MONTH),"Start month not parsed correctly.");
+        assertEquals(18,calendar.get(Calendar.DAY_OF_MONTH),"Start day not parsed correctly.");
+        assertEquals(16,calendar.get(Calendar.HOUR_OF_DAY),"Start hour not parsed correctly.");
+        assertEquals(24,calendar.get(Calendar.MINUTE),"Start minute not parsed correctly.");
+        assertEquals(8,calendar.get(Calendar.SECOND),"Start second not parsed correctly.");
+        assertEquals(172,calendar.get(Calendar.MILLISECOND),"Start millisecond not parsed correctly.");
     }
 
     @Test
     public void testNumberOfDaysInZeroMilliSeconds() {
         long milliSeconds = 0;
-        assertEquals("Number of days calculated wrong.", 0, GcUtil.daysInMilliSeconds(milliSeconds));
+        assertEquals(0,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
     public void testNumberOfDaysInMilliSecondsLessThanOneDay() {
         long milliSeconds = 82800000L;
-        assertEquals("Number of days calculated wrong.", 0, GcUtil.daysInMilliSeconds(milliSeconds));
+        assertEquals(0,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
     public void testNumberOfDaysInMilliSecondsEqualOneDay() {
         long milliSeconds = 86400000L;
-        assertEquals("Number of days calculated wrong.", 1, GcUtil.daysInMilliSeconds(milliSeconds));
+        assertEquals(1,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
     public void testNumberOfDaysInMilliSeconds9Days() {
         long milliSeconds = 863999999L;
-        assertEquals("Number of days calculated wrong.", 9, GcUtil.daysInMilliSeconds(milliSeconds));
+        assertEquals(9,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
@@ -96,8 +96,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 0L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-18 19:21:44,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-18 19:21:44,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -113,8 +112,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 10L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-18 19:21:44,022",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-18 19:21:44,022",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -130,8 +128,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 1000L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-18 19:21:45,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-18 19:21:45,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -147,8 +144,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 60000L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-18 19:22:44,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-18 19:22:44,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -164,8 +160,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 3600000L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-18 20:21:44,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-18 20:21:44,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -181,8 +176,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 86400000L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-08-19 19:21:44,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-08-19 19:21:44,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -198,8 +192,7 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 12);
         long timestamp = 2592000000L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "1966-09-17 19:21:44,012",
-                formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)));
+        assertEquals("1966-09-17 19:21:44,012",formatter.format(GcUtil.getDatePlusTimestamp(calendar.getTime(), timestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -207,8 +200,7 @@ public class TestGcUtil {
         String jvmStarted = "2009-11-01 02:30:52,917";
         long gcLogTimestamp = 353647157L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
-        assertEquals("Date calculated wrong.", "2009-11-05 04:45:00,074",
-                formatter.format(GcUtil.getDatePlusTimestamp(GcUtil.parseStartDateTime(jvmStarted), gcLogTimestamp)));
+        assertEquals("2009-11-05 04:45:00,074",formatter.format(GcUtil.getDatePlusTimestamp(GcUtil.parseStartDateTime(jvmStarted), gcLogTimestamp)),"Date calculated wrong.");
     }
 
     @Test
@@ -226,13 +218,13 @@ public class TestGcUtil {
         assertNotNull(date);
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
-        assertEquals("Datestamp year not parsed correctly.", 2010, calendar.get(Calendar.YEAR));
-        assertEquals("Datestamp month not parsed correctly.", 1, calendar.get(Calendar.MONTH));
-        assertEquals("Datestamp day not parsed correctly.", 26, calendar.get(Calendar.DAY_OF_MONTH));
-        assertEquals("Datestamp hour not parsed correctly.", 9, calendar.get(Calendar.HOUR_OF_DAY));
-        assertEquals("Datestamp minute not parsed correctly.", 32, calendar.get(Calendar.MINUTE));
-        assertEquals("Datestamp second not parsed correctly.", 12, calendar.get(Calendar.SECOND));
-        assertEquals("Datestamp millisecond not parsed correctly.", 486, calendar.get(Calendar.MILLISECOND));
+        assertEquals(2010,calendar.get(Calendar.YEAR),"Datestamp year not parsed correctly.");
+        assertEquals(1,calendar.get(Calendar.MONTH),"Datestamp month not parsed correctly.");
+        assertEquals(26,calendar.get(Calendar.DAY_OF_MONTH),"Datestamp day not parsed correctly.");
+        assertEquals(9,calendar.get(Calendar.HOUR_OF_DAY),"Datestamp hour not parsed correctly.");
+        assertEquals(32,calendar.get(Calendar.MINUTE),"Datestamp minute not parsed correctly.");
+        assertEquals(12,calendar.get(Calendar.SECOND),"Datestamp second not parsed correctly.");
+        assertEquals(486,calendar.get(Calendar.MILLISECOND),"Datestamp millisecond not parsed correctly.");
     }
 
     @Test
@@ -254,12 +246,12 @@ public class TestGcUtil {
         calendar.set(Calendar.MILLISECOND, 1);
         Date end = calendar.getTime();
 
-        assertEquals("Date difference incorrect.", 90061001L, GcUtil.dateDiff(start, end));
+        assertEquals(90061001L,GcUtil.dateDiff(start, end),"Date difference incorrect.");
     }
 
     @Test
     public void testPartialLog() {
-        assertFalse("Not a partial log.", GcUtil.isPartialLog(59999));
-        assertTrue("Is a partial log.", GcUtil.isPartialLog(60001));
+        assertFalse(GcUtil.isPartialLog(59999), "Not a partial log.");
+        assertTrue(GcUtil.isPartialLog(60001), "Is a partial log.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
@@ -28,23 +28,23 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestGcUtil {
+class TestGcUtil {
 
     @Test
-    public void testStartDateTime() {
+    void testStartDateTime() {
         String startDateTime = "2009-09-18 00:00:08,172";
         assertTrue(GcUtil.isValidStartDateTime(startDateTime), "Start date/time not recognized as a valid format.");
     }
 
     @Test
-    public void testInvalidStartDateTime() {
+    void testInvalidStartDateTime() {
         // Replace comma with space
         String startDateTime = "2009-09-18 00:00:08 172";
         assertFalse(GcUtil.isValidStartDateTime(startDateTime), "Start date/time recognized as a valid format.");
     }
 
     @Test
-    public void testConvertStartDateTimeStringToDate() {
+    void testConvertStartDateTimeStringToDate() {
         String startDateTime = "2009-09-18 16:24:08,172";
         Date date = GcUtil.parseStartDateTime(startDateTime);
         assertNotNull(date);
@@ -60,31 +60,31 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testNumberOfDaysInZeroMilliSeconds() {
+    void testNumberOfDaysInZeroMilliSeconds() {
         long milliSeconds = 0;
         assertEquals(0,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
-    public void testNumberOfDaysInMilliSecondsLessThanOneDay() {
+    void testNumberOfDaysInMilliSecondsLessThanOneDay() {
         long milliSeconds = 82800000L;
         assertEquals(0,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
-    public void testNumberOfDaysInMilliSecondsEqualOneDay() {
+    void testNumberOfDaysInMilliSecondsEqualOneDay() {
         long milliSeconds = 86400000L;
         assertEquals(1,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
-    public void testNumberOfDaysInMilliSeconds9Days() {
+    void testNumberOfDaysInMilliSeconds9Days() {
         long milliSeconds = 863999999L;
         assertEquals(9,GcUtil.daysInMilliSeconds(milliSeconds),"Number of days calculated wrong.");
     }
 
     @Test
-    public void testAddingDateAndTimestampZero() {
+    void testAddingDateAndTimestampZero() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -100,7 +100,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp10Ms() {
+    void testAddingDateAndTimestamp10Ms() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -116,7 +116,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp1Sec() {
+    void testAddingDateAndTimestamp1Sec() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -132,7 +132,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp1Min() {
+    void testAddingDateAndTimestamp1Min() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -148,7 +148,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp1Hr() {
+    void testAddingDateAndTimestamp1Hr() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -164,7 +164,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp1Day() {
+    void testAddingDateAndTimestamp1Day() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -180,7 +180,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateAndTimestamp30Days() {
+    void testAddingDateAndTimestamp30Days() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -196,7 +196,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testAddingDateWith2DigitMonth() {
+    void testAddingDateWith2DigitMonth() {
         String jvmStarted = "2009-11-01 02:30:52,917";
         long gcLogTimestamp = 353647157L;
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
@@ -204,7 +204,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testGetPropertyValues() {
+    void testGetPropertyValues() {
         assertNotNull("Could not retrieve " + Analysis.WARN_THREAD_STACK_SIZE_NOT_SET.getKey() + ".",
                 GcUtil.getPropertyValue("analysis", Analysis.WARN_THREAD_STACK_SIZE_NOT_SET.getKey()));
         assertNotNull("Could not retrieve " + Analysis.WARN_HEAP_MIN_NOT_EQUAL_MAX.getKey() + ".",
@@ -212,7 +212,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testConvertDateStampStringToDate() {
+    void testConvertDateStampStringToDate() {
         String datestamp = "2010-02-26T09:32:12.486-0600";
         Date date = GcUtil.parseDateStamp(datestamp);
         assertNotNull(date);
@@ -228,7 +228,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testDateDiff() {
+    void testDateDiff() {
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 2010);
         calendar.set(Calendar.MONTH, Calendar.FEBRUARY);
@@ -250,7 +250,7 @@ public class TestGcUtil {
     }
 
     @Test
-    public void testPartialLog() {
+    void testPartialLog() {
         assertFalse(GcUtil.isPartialLog(59999), "Not a partial log.");
         assertTrue(GcUtil.isPartialLog(60001), "Is a partial log.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestAnalysis.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestAnalysis.java
@@ -13,10 +13,10 @@
 package org.eclipselabs.garbagecat.util.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.bytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.service.GcManager;
 import org.eclipselabs.garbagecat.util.Constants;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.CollectorFamily;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -54,15 +54,13 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_BIASED_LOCKING_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BIASED_LOCKING_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_BIASED_LOCKING_DISABLED), Analysis.WARN_BIASED_LOCKING_DISABLED + " analysis not identified.");
         jvmRun.getAnalysis().clear();
         List<CollectorFamily> collectorFamilies = new ArrayList<CollectorFamily>();
         collectorFamilies.add(CollectorFamily.SHENANDOAH);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_BIASED_LOCKING_DISABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BIASED_LOCKING_DISABLED));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_BIASED_LOCKING_DISABLED), Analysis.WARN_BIASED_LOCKING_DISABLED + " analysis incorrectly identified.");
 
     }
 
@@ -73,12 +71,9 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM), Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis incorrectly identified.");
     }
 
     @Test
@@ -88,12 +83,9 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM), Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis incorrectly identified.");
     }
 
     @Test
@@ -103,12 +95,9 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM));
-        assertFalse(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_BEFORE_FULL_GC + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM), Analysis.WARN_PRINT_CLASS_HISTOGRAM + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC), Analysis.WARN_PRINT_CLASS_HISTOGRAM_AFTER_FULL_GC + " analysis incorrectly identified.");
     }
 
     @Test
@@ -118,8 +107,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME), Analysis.WARN_PRINT_GC_APPLICATION_CONCURRENT_TIME + " analysis not identified.");
     }
 
     @Test
@@ -129,8 +117,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_TRACE_CLASS_UNLOADING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_TRACE_CLASS_UNLOADING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_TRACE_CLASS_UNLOADING), Analysis.WARN_TRACE_CLASS_UNLOADING + " analysis not identified.");
     }
 
     @Test
@@ -140,8 +127,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK), Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis not identified.");
     }
 
     @Test
@@ -151,8 +137,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_COMP_CLASS_ENABLED_HEAP_GT_32G + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_ENABLED_HEAP_GT_32G));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_ENABLED_HEAP_GT_32G), Analysis.ERROR_COMP_CLASS_ENABLED_HEAP_GT_32G + " analysis not identified.");
     }
 
     @Test
@@ -162,8 +147,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_COMP_CLASS_DISABLED_HEAP_LT_32G + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_DISABLED_HEAP_LT_32G));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_DISABLED_HEAP_LT_32G), Analysis.ERROR_COMP_CLASS_DISABLED_HEAP_LT_32G + " analysis not identified.");
     }
 
     @Test
@@ -173,8 +157,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK), Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK + " analysis not identified.");
     }
 
     @Test
@@ -184,10 +167,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK));
-        assertTrue(Analysis.INFO_COMP_CLASS_SIZE_COMP_OOPS_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_COMP_CLASS_SIZE_COMP_OOPS_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK), Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_COMP_CLASS_SIZE_COMP_OOPS_DISABLED), Analysis.INFO_COMP_CLASS_SIZE_COMP_OOPS_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -197,10 +178,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK));
-        assertTrue(Analysis.INFO_COMP_CLASS_SIZE_COMP_CLASS_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_COMP_CLASS_SIZE_COMP_CLASS_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK), Analysis.WARN_COMP_CLASS_DISABLED_HEAP_UNK + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_COMP_CLASS_SIZE_COMP_CLASS_DISABLED), Analysis.INFO_COMP_CLASS_SIZE_COMP_CLASS_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -210,8 +189,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G), Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis not identified.");
     }
 
     @Test
@@ -221,10 +199,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G));
-        assertFalse(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G), Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK), Analysis.WARN_COMP_OOPS_DISABLED_HEAP_UNK + " analysis incorrectly identified.");
     }
 
     @Test
@@ -234,8 +210,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G), Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.");
     }
 
     @Test
@@ -245,8 +220,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G), Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G + " analysis not identified.");
     }
 
     @Test
@@ -256,8 +230,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS), Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.");
     }
 
     @Test
@@ -270,8 +243,7 @@ public class TestAnalysis {
                 + "Oct  2 2015 03:26:24 by \"java_re\" with unknown MS VC++:1600";
         jvmRun.getJvm().setVersion(version);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_TIERED_COMPILATION_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_TIERED_COMPILATION_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_TIERED_COMPILATION_ENABLED), Analysis.WARN_TIERED_COMPILATION_ENABLED + " analysis not identified.");
     }
 
     @Test
@@ -281,8 +253,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED), Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -292,10 +263,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED));
-        assertTrue(Analysis.WARN_GC_LOG_FILE_NUM_ROTATION_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_LOG_FILE_NUM_ROTATION_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED), Analysis.INFO_GC_LOG_FILE_ROTATION_DISABLED + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_GC_LOG_FILE_NUM_ROTATION_DISABLED), Analysis.WARN_GC_LOG_FILE_NUM_ROTATION_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -307,8 +276,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(options, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_THREAD_STACK_SIZE_LARGE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_LARGE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_LARGE), Analysis.WARN_THREAD_STACK_SIZE_LARGE + " analysis not identified.");
     }
 
     /**
@@ -321,10 +289,8 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_REDUNDANT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_REDUNDANT));
-        assertTrue(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_REDUNDANT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_REDUNDANT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_REDUNDANT), Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_REDUNDANT + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_REDUNDANT), Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_REDUNDANT + " analysis not identified.");
     }
 
     /**
@@ -336,10 +302,8 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL));
-        assertFalse(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL), Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL + " analysis identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL), Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL + " analysis identified.");
     }
 
     /**
@@ -351,10 +315,8 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL));
-        assertTrue(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL), Analysis.WARN_RMI_DGC_CLIENT_GCINTERVAL_SMALL + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL), Analysis.WARN_RMI_DGC_SERVER_GCINTERVAL_SMALL + " analysis not identified.");
     }
 
     /**
@@ -366,10 +328,8 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_HEAP_DUMP_ON_OOME_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_ON_OOME_MISSING));
-        assertFalse(Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_ON_OOME_MISSING), Analysis.WARN_HEAP_DUMP_ON_OOME_MISSING + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING), Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis incorrectly identified.");
     }
 
     /**
@@ -381,8 +341,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_INSTRUMENTATION + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_INSTRUMENTATION));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_INSTRUMENTATION), Analysis.INFO_INSTRUMENTATION + " analysis not identified.");
     }
 
     /**
@@ -394,8 +353,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_NATIVE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_NATIVE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_NATIVE), Analysis.INFO_NATIVE + " analysis not identified.");
     }
 
     /**
@@ -407,8 +365,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED), Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -420,8 +377,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED), Analysis.WARN_BYTECODE_BACKGROUND_COMPILE_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -433,8 +389,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_BYTECODE_COMPILE_FIRST_INVOCATION + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_COMPILE_FIRST_INVOCATION));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_COMPILE_FIRST_INVOCATION), Analysis.WARN_BYTECODE_COMPILE_FIRST_INVOCATION + " analysis not identified.");
     }
 
     /**
@@ -446,8 +401,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_BYTECODE_COMPILE_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_COMPILE_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_BYTECODE_COMPILE_DISABLED), Analysis.WARN_BYTECODE_COMPILE_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -459,8 +413,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.ERROR_METASPACE_SIZE_LT_COMP_CLASS_SIZE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_METASPACE_SIZE_LT_COMP_CLASS_SIZE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_METASPACE_SIZE_LT_COMP_CLASS_SIZE), Analysis.ERROR_METASPACE_SIZE_LT_COMP_CLASS_SIZE + " analysis not identified.");
     }
 
     /**
@@ -479,8 +432,7 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.G1);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT), Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.");
     }
 
     /**
@@ -499,8 +451,7 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.CMS);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT), Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.");
     }
 
     /**
@@ -512,8 +463,7 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_EXPLICIT_GC_DISABLED_CONCURRENT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_DISABLED_CONCURRENT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_DISABLED_CONCURRENT), Analysis.WARN_EXPLICIT_GC_DISABLED_CONCURRENT + " analysis not identified.");
     }
 
     /**
@@ -525,10 +475,8 @@ public class TestAnalysis {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_HEAP_DUMP_ON_OOME_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_ON_OOME_DISABLED));
-        assertFalse(Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_ON_OOME_DISABLED), Analysis.WARN_HEAP_DUMP_ON_OOME_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING), Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis incorrectly identified.");
     }
 
     /**
@@ -541,8 +489,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS), Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis identified.");
     }
 
     /**
@@ -558,8 +505,7 @@ public class TestAnalysis {
         eventTypes.add(LogEventType.UNKNOWN);
         jvmRun.setEventTypes(eventTypes);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS), Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis not identified.");
     }
 
     /**
@@ -572,8 +518,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_COMMANDLINE_FLAGS), Analysis.WARN_PRINT_COMMANDLINE_FLAGS + " analysis identified.");
     }
 
     /**
@@ -586,8 +531,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING), Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis not identified.");
     }
 
     /**
@@ -600,8 +544,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING), Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis identified.");
     }
 
     /**
@@ -614,8 +557,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED), Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " not identified.");
     }
 
     /**
@@ -628,8 +570,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_CMS_SERIAL_OLD + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_SERIAL_OLD));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_SERIAL_OLD), Analysis.ERROR_CMS_SERIAL_OLD + " analysis not identified.");
     }
 
     /**
@@ -642,8 +583,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.ERROR_CMS_SERIAL_OLD + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_SERIAL_OLD));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_SERIAL_OLD), Analysis.ERROR_CMS_SERIAL_OLD + " analysis identified.");
     }
 
     /**
@@ -662,10 +602,8 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.CMS);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED));
-        assertFalse(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED), Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED), Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis identified.");
     }
 
     /**
@@ -678,8 +616,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED), Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis identified.");
     }
 
     @Test
@@ -689,8 +626,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_PRINT_ADAPTIVE_RESIZE_PLCY_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_ADAPTIVE_RESIZE_PLCY_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_ADAPTIVE_RESIZE_PLCY_ENABLED), Analysis.INFO_PRINT_ADAPTIVE_RESIZE_PLCY_ENABLED + " analysis not identified.");
     }
 
     @Test
@@ -700,8 +636,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_TENURING_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_TENURING_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_TENURING_DISABLED), Analysis.WARN_TENURING_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -714,8 +649,7 @@ public class TestAnalysis {
         collectors.add(JdkUtil.CollectorFamily.PARALLEL);
         jvmRun.setCollectorFamilies(collectors);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE), Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.");
     }
 
     @Test
@@ -728,8 +662,7 @@ public class TestAnalysis {
         collectors.add(JdkUtil.CollectorFamily.CMS);
         jvmRun.setCollectorFamilies(collectors);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE), Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.");
     }
 
     @Test
@@ -742,8 +675,7 @@ public class TestAnalysis {
         collectors.add(JdkUtil.CollectorFamily.G1);
         jvmRun.setCollectorFamilies(collectors);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_MAX_TENURING_OVERRIDE), Analysis.INFO_MAX_TENURING_OVERRIDE + " analysis not identified.");
     }
 
     @Test
@@ -753,8 +685,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_SURVIVOR_RATIO + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SURVIVOR_RATIO));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_SURVIVOR_RATIO), Analysis.INFO_SURVIVOR_RATIO + " analysis not identified.");
     }
 
     @Test
@@ -764,8 +695,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_SURVIVOR_RATIO_TARGET + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SURVIVOR_RATIO_TARGET));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_SURVIVOR_RATIO_TARGET), Analysis.INFO_SURVIVOR_RATIO_TARGET + " analysis not identified.");
     }
 
     @Test
@@ -776,8 +706,7 @@ public class TestAnalysis {
         jvm.setVersion("1.8.0_91-b14");
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis not identified.");
     }
 
     @Test
@@ -787,10 +716,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS), Analysis.WARN_FAST_UNORDERED_TIMESTAMPS + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -804,12 +731,9 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.G1);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40));
-        assertTrue(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40), Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS), Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -820,12 +744,9 @@ public class TestAnalysis {
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.getJvm().setVersion(" JRE (1.8.0_20-b32) ");
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40));
-        assertTrue(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40), Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS), Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -839,12 +760,9 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.CMS);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40));
-        assertFalse(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40), Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS), Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -859,12 +777,9 @@ public class TestAnalysis {
         collectorFamilies.add(CollectorFamily.G1);
         jvmRun.setCollectorFamilies(collectorFamilies);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40));
-        assertFalse(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40), Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS), Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -875,12 +790,9 @@ public class TestAnalysis {
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.getJvm().setVersion(" JRE (1.8.0_40-b26) ");
         jvmRun.doAnalysis();
-        assertTrue(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
-        assertFalse(Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40));
-        assertFalse(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40), Analysis.WARN_G1_JDK8_PRIOR_U40 + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_G1_JDK8_PRIOR_U40_RECS), Analysis.WARN_G1_JDK8_PRIOR_U40_RECS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -890,8 +802,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_CMS_PARALLEL_INITIAL_MARK_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PARALLEL_INITIAL_MARK_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PARALLEL_INITIAL_MARK_DISABLED), Analysis.ERROR_CMS_PARALLEL_INITIAL_MARK_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -901,8 +812,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.ERROR_CMS_PARALLEL_REMARK_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PARALLEL_REMARK_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PARALLEL_REMARK_DISABLED), Analysis.ERROR_CMS_PARALLEL_REMARK_DISABLED + " analysis not identified.");
     }
 
     @Test
@@ -913,8 +823,7 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertFalse(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT), Analysis.INFO_G1_SUMMARIZE_RSET_STATS_OUTPUT + " analysis incorrectly identified.");
     }
 
     @Test
@@ -927,8 +836,7 @@ public class TestAnalysis {
         jvmRun.setEventTypes(eventTypes);
         jvmRun.getAnalysis().clear();
         jvmRun.doAnalysis();
-        assertFalse(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING), Analysis.WARN_APPLICATION_STOPPED_TIME_MISSING + " analysis incorrectly identified.");
     }
 
     @Test
@@ -938,10 +846,8 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_CGROUP_MEMORY_LIMIT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CGROUP_MEMORY_LIMIT));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CGROUP_MEMORY_LIMIT), Analysis.WARN_CGROUP_MEMORY_LIMIT + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
     }
 
     @Test
@@ -951,12 +857,9 @@ public class TestAnalysis {
         Jvm jvm = new Jvm(jvmOptions, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         jvmRun.doAnalysis();
-        assertTrue(Analysis.WARN_HEAP_MIN_NOT_EQUAL_MAX + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_MIN_NOT_EQUAL_MAX));
-        assertTrue(Analysis.ERROR_ADAPTIVE_SIZE_POLICY_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_ADAPTIVE_SIZE_POLICY_DISABLED));
-        assertFalse(Analysis.INFO_UNACCOUNTED_OPTIONS_DISABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_UNACCOUNTED_OPTIONS_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_MIN_NOT_EQUAL_MAX), Analysis.WARN_HEAP_MIN_NOT_EQUAL_MAX + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_ADAPTIVE_SIZE_POLICY_DISABLED), Analysis.ERROR_ADAPTIVE_SIZE_POLICY_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_UNACCOUNTED_OPTIONS_DISABLED), Analysis.INFO_UNACCOUNTED_OPTIONS_DISABLED + " analysis incorrectly identified.");
     }
 
     @Test
@@ -966,15 +869,11 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " information not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS));
-        assertTrue(JdkUtil.LogEventType.HEADER_MEMORY.toString() + " information not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY));
-        assertTrue(JdkUtil.LogEventType.HEADER_VERSION.toString() + " information not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION));
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_COMMAND_LINE_FLAGS), JdkUtil.LogEventType.HEADER_COMMAND_LINE_FLAGS.toString() + " information not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_MEMORY), JdkUtil.LogEventType.HEADER_MEMORY.toString() + " information not identified.");
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.HEADER_VERSION), JdkUtil.LogEventType.HEADER_VERSION.toString() + " information not identified.");
         // Usually no reason to set the thread stack size on 64 bit.
-        assertFalse(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET), Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis incorrectly identified.");
     }
 
     /**
@@ -988,10 +887,8 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_PERM_SIZE_NOT_SET + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PERM_SIZE_NOT_SET));
-        assertFalse(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PERM_SIZE_NOT_SET), Analysis.WARN_PERM_SIZE_NOT_SET + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT), Analysis.WARN_EXPLICIT_GC_NOT_CONCURRENT + " analysis not identified.");
     }
 
     /**
@@ -1005,17 +902,12 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW));
-        assertTrue(Analysis.ERROR_EXPLICIT_GC_SERIAL_CMS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_CMS));
-        assertFalse(Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS));
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_SERIAL_OLD), "Log line not recognized as " + JdkUtil.LogEventType.CMS_SERIAL_OLD.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PAR_NEW), "Log line not recognized as " + JdkUtil.LogEventType.PAR_NEW.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_EXPLICIT_GC_SERIAL_CMS), Analysis.ERROR_EXPLICIT_GC_SERIAL_CMS + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_CMS), Analysis.ERROR_SERIAL_GC_CMS + " analysis incorrectly identified.");
     }
 
     /**
@@ -1028,18 +920,13 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 2, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SCAVENGE));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD));
-        assertTrue(Analysis.WARN_EXPLICIT_GC_PARALLEL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_PARALLEL));
-        assertFalse(Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL));
-        assertEquals("Inverted parallelism event count not correct.", 0, jvmRun.getInvertedParallelismCount());
+        assertEquals(2,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_SCAVENGE), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_SCAVENGE.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD), "Log line not recognized as " + JdkUtil.LogEventType.PARALLEL_COMPACTING_OLD.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_PARALLEL), Analysis.WARN_EXPLICIT_GC_PARALLEL + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC_PARALLEL), Analysis.ERROR_SERIAL_GC_PARALLEL + " analysis incorrectly identified.");
+        assertEquals((long) 0,jvmRun.getInvertedParallelismCount(),"Inverted parallelism event count not correct.");
     }
 
     @Test
@@ -1049,8 +936,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET), Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis not identified.");
     }
 
     @Test
@@ -1060,8 +946,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_HEAP_DUMP_PATH_FILENAME + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_PATH_FILENAME));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_HEAP_DUMP_PATH_FILENAME), Analysis.WARN_HEAP_DUMP_PATH_FILENAME + " analysis not identified.");
     }
 
     /**
@@ -1074,23 +959,15 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 4, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.SERIAL_NEW));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_INITIAL_MARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_REMARK));
-        assertTrue("Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".",
-                jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT));
-        assertTrue(Analysis.WARN_CMS_PAR_NEW_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_PAR_NEW_DISABLED));
-        assertFalse(Analysis.ERROR_SERIAL_GC + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC));
-        assertFalse(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED));
+        assertEquals(4,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.SERIAL_NEW), "Log line not recognized as " + JdkUtil.LogEventType.SERIAL_NEW.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_INITIAL_MARK), "Log line not recognized as " + JdkUtil.LogEventType.CMS_INITIAL_MARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_REMARK), "Log line not recognized as " + JdkUtil.LogEventType.CMS_REMARK.toString() + ".");
+        assertTrue(jvmRun.getEventTypes().contains(JdkUtil.LogEventType.CMS_CONCURRENT), "Log line not recognized as " + JdkUtil.LogEventType.CMS_CONCURRENT.toString() + ".");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_PAR_NEW_DISABLED), Analysis.WARN_CMS_PAR_NEW_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_SERIAL_GC), Analysis.ERROR_SERIAL_GC + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED), Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis incorrectly identified.");
     }
 
     /**
@@ -1103,13 +980,10 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Max heap value not parsed correctly.", "45097156608", jvmRun.getJvm().getMaxHeapValue());
-        assertFalse(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G));
-        assertFalse(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G));
-        assertTrue(Analysis.ERROR_COMP_CLASS_SIZE_HEAP_GT_32G + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_SIZE_HEAP_GT_32G));
+        assertEquals("45097156608",jvmRun.getJvm().getMaxHeapValue(),"Max heap value not parsed correctly.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G), Analysis.ERROR_COMP_OOPS_DISABLED_HEAP_LT_32G + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G), Analysis.ERROR_COMP_OOPS_ENABLED_HEAP_GT_32G + " analysis incorrectly identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_COMP_CLASS_SIZE_HEAP_GT_32G), Analysis.ERROR_COMP_CLASS_SIZE_HEAP_GT_32G + " analysis not identified.");
     }
 
     /**
@@ -1122,15 +996,12 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Physical not parsed correctly.", bytes(50465866752L), jvmRun.getJvm().getPhysicalMemory());
-        assertEquals("Heap size not parsed correctly.", bytes(45097156608L), jvmRun.getJvm().getMaxHeapBytes());
-        assertEquals("Metaspace size not parsed correctly.", bytes(5368709120L),
-                jvmRun.getJvm().getMaxMetaspaceBytes());
+        assertEquals(bytes(50465866752L),jvmRun.getJvm().getPhysicalMemory(),"Physical not parsed correctly.");
+        assertEquals(bytes(45097156608L),jvmRun.getJvm().getMaxHeapBytes(),"Heap size not parsed correctly.");
+        assertEquals(bytes(5368709120L),jvmRun.getJvm().getMaxMetaspaceBytes(),"Metaspace size not parsed correctly.");
         // Class compressed pointer space has a size, but it is ignored when calculating JVM memory.
-        assertEquals("Class compressed pointer space size not parsed correctly.", bytes(1073741824L),
-                jvmRun.getJvm().getCompressedClassSpaceSizeBytes());
-        assertFalse(Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY));
+        assertEquals(bytes(1073741824L),jvmRun.getJvm().getCompressedClassSpaceSizeBytes(),"Class compressed pointer space size not parsed correctly.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY), Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.");
     }
 
     /**
@@ -1143,12 +1014,9 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + " collector not identified.",
-                jvmRun.getEventTypes().contains(LogEventType.VERBOSE_GC_YOUNG));
-        assertTrue(Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED));
-        assertFalse(Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING));
+        assertTrue(jvmRun.getEventTypes().contains(LogEventType.VERBOSE_GC_YOUNG), JdkUtil.LogEventType.VERBOSE_GC_YOUNG.toString() + " collector not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_DISABLED), Analysis.WARN_PRINT_GC_DETAILS_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_DETAILS_MISSING), Analysis.WARN_PRINT_GC_DETAILS_MISSING + " analysis incorrectly identified.");
     }
 
     /**
@@ -1161,14 +1029,11 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Physical not parsed correctly.", bytes(16728526848L), jvmRun.getJvm().getPhysicalMemory());
-        assertEquals("Heap size not parsed correctly.", bytes(5368709120L), jvmRun.getJvm().getMaxHeapBytes());
-        assertEquals("Metaspace size not parsed correctly.", bytes(3221225472L),
-                jvmRun.getJvm().getMaxMetaspaceBytes());
-        assertEquals("Class compressed pointer space size not parsed correctly.", bytes(2147483648L),
-                jvmRun.getJvm().getCompressedClassSpaceSizeBytes());
-        assertFalse(Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY));
+        assertEquals(bytes(16728526848L),jvmRun.getJvm().getPhysicalMemory(),"Physical not parsed correctly.");
+        assertEquals(bytes(5368709120L),jvmRun.getJvm().getMaxHeapBytes(),"Heap size not parsed correctly.");
+        assertEquals(bytes(3221225472L),jvmRun.getJvm().getMaxMetaspaceBytes(),"Metaspace size not parsed correctly.");
+        assertEquals(bytes(2147483648L),jvmRun.getJvm().getCompressedClassSpaceSizeBytes(),"Class compressed pointer space size not parsed correctly.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY), Analysis.ERROR_PHYSICAL_MEMORY + " analysis incorrectly identified.");
     }
 
     /**
@@ -1181,13 +1046,11 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Physical not parsed correctly.", bytes(1968287744L), jvmRun.getJvm().getPhysicalMemory());
-        assertEquals("Heap size not parsed correctly.", bytes(4718592000L), jvmRun.getJvm().getMaxHeapBytes());
-        assertEquals("Metaspace size not parsed correctly.", bytes(0L), jvmRun.getJvm().getMaxMetaspaceBytes());
-        assertEquals("Class compressed pointer space size not parsed correctly.", bytes(0L),
-                jvmRun.getJvm().getCompressedClassSpaceSizeBytes());
-        assertTrue(Analysis.ERROR_PHYSICAL_MEMORY + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY));
+        assertEquals(bytes(1968287744L),jvmRun.getJvm().getPhysicalMemory(),"Physical not parsed correctly.");
+        assertEquals(bytes(4718592000L),jvmRun.getJvm().getMaxHeapBytes(),"Heap size not parsed correctly.");
+        assertEquals(bytes(0L),jvmRun.getJvm().getMaxMetaspaceBytes(),"Metaspace size not parsed correctly.");
+        assertEquals(bytes(0L),jvmRun.getJvm().getCompressedClassSpaceSizeBytes(),"Class compressed pointer space size not parsed correctly.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_PHYSICAL_MEMORY), Analysis.ERROR_PHYSICAL_MEMORY + " analysis not identified.");
     }
 
     /**
@@ -1200,14 +1063,10 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED));
-        assertFalse(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED));
-        assertTrue(Analysis.WARN_CLASS_UNLOADING_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CLASS_UNLOADING_DISABLED));
-        assertTrue(Analysis.INFO_CRUFT_EXP_GC_INV_CON_AND_UNL_CLA + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_CRUFT_EXP_GC_INV_CON_AND_UNL_CLA));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED), Analysis.WARN_CMS_CLASS_UNLOADING_DISABLED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED), Analysis.WARN_CMS_CLASS_UNLOADING_NOT_ENABLED + " analysis incorrectly identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CLASS_UNLOADING_DISABLED), Analysis.WARN_CLASS_UNLOADING_DISABLED + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_CRUFT_EXP_GC_INV_CON_AND_UNL_CLA), Analysis.INFO_CRUFT_EXP_GC_INV_CON_AND_UNL_CLA + " analysis not identified.");
     }
 
     /**
@@ -1220,11 +1079,9 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_APPLICATION_LOGGING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_LOGGING));
-        assertTrue("64-bit not identified.", jvmRun.getJvm().is64Bit());
-        assertFalse(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_APPLICATION_LOGGING), Analysis.WARN_APPLICATION_LOGGING + " analysis not identified.");
+        assertTrue(jvmRun.getJvm().is64Bit(), "64-bit not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_THREAD_STACK_SIZE_NOT_SET), Analysis.WARN_THREAD_STACK_SIZE_NOT_SET + " analysis incorrectly identified.");
 
     }
 
@@ -1238,14 +1095,10 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS));
-        assertTrue(Analysis.INFO_PRINT_PROMOTION_FAILURE + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_PROMOTION_FAILURE));
-        assertTrue(Analysis.WARN_USE_MEMBAR + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_USE_MEMBAR));
-        assertTrue(Analysis.WARN_CMS_INIT_OCCUPANCY_ONLY_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INIT_OCCUPANCY_ONLY_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_FLS_STATISTICS), Analysis.INFO_PRINT_FLS_STATISTICS + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_PRINT_PROMOTION_FAILURE), Analysis.INFO_PRINT_PROMOTION_FAILURE + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_USE_MEMBAR), Analysis.WARN_USE_MEMBAR + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INIT_OCCUPANCY_ONLY_MISSING), Analysis.WARN_CMS_INIT_OCCUPANCY_ONLY_MISSING + " analysis not identified.");
     }
 
     /**
@@ -1258,14 +1111,10 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.ERROR_G1_HUMONGOUS_JDK_OLD + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_G1_HUMONGOUS_JDK_OLD));
-        assertTrue(Analysis.WARN_G1_MIXED_GC_LIVE_THRSHOLD_PRCNT + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_G1_MIXED_GC_LIVE_THRSHOLD_PRCNT));
-        assertFalse(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS));
-        assertFalse(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_G1_HUMONGOUS_JDK_OLD), Analysis.ERROR_G1_HUMONGOUS_JDK_OLD + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_G1_MIXED_GC_LIVE_THRSHOLD_PRCNT), Analysis.WARN_G1_MIXED_GC_LIVE_THRSHOLD_PRCNT + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_EXPERIMENTAL_VM_OPTIONS), Analysis.INFO_EXPERIMENTAL_VM_OPTIONS + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED), Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis incorrectly identified.");
     }
 
     /**
@@ -1278,12 +1127,9 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.ERROR_CMS_PAR_NEW_GC_LOCKER_FAILED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PAR_NEW_GC_LOCKER_FAILED));
-        assertFalse(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED));
-        assertTrue(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PAR_NEW_GC_LOCKER_FAILED), Analysis.ERROR_CMS_PAR_NEW_GC_LOCKER_FAILED + " analysis not identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED), Analysis.WARN_PRINT_GC_CAUSE_NOT_ENABLED + " analysis incorrectly identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED), Analysis.INFO_GC_LOG_FILE_ROTATION_NOT_ENABLED + " analysis not identified.");
     }
 
     /**
@@ -1297,8 +1143,7 @@ public class TestAnalysis {
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
         // VERGOSE_GC_OLD looks the same as G1_FULL without -XX:+PrintGCDetails
-        assertTrue(Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN), Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.");
     }
 
     /**
@@ -1311,8 +1156,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_EXPLICIT_GC_UNKNOWN), Analysis.WARN_EXPLICIT_GC_UNKNOWN + " analysis not identified.");
     }
 
     /**
@@ -1325,8 +1169,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.ERROR_CMS_PROMOTION_FAILED), Analysis.ERROR_CMS_PROMOTION_FAILED + " analysis incorrectly identified.");
     }
 
     /**
@@ -1339,8 +1182,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM), Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis not identified.");
     }
 
     /**
@@ -1353,8 +1195,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_CMS_REMARK_LOW_PARALLELISM + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_REMARK_LOW_PARALLELISM));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_REMARK_LOW_PARALLELISM), Analysis.WARN_CMS_REMARK_LOW_PARALLELISM + " analysis not identified.");
     }
 
     /**
@@ -1367,8 +1208,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM), Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis incorrectly identified.");
     }
 
     /**
@@ -1381,10 +1221,8 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertFalse(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM));
-        assertFalse(Analysis.INFO_SWAP_DISABLED + " analysis incorrectly identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SWAP_DISABLED));
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM), Analysis.WARN_CMS_INITIAL_MARK_LOW_PARALLELISM + " analysis incorrectly identified.");
+        assertFalse(jvmRun.getAnalysis().contains(Analysis.INFO_SWAP_DISABLED), Analysis.INFO_SWAP_DISABLED + " analysis incorrectly identified.");
     }
 
     /**
@@ -1397,8 +1235,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_GC_LOG_FILE_SIZE_SMALL + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_GC_LOG_FILE_SIZE_SMALL));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_GC_LOG_FILE_SIZE_SMALL), Analysis.WARN_GC_LOG_FILE_SIZE_SMALL + " analysis not identified.");
     }
 
     /**
@@ -1411,8 +1248,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_HEAP_DUMP_PATH_MISSING), Analysis.INFO_HEAP_DUMP_PATH_MISSING + " analysis not identified.");
     }
 
     /**
@@ -1425,8 +1261,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_SWAP_DISABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_SWAP_DISABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_SWAP_DISABLED), Analysis.INFO_SWAP_DISABLED + " analysis not identified.");
     }
 
     /**
@@ -1439,10 +1274,8 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.INFO_JMX_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_JMX_ENABLED));
-        assertTrue(Analysis.INFO_DIAGNOSTIC_VM_OPTIONS_ENABLED + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.INFO_DIAGNOSTIC_VM_OPTIONS_ENABLED));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_JMX_ENABLED), Analysis.INFO_JMX_ENABLED + " analysis not identified.");
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.INFO_DIAGNOSTIC_VM_OPTIONS_ENABLED), Analysis.INFO_DIAGNOSTIC_VM_OPTIONS_ENABLED + " analysis not identified.");
     }
 
     /**
@@ -1455,8 +1288,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertTrue(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS + " analysis not identified.",
-                jvmRun.getAnalysis().contains(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS));
+        assertTrue(jvmRun.getAnalysis().contains(Analysis.WARN_FAST_UNORDERED_TIMESTAMPS), Analysis.WARN_FAST_UNORDERED_TIMESTAMPS + " analysis not identified.");
     }
 
     /**
@@ -1469,8 +1301,7 @@ public class TestAnalysis {
         File preprocessedFile = gcManager.preprocess(testFile, null);
         gcManager.store(preprocessedFile, false);
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(null, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
-        assertEquals("Event type count not correct.", 1, jvmRun.getEventTypes().size());
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.",
-                jvmRun.getEventTypes().contains(LogEventType.UNKNOWN));
+        assertEquals(1,jvmRun.getEventTypes().size(),"Event type count not correct.");
+        assertFalse(jvmRun.getEventTypes().contains(LogEventType.UNKNOWN), JdkUtil.LogEventType.UNKNOWN.toString() + " collector identified.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestAnalysis.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestAnalysis.java
@@ -34,13 +34,13 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestAnalysis {
+class TestAnalysis {
 
     /**
      * Verify analysis file property key/value lookup.
      */
     @Test
-    public void testPropertyKeyValueLookup() {
+    void testPropertyKeyValueLookup() {
         Analysis[] analysis = Analysis.values();
         for (int i = 0; i < analysis.length; i++) {
             assertNotNull(analysis[i].getKey() + " not found.", analysis[i].getValue());
@@ -48,7 +48,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testBisasedLockingDisabled() {
+    void testBisasedLockingDisabled() {
         String jvmOptions = "-Xss128k -XX:-UseBiasedLocking -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -65,7 +65,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintClassHistogramEnabled() {
+    void testPrintClassHistogramEnabled() {
         String jvmOptions = "-Xss128k -XX:+PrintClassHistogram -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -77,7 +77,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintClassHistogramAfterFullGcEnabled() {
+    void testPrintClassHistogramAfterFullGcEnabled() {
         String jvmOptions = "-Xss128k -XX:+PrintClassHistogramAfterFullGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -89,7 +89,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintClassHistogramBeforeFullGcEnabled() {
+    void testPrintClassHistogramBeforeFullGcEnabled() {
         String jvmOptions = "-Xss128k -XX:+PrintClassHistogramBeforeFullGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -101,7 +101,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintApplicationConcurrentTime() {
+    void testPrintApplicationConcurrentTime() {
         String jvmOptions = "-Xss128k -XX:+PrintGCApplicationConcurrentTime -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -111,7 +111,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testTraceClassUnloading() {
+    void testTraceClassUnloading() {
         String jvmOptions = "-Xss128k -XX:+TraceClassUnloading -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -121,7 +121,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassPointersEnabledCompressedOopsDisabledHeapUnknown() {
+    void testCompressedClassPointersEnabledCompressedOopsDisabledHeapUnknown() {
         String jvmOptions = "-Xss128k -XX:+UseCompressedClassPointers -XX:-UseCompressedOops -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -131,7 +131,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassPointersEnabledHeapGt32G() {
+    void testCompressedClassPointersEnabledHeapGt32G() {
         String jvmOptions = "-Xss128k -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -Xmx32g";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -141,7 +141,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassPointersDisabledHeapLt32G() {
+    void testCompressedClassPointersDisabledHeapLt32G() {
         String jvmOptions = "-Xss128k -XX:-UseCompressedClassPointers -XX:+UseCompressedOops -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -151,7 +151,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassPointersDisabledHeapUnknown() {
+    void testCompressedClassPointersDisabledHeapUnknown() {
         String jvmOptions = "-Xss128k -XX:-UseCompressedClassPointers -XX:+UseCompressedOops";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -161,7 +161,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassSpaceSizeWithCompressedOopsDisabledHeapUnknown() {
+    void testCompressedClassSpaceSizeWithCompressedOopsDisabledHeapUnknown() {
         String jvmOptions = "-Xss128k -XX:CompressedClassSpaceSize=1G -XX:-UseCompressedOops -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -172,7 +172,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedClassSpaceSizeWithCompressedClassPointersDisabledHeapUnknown() {
+    void testCompressedClassSpaceSizeWithCompressedClassPointersDisabledHeapUnknown() {
         String jvmOptions = "-Xss128k -XX:CompressedClassSpaceSize=1G -XX:-UseCompressedClassPointers -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -183,7 +183,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedOopsDisabledHeapLess32G() {
+    void testCompressedOopsDisabledHeapLess32G() {
         String jvmOptions = "-Xss128k -XX:-UseCompressedOops -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -193,7 +193,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedOopsDisabledHeapEqual32G() {
+    void testCompressedOopsDisabledHeapEqual32G() {
         String jvmOptions = "-Xss128k -XX:-UseCompressedOops -Xmx32G";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -204,7 +204,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedOopsDisabledHeapGreater32G() {
+    void testCompressedOopsDisabledHeapGreater32G() {
         String jvmOptions = "-Xss128k -XX:-UseCompressedOops -Xmx40G";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -214,7 +214,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCompressedOopsEnabledHeapGreater32G() {
+    void testCompressedOopsEnabledHeapGreater32G() {
         String jvmOptions = "-Xss128k -XX:+UseCompressedOops -Xmx40G";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -224,7 +224,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintFlsStatistics() {
+    void testPrintFlsStatistics() {
         String jvmOptions = "-Xss128k -XX:PrintFLSStatistics=1 -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -234,7 +234,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testTieredCompilation() {
+    void testTieredCompilation() {
         String jvmOptions = "-Xss128k -XX:+TieredCompilation -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -247,7 +247,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testLogFileRotationDisabled() {
+    void testLogFileRotationDisabled() {
         String jvmOptions = "-Xss128k -XX:-UseGCLogFileRotation -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -257,7 +257,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testLogFileNumberWithRotationDisabled() {
+    void testLogFileNumberWithRotationDisabled() {
         String jvmOptions = "-Xss128k -XX:NumberOfGCLogFiles=5 -XX:-UseGCLogFileRotation -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -271,7 +271,7 @@ public class TestAnalysis {
      * Test passing JVM options on the command line.
      */
     @Test
-    public void testThreadStackSizeLarge() {
+    void testThreadStackSizeLarge() {
         String options = "-o \"-Xss1024k\"";
         GcManager gcManager = new GcManager();
         JvmRun jvmRun = gcManager.getJvmRun(new Jvm(options, null), Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
@@ -283,7 +283,7 @@ public class TestAnalysis {
      * Test DGC redundant options analysis.
      */
     @Test
-    public void testDgcRedundantOptions() {
+    void testDgcRedundantOptions() {
         String jvmOptions = "-XX:+DisableExplicitGC -Dsun.rmi.dgc.client.gcInterval=14400000 "
                 + "-Dsun.rmi.dgc.server.gcInterval=24400000";
         GcManager gcManager = new GcManager();
@@ -297,7 +297,7 @@ public class TestAnalysis {
      * Test analysis not small DGC intervals.
      */
     @Test
-    public void testDgcNotSmallIntervals() {
+    void testDgcNotSmallIntervals() {
         String jvmOptions = "-Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -310,7 +310,7 @@ public class TestAnalysis {
      * Test analysis small DGC intervals
      */
     @Test
-    public void testDgcSmallIntervals() {
+    void testDgcSmallIntervals() {
         String jvmOptions = "-Dsun.rmi.dgc.client.gcInterval=3599999 -Dsun.rmi.dgc.server.gcInterval=3599999";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -323,7 +323,7 @@ public class TestAnalysis {
      * Test analysis if heap dump on OOME enabled.
      */
     @Test
-    public void testHeapDumpOnOutOfMemoryError() {
+    void testHeapDumpOnOutOfMemoryError() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -336,7 +336,7 @@ public class TestAnalysis {
      * Test analysis if instrumentation being used.
      */
     @Test
-    public void testInstrumentation() {
+    void testInstrumentation() {
         String jvmOptions = "-Xss128k -Xms2048M -javaagent:byteman.jar=script:kill-3.btm,boot:byteman.jar -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -348,7 +348,7 @@ public class TestAnalysis {
      * Test analysis if native library being used.
      */
     @Test
-    public void testNative() {
+    void testNative() {
         String jvmOptions = "-Xss128k -Xms2048M -agentpath:/path/to/agent.so -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -360,7 +360,7 @@ public class TestAnalysis {
      * Test analysis background compilation disabled.
      */
     @Test
-    public void testBackgroundCompilationDisabled() {
+    void testBackgroundCompilationDisabled() {
         String jvmOptions = "-Xss128k -XX:-BackgroundCompilation -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -372,7 +372,7 @@ public class TestAnalysis {
      * Test analysis background compilation disabled.
      */
     @Test
-    public void testBackgroundCompilationDisabledXBatch() {
+    void testBackgroundCompilationDisabledXBatch() {
         String jvmOptions = "-Xss128k -Xbatch -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -384,7 +384,7 @@ public class TestAnalysis {
      * Test analysis compilation on first invocation enabled.
      */
     @Test
-    public void testCompilationOnFirstInvocation() {
+    void testCompilationOnFirstInvocation() {
         String jvmOptions = "-Xss128k -Xcomp-Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -396,7 +396,7 @@ public class TestAnalysis {
      * Test analysis just in time (JIT) compiler disabled.
      */
     @Test
-    public void testCompilationDisabled() {
+    void testCompilationDisabled() {
         String jvmOptions = "-Xss128k -Xint -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -408,7 +408,7 @@ public class TestAnalysis {
      * Test MaxMetaspaceSize is less than CompressedClassSpaceSize.
      */
     @Test
-    public void testMetaspaceSizeLtCompClassSize() {
+    void testMetaspaceSizeLtCompClassSize() {
         String jvmOptions = "-XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=512M -XX:CompressedClassSpaceSize=1024M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -420,7 +420,7 @@ public class TestAnalysis {
      * Test analysis explicit GC not concurrent.
      */
     @Test
-    public void testExplicitGcNotConcurrentG1() {
+    void testExplicitGcNotConcurrentG1() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -439,7 +439,7 @@ public class TestAnalysis {
      * Test analysis explicit GC not concurrent.
      */
     @Test
-    public void testExplicitGcNotConcurrentCms() {
+    void testExplicitGcNotConcurrentCms() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -458,7 +458,7 @@ public class TestAnalysis {
      * Test DisableExplicitGC in combination with ExplicitGCInvokesConcurrent.
      */
     @Test
-    public void testDisableExplictGcWithConcurrentHandling() {
+    void testDisableExplictGcWithConcurrentHandling() {
         String jvmOptions = "-Xss128k -XX:+DisableExplicitGC -XX:+ExplicitGCInvokesConcurrent -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -470,7 +470,7 @@ public class TestAnalysis {
      * Test HeapDumpOnOutOfMemoryError disabled.
      */
     @Test
-    public void testHeapDumpOnOutOfMemoryErrorDisabled() {
+    void testHeapDumpOnOutOfMemoryErrorDisabled() {
         String jvmOptions = "-Xss128k -XX:-HeapDumpOnOutOfMemoryError -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -483,7 +483,7 @@ public class TestAnalysis {
      * Test PrintCommandLineFlags missing.
      */
     @Test
-    public void testPrintCommandlineFlagsNoGcLogging() {
+    void testPrintCommandlineFlagsNoGcLogging() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -496,7 +496,7 @@ public class TestAnalysis {
      * Test PrintCommandLineFlags missing.
      */
     @Test
-    public void testPrintCommandlineFlagsMissing() {
+    void testPrintCommandlineFlagsMissing() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -512,7 +512,7 @@ public class TestAnalysis {
      * Test PrintCommandLineFlags not missing.
      */
     @Test
-    public void testPrintCommandlineFlagsNotMissing() {
+    void testPrintCommandlineFlagsNotMissing() {
         String jvmOptions = "-Xss128k -XX:+PrintCommandLineFlags -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -525,7 +525,7 @@ public class TestAnalysis {
      * Test PrintGCDetails missing.
      */
     @Test
-    public void testPrintGCDetailsMissing() {
+    void testPrintGCDetailsMissing() {
         String jvmOptions = "-Xss128k -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -538,7 +538,7 @@ public class TestAnalysis {
      * Test PrintGCDetails not missing.
      */
     @Test
-    public void testPrintGCDetailsNotMissing() {
+    void testPrintGCDetailsNotMissing() {
         String jvmOptions = "-Xss128k -XX:+PrintGCDetails -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -551,7 +551,7 @@ public class TestAnalysis {
      * Test PrintGCDetails disabled.
      */
     @Test
-    public void testPrintGCDetailsDisabled() {
+    void testPrintGCDetailsDisabled() {
         String jvmOptions = "-Xss128k -XX:-PrintGCDetails -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -564,7 +564,7 @@ public class TestAnalysis {
      * Test CMS not being used to collect old generation.
      */
     @Test
-    public void testCmsYoungSerialOld() {
+    void testCmsYoungSerialOld() {
         String jvmOptions = "-Xss128k -XX:+UseParNewGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -577,7 +577,7 @@ public class TestAnalysis {
      * Test CMS being used to collect old generation.
      */
     @Test
-    public void testCmsYoungCmsOld() {
+    void testCmsYoungCmsOld() {
         String jvmOptions = "-Xss128k -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -Xms2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -590,7 +590,7 @@ public class TestAnalysis {
      * Test CMS being used to collect old generation.
      */
     @Test
-    public void testCMSClassUnloadingEnabledMissing() {
+    void testCMSClassUnloadingEnabledMissing() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -610,7 +610,7 @@ public class TestAnalysis {
      * Test CMS handling perm/metaspace collections.
      */
     @Test
-    public void testCMSClassUnloadingEnabledMissingButNotCms() {
+    void testCMSClassUnloadingEnabledMissingButNotCms() {
         String jvmOptions = "MGM";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -620,7 +620,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testPrintAdaptiveResizePolicyEnabled() {
+    void testPrintAdaptiveResizePolicyEnabled() {
         String jvmOptions = "-Xss128k -XX:+PrintAdaptiveSizePolicy -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -630,7 +630,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testTenuringDisabled() {
+    void testTenuringDisabled() {
         String jvmOptions = "-Xss128k -XX:MaxTenuringThreshold=0 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -640,7 +640,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testMaxTenuringOverrideParallel() {
+    void testMaxTenuringOverrideParallel() {
         String jvmOptions = "-Xss128k -XX:MaxTenuringThreshold=6 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -653,7 +653,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testMaxTenuringOverrideCms() {
+    void testMaxTenuringOverrideCms() {
         String jvmOptions = "-Xss128k -XX:MaxTenuringThreshold=14 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -666,7 +666,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testMaxTenuringOverrideG1() {
+    void testMaxTenuringOverrideG1() {
         String jvmOptions = "-Xss128k -XX:MaxTenuringThreshold=6 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -679,7 +679,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testSurvivorRatio() {
+    void testSurvivorRatio() {
         String jvmOptions = "-Xss128k -XX:SurvivorRatio=6 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -689,7 +689,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testTargetSurvivorRatio() {
+    void testTargetSurvivorRatio() {
         String jvmOptions = "-Xss128k -XX:TargetSurvivorRatio=90 -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -699,7 +699,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testExperimentalOptionsEnabled() {
+    void testExperimentalOptionsEnabled() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -710,7 +710,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testUseFastUnorderedTimeStamps() {
+    void testUseFastUnorderedTimeStamps() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:+UseFastUnorderedTimeStamps -Xmx2048M";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -721,7 +721,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testJdk8G1PriorUpdate40() {
+    void testJdk8G1PriorUpdate40() {
         String jvmOptions = "";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -737,7 +737,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testJdk8G1PriorUpdate40NoLoggingEvents() {
+    void testJdk8G1PriorUpdate40NoLoggingEvents() {
         String jvmOptions = "-XX:+UseG1GC";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -750,7 +750,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testJdk8NotG1PriorUpdate40() {
+    void testJdk8NotG1PriorUpdate40() {
         String jvmOptions = "";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -766,7 +766,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testJdk8G1PriorUpdate40WithRecommendedJvmOptions() {
+    void testJdk8G1PriorUpdate40WithRecommendedJvmOptions() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:G1MixedGCLiveThresholdPercent=85 "
                 + "-XX:G1HeapWastePercent=5";
         GcManager gcManager = new GcManager();
@@ -783,7 +783,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testJdk8Update40() {
+    void testJdk8Update40() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -796,7 +796,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCmsParallelInitialMarkDisabled() {
+    void testCmsParallelInitialMarkDisabled() {
         String jvmOptions = "-XX:-CMSParallelInitialMarkEnabled";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -806,7 +806,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCmsParallelRemarkDisabled() {
+    void testCmsParallelRemarkDisabled() {
         String jvmOptions = "-XX:-CMSParallelRemarkEnabled";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -816,7 +816,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testG1SummarizeRSetStatsPeriod0() {
+    void testG1SummarizeRSetStatsPeriod0() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:+G1SummarizeRSetStats "
                 + "-XX:G1SummarizeRSetStatsPeriod=0";
         GcManager gcManager = new GcManager();
@@ -827,7 +827,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testApplicationStoppedTimeMissingNoData() {
+    void testApplicationStoppedTimeMissingNoData() {
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(null, null);
         JvmRun jvmRun = gcManager.getJvmRun(jvm, Constants.DEFAULT_BOTTLENECK_THROUGHPUT_THRESHOLD);
@@ -840,7 +840,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testCGroupMemoryLimit() {
+    void testCGroupMemoryLimit() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -851,7 +851,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testAdaptiveSizePolicy() {
+    void testAdaptiveSizePolicy() {
         String jvmOptions = "-XX:InitialHeapSize=2147483648 -XX:MaxHeapSize=8589934592 -XX:-UseAdaptiveSizePolicy";
         GcManager gcManager = new GcManager();
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -863,7 +863,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testHeaderLogging() {
+    void testHeaderLogging() {
         File testFile = TestUtil.getFile("dataset42.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -881,7 +881,7 @@ public class TestAnalysis {
      * 
      */
     @Test
-    public void testAnalysisPermSizeNotSet() {
+    void testAnalysisPermSizeNotSet() {
         File testFile = TestUtil.getFile("dataset60.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -896,7 +896,7 @@ public class TestAnalysis {
      * <code>Analysis.KEY_SERIAL_GC_CMS</code>.
      */
     @Test
-    public void testCmsSerialOldExplicitGc() {
+    void testCmsSerialOldExplicitGc() {
         File testFile = TestUtil.getFile("dataset85.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -914,7 +914,7 @@ public class TestAnalysis {
      * Test PARALLEL_COMPACTING_OLD caused by <code>Analysis.KEY_EXPLICIT_GC_SERIAL</code>.
      */
     @Test
-    public void testParallelOldCompactingExplicitGc() {
+    void testParallelOldCompactingExplicitGc() {
         File testFile = TestUtil.getFile("dataset86.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -930,7 +930,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testThreadStackSizeAnalysis32Bit() {
+    void testThreadStackSizeAnalysis32Bit() {
         File testFile = TestUtil.getFile("dataset87.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -940,7 +940,7 @@ public class TestAnalysis {
     }
 
     @Test
-    public void testHeapDumpPathFilename() {
+    void testHeapDumpPathFilename() {
         File testFile = TestUtil.getFile("dataset95.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -953,7 +953,7 @@ public class TestAnalysis {
      * Test PAR_NEW disabled with -XX:-UseParNewGC.
      */
     @Test
-    public void testParNewDisabled() {
+    void testParNewDisabled() {
         File testFile = TestUtil.getFile("dataset101.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -974,7 +974,7 @@ public class TestAnalysis {
      * Test compressed oops disabled with heap >= 32G.
      */
     @Test
-    public void testCompressedOopsDisabledLargeHeap() {
+    void testCompressedOopsDisabledLargeHeap() {
         File testFile = TestUtil.getFile("dataset106.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -990,7 +990,7 @@ public class TestAnalysis {
      * Test physical memory less than heap + perm/metaspace.
      */
     @Test
-    public void testPhysicalMemoryLessThanJvmMemoryWithoutCompressedClassPointerSpace() {
+    void testPhysicalMemoryLessThanJvmMemoryWithoutCompressedClassPointerSpace() {
         File testFile = TestUtil.getFile("dataset106.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1008,7 +1008,7 @@ public class TestAnalysis {
      * Test PrintGCDetails disabled with VERBOSE_GC logging.
      */
     @Test
-    public void testPrintGcDetailsDisabledWithVerboseGc() {
+    void testPrintGcDetailsDisabledWithVerboseGc() {
         File testFile = TestUtil.getFile("dataset107.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1023,7 +1023,7 @@ public class TestAnalysis {
      * Test physical memory less than heap + perm/metaspace.
      */
     @Test
-    public void testPhysicalMemoryLessThanJvmMemoryWithCompressedClassPointerSpace() {
+    void testPhysicalMemoryLessThanJvmMemoryWithCompressedClassPointerSpace() {
         File testFile = TestUtil.getFile("dataset107.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1040,7 +1040,7 @@ public class TestAnalysis {
      * Test physical memory less than heap + perm/metaspace.
      */
     @Test
-    public void testPhysicalMemoryLessThanHeapAllocation() {
+    void testPhysicalMemoryLessThanHeapAllocation() {
         File testFile = TestUtil.getFile("dataset109.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1057,7 +1057,7 @@ public class TestAnalysis {
      * Test CMS class unloading disabled.
      */
     @Test
-    public void testCmsClassunloadingDisabled() {
+    void testCmsClassunloadingDisabled() {
         File testFile = TestUtil.getFile("dataset110.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1073,7 +1073,7 @@ public class TestAnalysis {
      * Test application/gc logging mixed.
      */
     @Test
-    public void testApplicationLogging() {
+    void testApplicationLogging() {
         File testFile = TestUtil.getFile("dataset114.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1089,7 +1089,7 @@ public class TestAnalysis {
      * Test <code>-XX:PrintFLSStatistics</code> and <code>-XX:PrintPromotionFailure</code>.
      */
     @Test
-    public void testPrintFlsStatisticsPrintPromotionFailure() {
+    void testPrintFlsStatisticsPrintPromotionFailure() {
         File testFile = TestUtil.getFile("dataset115.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1105,7 +1105,7 @@ public class TestAnalysis {
      * Test humongous allocations on old JDK not able to reclaim humongous objects during young collections.
      */
     @Test
-    public void testHumongousAllocationsNotCollectedYoung() {
+    void testHumongousAllocationsNotCollectedYoung() {
         File testFile = TestUtil.getFile("dataset118.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1121,7 +1121,7 @@ public class TestAnalysis {
      * Test CMS_SERIAL_OLD triggered by GCLocker promotion failure.
      */
     @Test
-    public void testCmsSerialOldGcLocker() {
+    void testCmsSerialOldGcLocker() {
         File testFile = TestUtil.getFile("dataset119.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1136,7 +1136,7 @@ public class TestAnalysis {
      * Test VERBOSE_GC_OLD triggered by explicit GC.
      */
     @Test
-    public void testVerboseGcOldExplicitGc() {
+    void testVerboseGcOldExplicitGc() {
         File testFile = TestUtil.getFile("dataset125.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1150,7 +1150,7 @@ public class TestAnalysis {
      * Test VERBOSE_GC_YOUNG triggered by explicit GC.
      */
     @Test
-    public void testVerboseGcYoungExplicitGc() {
+    void testVerboseGcYoungExplicitGc() {
         File testFile = TestUtil.getFile("dataset126.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1163,7 +1163,7 @@ public class TestAnalysis {
      * Test serial promotion failed is not reported as cms promotion failed.
      */
     @Test
-    public void testSerialPromotionFailed() {
+    void testSerialPromotionFailed() {
         File testFile = TestUtil.getFile("dataset129.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1176,7 +1176,7 @@ public class TestAnalysis {
      * Test CMS initial mark low parallelism.
      */
     @Test
-    public void testCmsInitialMarkSerial() {
+    void testCmsInitialMarkSerial() {
         File testFile = TestUtil.getFile("dataset130.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1189,7 +1189,7 @@ public class TestAnalysis {
      * Test CMS remark low parallelism.
      */
     @Test
-    public void testCmsRemarkSerial() {
+    void testCmsRemarkSerial() {
         File testFile = TestUtil.getFile("dataset131.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1202,7 +1202,7 @@ public class TestAnalysis {
      * Test CMS remark low parallelism not reported with pause times less than zero.
      */
     @Test
-    public void testInitialMarkLowParallelismFalseReportZeroReal() {
+    void testInitialMarkLowParallelismFalseReportZeroReal() {
         File testFile = TestUtil.getFile("dataset137.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1215,7 +1215,7 @@ public class TestAnalysis {
      * Test CMS remark low parallelism not reported with pause times less than times data centisecond precision.
      */
     @Test
-    public void testInitialMarkLowParallelismFalseReportSmallPause() {
+    void testInitialMarkLowParallelismFalseReportSmallPause() {
         File testFile = TestUtil.getFile("dataset138.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1229,7 +1229,7 @@ public class TestAnalysis {
      * Test small gc log file size.
      */
     @Test
-    public void testGcLogFileSizeSmall() {
+    void testGcLogFileSizeSmall() {
         File testFile = TestUtil.getFile("dataset181.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1242,7 +1242,7 @@ public class TestAnalysis {
      * Test heap dump location missing
      */
     @Test
-    public void testHeapDumpPathMissing() {
+    void testHeapDumpPathMissing() {
         File testFile = TestUtil.getFile("dataset181.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1255,7 +1255,7 @@ public class TestAnalysis {
      * Test swap disabled.
      */
     @Test
-    public void testSwapDisabled() {
+    void testSwapDisabled() {
         File testFile = TestUtil.getFile("dataset187.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1268,7 +1268,7 @@ public class TestAnalysis {
      * Test diagnostic options
      */
     @Test
-    public void testDiagnosticOptions() {
+    void testDiagnosticOptions() {
         File testFile = TestUtil.getFile("dataset192.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1282,7 +1282,7 @@ public class TestAnalysis {
      * Test -XX:+UseFastUnorderedTimeStamps
      */
     @Test
-    public void testFastUnorderedTimestamps() {
+    void testFastUnorderedTimestamps() {
         File testFile = TestUtil.getFile("dataset193.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);
@@ -1295,7 +1295,7 @@ public class TestAnalysis {
      * Test Metadata GC Threshold
      */
     @Test
-    public void testMetadataGcThreshold() {
+    void testMetadataGcThreshold() {
         File testFile = TestUtil.getFile("dataset199.txt");
         GcManager gcManager = new GcManager();
         File preprocessedFile = gcManager.preprocess(testFile, null);

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkMath.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkMath.java
@@ -15,13 +15,13 @@ package org.eclipselabs.garbagecat.util.jdk;
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.GIGABYTES;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.MEGABYTES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.domain.TimesData;
 import org.eclipselabs.garbagecat.util.Memory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,13 +32,13 @@ public class TestJdkMath {
     @Test
     public void testConvertDurationToMillis() {
         String secs = "0.0225213";
-        assertEquals("Secs not converted to milliseconds properly.", 22, JdkMath.convertSecsToMillis(secs).intValue());
+        assertEquals(22,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds properly.");
     }
 
     @Test
     public void testConvertDurationDecimalCommaToMillis() {
         String secs = "0,0225213";
-        assertEquals("Secs not converted to milliseconds properly.", 22, JdkMath.convertSecsToMillis(secs).intValue());
+        assertEquals(22,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds properly.");
     }
 
     /**
@@ -47,50 +47,43 @@ public class TestJdkMath {
     @Test
     public void testConvertDurationToMillisRoundDownOddFive() {
         String secs = "0.0975";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 97,
-                JdkMath.convertSecsToMillis(secs).intValue());
+        assertEquals(97,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
     public void testConvertDurationToMillisRoundDownEvenFive() {
         String secs = "0.0985";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 98,
-                JdkMath.convertSecsToMillis(secs).intValue());
+        assertEquals(98,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
     public void testConvertDurationToMicrosRoundUp() {
         String secs = "0.0968475";
-        assertEquals("Secs not converted to microseconds with expected rounding mode.", 96847,
-                JdkMath.convertSecsToMicros(secs).intValue());
+        assertEquals(96847,JdkMath.convertSecsToMicros(secs).intValue(),"Secs not converted to microseconds with expected rounding mode.");
     }
 
     @Test
     public void testConvertDurationToMicrosRoundDown() {
         String secs = "0.0968485";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 96848,
-                JdkMath.convertSecsToMicros(secs).intValue());
+        assertEquals(96848,JdkMath.convertSecsToMicros(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
     public void testConvertMillisToMicros() {
         String millis = "0.0975";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 97,
-                JdkMath.convertMillisToMicros(millis).intValue());
+        assertEquals(97,JdkMath.convertMillisToMicros(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
     public void testRoundMillis() {
         String millis = "2.169";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 2,
-                JdkMath.roundMillis(millis).intValue());
+        assertEquals(2,JdkMath.roundMillis(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
     public void testRoundMillisDown() {
         String millis = "2.969";
-        assertEquals("Secs not converted to milliseconds with expected rounding mode.", 2,
-                JdkMath.roundMillis(millis).intValue());
+        assertEquals(2,JdkMath.roundMillis(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
@@ -99,7 +92,7 @@ public class TestJdkMath {
         long timestamp = 1000;
         int priorDuration = 10;
         long priorTimestamp = 900;
-        assertEquals(50, JdkMath.calcThroughput(duration, timestamp, priorDuration, priorTimestamp));
+        assertEquals(50,JdkMath.calcThroughput(duration, timestamp, priorDuration, priorTimestamp));
     }
 
     @Test
@@ -108,7 +101,7 @@ public class TestJdkMath {
         durations[0] = "0.0226730";
         durations[1] = "0.0624566";
         durations[2] = "0.0857010";
-        assertEquals("CMS Remark times not added properly.", 170, JdkMath.totalDuration(durations));
+        assertEquals(170,JdkMath.totalDuration(durations),"CMS Remark times not added properly.");
     }
 
     @Test
@@ -117,64 +110,58 @@ public class TestJdkMath {
         durations[0] = "0,0226730";
         durations[1] = "0,0624566";
         durations[2] = "0,0857010";
-        assertEquals("CMS Remark times not added properly.", 170, JdkMath.totalDuration(durations));
+        assertEquals(170,JdkMath.totalDuration(durations),"CMS Remark times not added properly.");
     }
 
     @Test
     public void testConvertDurationMillisToSecs() {
         long duration = 123456;
-        assertEquals("Millis not converted to seconds with expected rounding mode.", "123.456",
-                JdkMath.convertMillisToSecs(duration).toString());
+        assertEquals("123.456",JdkMath.convertMillisToSecs(duration).toString(),"Millis not converted to seconds with expected rounding mode.");
     }
 
     @Test
     public void testCalcKilobytesMegabytes() {
-        assertEquals("Megabytes not converted to kilobytes.", kilobytes(1024), new Memory(1, MEGABYTES));
+        assertEquals(kilobytes(1024),new Memory(1, MEGABYTES),"Megabytes not converted to kilobytes.");
     }
 
     @Test
     public void testCalcKilobytesGigabytes() {
-        assertEquals("Megabytes not converted to kilobytes.", kilobytes(1024 * 1024), new Memory(1, GIGABYTES));
+        assertEquals(kilobytes(1024 * 1024),new Memory(1, GIGABYTES),"Megabytes not converted to kilobytes.");
     }
 
     @Test
     public void testConvertSizeG1DetailsToKilobytesB() {
         String size = "102400";
         char units = 'B';
-        assertEquals("G1 details not converted to kilobytes.", kilobytes(100),
-                JdkMath.convertSizeToKilobytes(size, units));
+        assertEquals(kilobytes(100),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
     public void testConvertSizeG1DetailsToKilobytesK() {
         String size = "1234567";
         char units = 'K';
-        assertEquals("G1 details not converted to kilobytes.", kilobytes(1234567),
-                JdkMath.convertSizeToKilobytes(size, units));
+        assertEquals(kilobytes(1234567),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
     public void testConvertSizeG1DetailsToKilobytesM() {
         String size = "10";
         char units = 'M';
-        assertEquals("G1 details not converted to kilobytes.", kilobytes(10240),
-                JdkMath.convertSizeToKilobytes(size, units));
+        assertEquals(kilobytes(10240),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
     public void testConvertSizeG1DetailsToKilobytesMWithComma() {
         String size = "306,0";
         char units = 'M';
-        assertEquals("G1 details not converted to kilobytes.", kilobytes(313344),
-                JdkMath.convertSizeToKilobytes(size, units));
+        assertEquals(kilobytes(313344),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
     public void testConvertSizeG1DetailsToKilobytesG() {
         String size = "100";
         char units = 'G';
-        assertEquals("G1 details not converted to kilobytes.", kilobytes(104857600),
-                JdkMath.convertSizeToKilobytes(size, units));
+        assertEquals(kilobytes(104857600),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
@@ -182,8 +169,7 @@ public class TestJdkMath {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 10;
-        assertEquals("Parallelism not calculated correctly.", 1000,
-                JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(1000,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -191,7 +177,7 @@ public class TestJdkMath {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 1000;
-        assertEquals("Parallelism not calculated correctly.", 10, JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(10,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -199,7 +185,7 @@ public class TestJdkMath {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 199;
-        assertEquals("Parallelism not calculated correctly.", 51, JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(51,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -207,7 +193,7 @@ public class TestJdkMath {
         int timeUser = 0;
         int timeSys = 0;
         int timeReal = 100;
-        assertEquals("Parallelism not calculated correctly.", 0, JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(0,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -215,8 +201,7 @@ public class TestJdkMath {
         int timeUser = 100;
         int timeSys = 0;
         int timeReal = 0;
-        assertEquals("Parallelism not calculated correctly.", Integer.MAX_VALUE,
-                JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(Integer.MAX_VALUE,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -224,8 +209,7 @@ public class TestJdkMath {
         int timeUser = 0;
         int timeSys = 0;
         int timeReal = 0;
-        assertEquals("Parallelism not calculated correctly.", 100,
-                JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(100,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
@@ -233,14 +217,13 @@ public class TestJdkMath {
         int timeUser = TimesData.NO_DATA;
         int timeSys = TimesData.NO_DATA;
         int timeReal = TimesData.NO_DATA;
-        assertEquals("Parallelism not calculated correctly.", 100,
-                JdkMath.calcParallelism(timeUser, timeSys, timeReal));
+        assertEquals(100,JdkMath.calcParallelism(timeUser, timeSys, timeReal),"Parallelism not calculated correctly.");
     }
 
     @Test
     public void testParallelism() {
-        assertTrue("Parallism not calculated correctly.", JdkMath.isInvertedParallelism(0));
-        assertTrue("Parallism not calculated correctly.", JdkMath.isInvertedParallelism(99));
-        assertFalse("Parallism not calculated correctly.", JdkMath.isInvertedParallelism(100));
+        assertTrue(JdkMath.isInvertedParallelism(0), "Parallism not calculated correctly.");
+        assertTrue(JdkMath.isInvertedParallelism(99), "Parallism not calculated correctly.");
+        assertFalse(JdkMath.isInvertedParallelism(100), "Parallism not calculated correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkMath.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkMath.java
@@ -27,16 +27,16 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJdkMath {
+class TestJdkMath {
 
     @Test
-    public void testConvertDurationToMillis() {
+    void testConvertDurationToMillis() {
         String secs = "0.0225213";
         assertEquals(22,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds properly.");
     }
 
     @Test
-    public void testConvertDurationDecimalCommaToMillis() {
+    void testConvertDurationDecimalCommaToMillis() {
         String secs = "0,0225213";
         assertEquals(22,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds properly.");
     }
@@ -45,49 +45,49 @@ public class TestJdkMath {
      * Durations are always rounded down.
      */
     @Test
-    public void testConvertDurationToMillisRoundDownOddFive() {
+    void testConvertDurationToMillisRoundDownOddFive() {
         String secs = "0.0975";
         assertEquals(97,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testConvertDurationToMillisRoundDownEvenFive() {
+    void testConvertDurationToMillisRoundDownEvenFive() {
         String secs = "0.0985";
         assertEquals(98,JdkMath.convertSecsToMillis(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testConvertDurationToMicrosRoundUp() {
+    void testConvertDurationToMicrosRoundUp() {
         String secs = "0.0968475";
         assertEquals(96847,JdkMath.convertSecsToMicros(secs).intValue(),"Secs not converted to microseconds with expected rounding mode.");
     }
 
     @Test
-    public void testConvertDurationToMicrosRoundDown() {
+    void testConvertDurationToMicrosRoundDown() {
         String secs = "0.0968485";
         assertEquals(96848,JdkMath.convertSecsToMicros(secs).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testConvertMillisToMicros() {
+    void testConvertMillisToMicros() {
         String millis = "0.0975";
         assertEquals(97,JdkMath.convertMillisToMicros(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testRoundMillis() {
+    void testRoundMillis() {
         String millis = "2.169";
         assertEquals(2,JdkMath.roundMillis(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testRoundMillisDown() {
+    void testRoundMillisDown() {
         String millis = "2.969";
         assertEquals(2,JdkMath.roundMillis(millis).intValue(),"Secs not converted to milliseconds with expected rounding mode.");
     }
 
     @Test
-    public void testThroughput() {
+    void testThroughput() {
         int duration = 81;
         long timestamp = 1000;
         int priorDuration = 10;
@@ -96,7 +96,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testTotalCmsRemarkDuration() {
+    void testTotalCmsRemarkDuration() {
         String[] durations = new String[3];
         durations[0] = "0.0226730";
         durations[1] = "0.0624566";
@@ -105,7 +105,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testTotalCmsRemarkDecimalCommaDuration() {
+    void testTotalCmsRemarkDecimalCommaDuration() {
         String[] durations = new String[3];
         durations[0] = "0,0226730";
         durations[1] = "0,0624566";
@@ -114,58 +114,58 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testConvertDurationMillisToSecs() {
+    void testConvertDurationMillisToSecs() {
         long duration = 123456;
         assertEquals("123.456",JdkMath.convertMillisToSecs(duration).toString(),"Millis not converted to seconds with expected rounding mode.");
     }
 
     @Test
-    public void testCalcKilobytesMegabytes() {
+    void testCalcKilobytesMegabytes() {
         assertEquals(kilobytes(1024),new Memory(1, MEGABYTES),"Megabytes not converted to kilobytes.");
     }
 
     @Test
-    public void testCalcKilobytesGigabytes() {
+    void testCalcKilobytesGigabytes() {
         assertEquals(kilobytes(1024 * 1024),new Memory(1, GIGABYTES),"Megabytes not converted to kilobytes.");
     }
 
     @Test
-    public void testConvertSizeG1DetailsToKilobytesB() {
+    void testConvertSizeG1DetailsToKilobytesB() {
         String size = "102400";
         char units = 'B';
         assertEquals(kilobytes(100),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
-    public void testConvertSizeG1DetailsToKilobytesK() {
+    void testConvertSizeG1DetailsToKilobytesK() {
         String size = "1234567";
         char units = 'K';
         assertEquals(kilobytes(1234567),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
-    public void testConvertSizeG1DetailsToKilobytesM() {
+    void testConvertSizeG1DetailsToKilobytesM() {
         String size = "10";
         char units = 'M';
         assertEquals(kilobytes(10240),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
-    public void testConvertSizeG1DetailsToKilobytesMWithComma() {
+    void testConvertSizeG1DetailsToKilobytesMWithComma() {
         String size = "306,0";
         char units = 'M';
         assertEquals(kilobytes(313344),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
-    public void testConvertSizeG1DetailsToKilobytesG() {
+    void testConvertSizeG1DetailsToKilobytesG() {
         String size = "100";
         char units = 'G';
         assertEquals(kilobytes(104857600),JdkMath.convertSizeToKilobytes(size, units),"G1 details not converted to kilobytes.");
     }
 
     @Test
-    public void testCalcParallelism() {
+    void testCalcParallelism() {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 10;
@@ -173,7 +173,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismRounded() {
+    void testCalcParallelismRounded() {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 1000;
@@ -181,7 +181,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismRoundedUp() {
+    void testCalcParallelismRoundedUp() {
         int timeUser = 90;
         int timeSys = 10;
         int timeReal = 199;
@@ -189,7 +189,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismUserZero() {
+    void testCalcParallelismUserZero() {
         int timeUser = 0;
         int timeSys = 0;
         int timeReal = 100;
@@ -197,7 +197,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismRealZero() {
+    void testCalcParallelismRealZero() {
         int timeUser = 100;
         int timeSys = 0;
         int timeReal = 0;
@@ -205,7 +205,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismUserZeroRealZero() {
+    void testCalcParallelismUserZeroRealZero() {
         int timeUser = 0;
         int timeSys = 0;
         int timeReal = 0;
@@ -213,7 +213,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testCalcParallelismNoData() {
+    void testCalcParallelismNoData() {
         int timeUser = TimesData.NO_DATA;
         int timeSys = TimesData.NO_DATA;
         int timeReal = TimesData.NO_DATA;
@@ -221,7 +221,7 @@ public class TestJdkMath {
     }
 
     @Test
-    public void testParallelism() {
+    void testParallelism() {
         assertTrue(JdkMath.isInvertedParallelism(0), "Parallism not calculated correctly.");
         assertTrue(JdkMath.isInvertedParallelism(99), "Parallism not calculated correctly.");
         assertFalse(JdkMath.isInvertedParallelism(100), "Parallism not calculated correctly.");

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkRegEx.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkRegEx.java
@@ -12,11 +12,11 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.util.jdk;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.domain.TimesData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -27,256 +27,253 @@ public class TestJdkRegEx {
     @Test
     public void testTimestampWithCharacter() {
         String timestamp = "A.123";
-        assertFalse("Timestamps are decimal numbers.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps are decimal numbers.");
     }
 
     @Test
     public void testTimestampWithFewerDecimalPlaces() {
         String timestamp = "1.12";
-        assertFalse("Timestamps have 3 decimal places.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
     public void testTimestampWithMoreDecimalPlaces() {
         String timestamp = "1.1234";
-        assertFalse("Timestamps have 3 decimal places.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
     public void testTimestampWithNoDecimal() {
         String timestamp = "11234";
-        assertFalse("Timestamps have 3 decimal places.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
     public void testTimestampLessThanOne() {
         String timestamp = ".123";
-        assertTrue("Timestamps less than one do not have a leading zero.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps less than one do not have a leading zero.");
     }
 
     @Test
     public void testTimestampValid() {
         String timestamp = "1.123";
-        assertTrue("'" + timestamp + "' is a valid timestamp.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
     public void testTimestampDecimalComma() {
         String timestamp = "1,123";
-        assertTrue("'" + timestamp + "' is a valid timestamp.", timestamp.matches(JdkRegEx.TIMESTAMP));
+        assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
     public void testSizeWithoutUnits() {
         String size = "1234";
-        assertFalse("Size must have capital K (kilobytes).", size.matches(JdkRegEx.SIZE_K));
+        assertFalse(size.matches(JdkRegEx.SIZE_K), "Size must have capital K (kilobytes).");
     }
 
     @Test
     public void testZeroSize() {
         String size = "0K";
-        assertTrue("Zero sizes are valid.", size.matches(JdkRegEx.SIZE_K));
+        assertTrue(size.matches(JdkRegEx.SIZE_K), "Zero sizes are valid.");
     }
 
     @Test
     public void testSizeUnitsCase() {
         String size = "1234k";
-        assertFalse("Size must have capital K (kilobytes).", size.matches(JdkRegEx.SIZE_K));
+        assertFalse(size.matches(JdkRegEx.SIZE_K), "Size must have capital K (kilobytes).");
     }
 
     @Test
     public void testSizeWithDecimal() {
         String size = "1.234K";
-        assertFalse("Size is a whole number.", size.matches(JdkRegEx.SIZE_K));
+        assertFalse(size.matches(JdkRegEx.SIZE_K), "Size is a whole number.");
     }
 
     @Test
     public void testSizeValid() {
         String size = "1234K";
-        assertTrue("'1234K' is a valid size.", size.matches(JdkRegEx.SIZE_K));
+        assertTrue(size.matches(JdkRegEx.SIZE_K), "'1234K' is a valid size.");
     }
 
     @Test
     public void testSizeWithInvalidCharacter() {
         String size = "A234K";
-        assertFalse("Size is a decimal number.", size.matches(JdkRegEx.SIZE_K));
+        assertFalse(size.matches(JdkRegEx.SIZE_K), "Size is a decimal number.");
     }
 
     @Test
     public void testSizeWithNineTensPlaces() {
         String size = "129092672K";
-        assertTrue("'129092672K' is a valid size.", size.matches(JdkRegEx.SIZE_K));
+        assertTrue(size.matches(JdkRegEx.SIZE_K), "'129092672K' is a valid size.");
     }
 
     @Test
     public void testDurationWithCharacter() {
         String duration = "0.02A5213 secs";
-        assertFalse("Duration is a decimal number.", duration.matches(JdkRegEx.DURATION));
+        assertFalse(duration.matches(JdkRegEx.DURATION), "Duration is a decimal number.");
     }
 
     @Test
     public void testDurationWithFewer7DecimalPlaces() {
         String duration = "0.022521 secs";
-        assertFalse("Duration has 7-8 decimal places.", duration.matches(JdkRegEx.DURATION));
+        assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7-8 decimal places.");
     }
 
     @Test
     public void testDurationWithMore8DecimalPlaces() {
         String duration = "0.022521394 secs";
-        assertFalse("Duration has 7 decimal places.", duration.matches(JdkRegEx.DURATION));
+        assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7 decimal places.");
     }
 
     @Test
     public void testDurationWithNoDecimal() {
         String duration = "00225213 secs";
-        assertFalse("Duration has 7 decimal places.", duration.matches(JdkRegEx.DURATION));
+        assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7 decimal places.");
     }
 
     @Test
     public void testDurationLessThanOne() {
         String duration = ".0225213 secs";
-        assertFalse("Durations less than one have a leading zero.", duration.matches(JdkRegEx.DURATION));
+        assertFalse(duration.matches(JdkRegEx.DURATION), "Durations less than one have a leading zero.");
     }
 
     @Test
     public void testDurationWithSec() {
         String duration = "0.0225213 sec";
-        assertTrue("'0.0225213 sec' is a valid duration.", duration.matches(JdkRegEx.DURATION));
+        assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213 sec' is a valid duration.");
     }
 
     @Test
     public void testDurationWithoutUnits() {
         String duration = "0.0225213";
-        assertTrue("'0.0225213' is a valid duration.", duration.matches(JdkRegEx.DURATION));
+        assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213' is a valid duration.");
     }
 
     @Test
     public void testDurationValid7() {
         String duration = "0.0225213 secs";
-        assertTrue("'0.0225213 secs' is a valid duration.", duration.matches(JdkRegEx.DURATION));
+        assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213 secs' is a valid duration.");
     }
 
     @Test
     public void testDurationValid8() {
         String duration = "0.02252132 secs";
-        assertTrue("'0.02252132 secs' is a valid duration.", duration.matches(JdkRegEx.DURATION));
+        assertTrue(duration.matches(JdkRegEx.DURATION), "'0.02252132 secs' is a valid duration.");
     }
 
     @Test
     public void testDurationDecimalComma() {
         String duration = "0,0225213 secs";
-        assertTrue("'0,0225213 secs' is a valid duration.", duration.matches(JdkRegEx.DURATION));
+        assertTrue(duration.matches(JdkRegEx.DURATION), "'0,0225213 secs' is a valid duration.");
     }
 
     @Test
     public void testUnloadingClassBlock() {
         String unloadingClassBlock = "[Unloading class sun.reflect.GeneratedSerializationConstructorAccessor13565]";
-        assertTrue("'" + unloadingClassBlock + "' " + "is a valid class unloading block.",
-                unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK));
+        assertTrue(unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK), "'" + unloadingClassBlock + "' " + "is a valid class unloading block.");
     }
 
     @Test
     public void testUnloadingClassProxyBlock() {
         String unloadingClassBlock = "[Unloading class $Proxy109]";
-        assertTrue("'" + unloadingClassBlock + "' " + "is a valid class unloading block.",
-                unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK));
+        assertTrue(unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK), "'" + unloadingClassBlock + "' " + "is a valid class unloading block.");
     }
 
     @Test
     public void testDatestampGmtMinus() {
         String datestamp = "2010-02-26T09:32:12.486-0600";
-        assertTrue("Datestamp not recognized.", datestamp.matches(JdkRegEx.DATESTAMP));
+        assertTrue(datestamp.matches(JdkRegEx.DATESTAMP), "Datestamp not recognized.");
     }
 
     @Test
     public void testDatestampGmtPlus() {
         String datestamp = "2010-04-16T12:11:18.979+0200";
-        assertTrue("Datestamp not recognized.", datestamp.matches(JdkRegEx.DATESTAMP));
+        assertTrue(datestamp.matches(JdkRegEx.DATESTAMP), "Datestamp not recognized.");
     }
 
     @Test
     public void testTimesBlock5Digits() {
         String timesBlock = " [Times: user=29858.25 sys=2074.63, real=35140.48 secs]";
-        assertTrue("'" + timesBlock + "' " + "is a valid times block.", timesBlock.matches(TimesData.REGEX));
+        assertTrue(timesBlock.matches(TimesData.REGEX), "'" + timesBlock + "' " + "is a valid times block.");
     }
 
     @Test
     public void testDurationFractionk5Digits() {
         String durationFraction = "4.583/35144.874 secs";
-        assertTrue("'" + durationFraction + "' " + "is a valid duration fraction.",
-                durationFraction.matches(JdkRegEx.DURATION_FRACTION));
+        assertTrue(durationFraction.matches(JdkRegEx.DURATION_FRACTION), "'" + durationFraction + "' " + "is a valid duration fraction.");
     }
 
     @Test
     public void testSizeWholeBytes() {
         String size = "0B";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeWholeKilobytes() {
         String size = "8192K";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeWholeMegabytes() {
         String size = "28M";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeWholeGigabytes() {
         String size = "30G";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeDecimalBytes() {
         String size = "0.0B";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeDecimalKilobytes() {
         String size = "8192.0K";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testSizeDecimalMegabytes() {
         String size = "28.0M";
-        assertTrue("'" + size + "' " + "is a valid size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
     public void testMegabytesM() {
         String unit = "M";
-        assertTrue("'" + unit + "' " + "is a valid unit.", unit.matches(JdkRegEx.MEGABYTES));
+        assertTrue(unit.matches(JdkRegEx.MEGABYTES), "'" + unit + "' " + "is a valid unit.");
     }
 
     @Test
     public void testSizeDecimalGigabytes() {
         String size = "30.0G";
-        assertTrue("'" + size + "' " + "is a valid G1 details size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid G1 details size.");
     }
 
     @Test
     public void testSizeComma() {
         String size = "306,0M";
-        assertTrue("'" + size + "' " + "is a valid G1 details size.", size.matches(JdkRegEx.SIZE));
+        assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid G1 details size.");
     }
 
     @Test
     public void testPercent() {
         String percent = "54.8%";
-        assertTrue("'" + percent + "' " + "not a valid percent.", percent.matches(JdkRegEx.PERCENT));
+        assertTrue(percent.matches(JdkRegEx.PERCENT), "'" + percent + "' " + "not a valid percent.");
     }
 
     @Test
     public void testDateTime() {
         String datetime = "2016-10-18 01:50:54";
-        assertTrue("'" + datetime + "' " + "not a valid datetime.", datetime.matches(JdkRegEx.DATETIME));
+        assertTrue(datetime.matches(JdkRegEx.DATETIME), "'" + datetime + "' " + "not a valid datetime.");
     }
 
     @Test
@@ -298,13 +295,12 @@ public class TestJdkRegEx {
                 + "(28: promotion failure size = 10)  (29: promotion failure size = 200)  "
                 + "(30: promotion failure size = 200)  (31: promotion failure size = 200)  "
                 + "(32: promotion failure size = 200) ";
-        assertTrue("'" + promotionFailure + "' " + "not a valid PROMOTION_FAILURE.",
-                promotionFailure.matches(JdkRegEx.PRINT_PROMOTION_FAILURE));
+        assertTrue(promotionFailure.matches(JdkRegEx.PRINT_PROMOTION_FAILURE), "'" + promotionFailure + "' " + "not a valid PROMOTION_FAILURE.");
     }
 
     @Test
     public void testDecoratorTimeUptime() {
         String decorator = "2020-03-10T08:03:29.311-0400: 0.373:";
-        assertTrue("'" + decorator + "' " + "not a valid decorator.", decorator.matches(JdkRegEx.DECORATOR));
+        assertTrue(decorator.matches(JdkRegEx.DECORATOR), "'" + decorator + "' " + "not a valid decorator.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkRegEx.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkRegEx.java
@@ -22,262 +22,262 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJdkRegEx {
+class TestJdkRegEx {
 
     @Test
-    public void testTimestampWithCharacter() {
+    void testTimestampWithCharacter() {
         String timestamp = "A.123";
         assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps are decimal numbers.");
     }
 
     @Test
-    public void testTimestampWithFewerDecimalPlaces() {
+    void testTimestampWithFewerDecimalPlaces() {
         String timestamp = "1.12";
         assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
-    public void testTimestampWithMoreDecimalPlaces() {
+    void testTimestampWithMoreDecimalPlaces() {
         String timestamp = "1.1234";
         assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
-    public void testTimestampWithNoDecimal() {
+    void testTimestampWithNoDecimal() {
         String timestamp = "11234";
         assertFalse(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps have 3 decimal places.");
     }
 
     @Test
-    public void testTimestampLessThanOne() {
+    void testTimestampLessThanOne() {
         String timestamp = ".123";
         assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "Timestamps less than one do not have a leading zero.");
     }
 
     @Test
-    public void testTimestampValid() {
+    void testTimestampValid() {
         String timestamp = "1.123";
         assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
-    public void testTimestampDecimalComma() {
+    void testTimestampDecimalComma() {
         String timestamp = "1,123";
         assertTrue(timestamp.matches(JdkRegEx.TIMESTAMP), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
-    public void testSizeWithoutUnits() {
+    void testSizeWithoutUnits() {
         String size = "1234";
         assertFalse(size.matches(JdkRegEx.SIZE_K), "Size must have capital K (kilobytes).");
     }
 
     @Test
-    public void testZeroSize() {
+    void testZeroSize() {
         String size = "0K";
         assertTrue(size.matches(JdkRegEx.SIZE_K), "Zero sizes are valid.");
     }
 
     @Test
-    public void testSizeUnitsCase() {
+    void testSizeUnitsCase() {
         String size = "1234k";
         assertFalse(size.matches(JdkRegEx.SIZE_K), "Size must have capital K (kilobytes).");
     }
 
     @Test
-    public void testSizeWithDecimal() {
+    void testSizeWithDecimal() {
         String size = "1.234K";
         assertFalse(size.matches(JdkRegEx.SIZE_K), "Size is a whole number.");
     }
 
     @Test
-    public void testSizeValid() {
+    void testSizeValid() {
         String size = "1234K";
         assertTrue(size.matches(JdkRegEx.SIZE_K), "'1234K' is a valid size.");
     }
 
     @Test
-    public void testSizeWithInvalidCharacter() {
+    void testSizeWithInvalidCharacter() {
         String size = "A234K";
         assertFalse(size.matches(JdkRegEx.SIZE_K), "Size is a decimal number.");
     }
 
     @Test
-    public void testSizeWithNineTensPlaces() {
+    void testSizeWithNineTensPlaces() {
         String size = "129092672K";
         assertTrue(size.matches(JdkRegEx.SIZE_K), "'129092672K' is a valid size.");
     }
 
     @Test
-    public void testDurationWithCharacter() {
+    void testDurationWithCharacter() {
         String duration = "0.02A5213 secs";
         assertFalse(duration.matches(JdkRegEx.DURATION), "Duration is a decimal number.");
     }
 
     @Test
-    public void testDurationWithFewer7DecimalPlaces() {
+    void testDurationWithFewer7DecimalPlaces() {
         String duration = "0.022521 secs";
         assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7-8 decimal places.");
     }
 
     @Test
-    public void testDurationWithMore8DecimalPlaces() {
+    void testDurationWithMore8DecimalPlaces() {
         String duration = "0.022521394 secs";
         assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7 decimal places.");
     }
 
     @Test
-    public void testDurationWithNoDecimal() {
+    void testDurationWithNoDecimal() {
         String duration = "00225213 secs";
         assertFalse(duration.matches(JdkRegEx.DURATION), "Duration has 7 decimal places.");
     }
 
     @Test
-    public void testDurationLessThanOne() {
+    void testDurationLessThanOne() {
         String duration = ".0225213 secs";
         assertFalse(duration.matches(JdkRegEx.DURATION), "Durations less than one have a leading zero.");
     }
 
     @Test
-    public void testDurationWithSec() {
+    void testDurationWithSec() {
         String duration = "0.0225213 sec";
         assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213 sec' is a valid duration.");
     }
 
     @Test
-    public void testDurationWithoutUnits() {
+    void testDurationWithoutUnits() {
         String duration = "0.0225213";
         assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213' is a valid duration.");
     }
 
     @Test
-    public void testDurationValid7() {
+    void testDurationValid7() {
         String duration = "0.0225213 secs";
         assertTrue(duration.matches(JdkRegEx.DURATION), "'0.0225213 secs' is a valid duration.");
     }
 
     @Test
-    public void testDurationValid8() {
+    void testDurationValid8() {
         String duration = "0.02252132 secs";
         assertTrue(duration.matches(JdkRegEx.DURATION), "'0.02252132 secs' is a valid duration.");
     }
 
     @Test
-    public void testDurationDecimalComma() {
+    void testDurationDecimalComma() {
         String duration = "0,0225213 secs";
         assertTrue(duration.matches(JdkRegEx.DURATION), "'0,0225213 secs' is a valid duration.");
     }
 
     @Test
-    public void testUnloadingClassBlock() {
+    void testUnloadingClassBlock() {
         String unloadingClassBlock = "[Unloading class sun.reflect.GeneratedSerializationConstructorAccessor13565]";
         assertTrue(unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK), "'" + unloadingClassBlock + "' " + "is a valid class unloading block.");
     }
 
     @Test
-    public void testUnloadingClassProxyBlock() {
+    void testUnloadingClassProxyBlock() {
         String unloadingClassBlock = "[Unloading class $Proxy109]";
         assertTrue(unloadingClassBlock.matches(JdkRegEx.UNLOADING_CLASS_BLOCK), "'" + unloadingClassBlock + "' " + "is a valid class unloading block.");
     }
 
     @Test
-    public void testDatestampGmtMinus() {
+    void testDatestampGmtMinus() {
         String datestamp = "2010-02-26T09:32:12.486-0600";
         assertTrue(datestamp.matches(JdkRegEx.DATESTAMP), "Datestamp not recognized.");
     }
 
     @Test
-    public void testDatestampGmtPlus() {
+    void testDatestampGmtPlus() {
         String datestamp = "2010-04-16T12:11:18.979+0200";
         assertTrue(datestamp.matches(JdkRegEx.DATESTAMP), "Datestamp not recognized.");
     }
 
     @Test
-    public void testTimesBlock5Digits() {
+    void testTimesBlock5Digits() {
         String timesBlock = " [Times: user=29858.25 sys=2074.63, real=35140.48 secs]";
         assertTrue(timesBlock.matches(TimesData.REGEX), "'" + timesBlock + "' " + "is a valid times block.");
     }
 
     @Test
-    public void testDurationFractionk5Digits() {
+    void testDurationFractionk5Digits() {
         String durationFraction = "4.583/35144.874 secs";
         assertTrue(durationFraction.matches(JdkRegEx.DURATION_FRACTION), "'" + durationFraction + "' " + "is a valid duration fraction.");
     }
 
     @Test
-    public void testSizeWholeBytes() {
+    void testSizeWholeBytes() {
         String size = "0B";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeWholeKilobytes() {
+    void testSizeWholeKilobytes() {
         String size = "8192K";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeWholeMegabytes() {
+    void testSizeWholeMegabytes() {
         String size = "28M";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeWholeGigabytes() {
+    void testSizeWholeGigabytes() {
         String size = "30G";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeDecimalBytes() {
+    void testSizeDecimalBytes() {
         String size = "0.0B";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeDecimalKilobytes() {
+    void testSizeDecimalKilobytes() {
         String size = "8192.0K";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testSizeDecimalMegabytes() {
+    void testSizeDecimalMegabytes() {
         String size = "28.0M";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid size.");
     }
 
     @Test
-    public void testMegabytesM() {
+    void testMegabytesM() {
         String unit = "M";
         assertTrue(unit.matches(JdkRegEx.MEGABYTES), "'" + unit + "' " + "is a valid unit.");
     }
 
     @Test
-    public void testSizeDecimalGigabytes() {
+    void testSizeDecimalGigabytes() {
         String size = "30.0G";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid G1 details size.");
     }
 
     @Test
-    public void testSizeComma() {
+    void testSizeComma() {
         String size = "306,0M";
         assertTrue(size.matches(JdkRegEx.SIZE), "'" + size + "' " + "is a valid G1 details size.");
     }
 
     @Test
-    public void testPercent() {
+    void testPercent() {
         String percent = "54.8%";
         assertTrue(percent.matches(JdkRegEx.PERCENT), "'" + percent + "' " + "not a valid percent.");
     }
 
     @Test
-    public void testDateTime() {
+    void testDateTime() {
         String datetime = "2016-10-18 01:50:54";
         assertTrue(datetime.matches(JdkRegEx.DATETIME), "'" + datetime + "' " + "not a valid datetime.");
     }
 
     @Test
-    public void testPromotionFailure() {
+    void testPromotionFailure() {
         String promotionFailure = " (0: promotion failure size = 200)  (1: promotion failure size = 8)  "
                 + "(2: promotion failure size = 200)  (3: promotion failure size = 200)  "
                 + "(4: promotion failure size = 200)  (5: promotion failure size = 200)  "
@@ -299,7 +299,7 @@ public class TestJdkRegEx {
     }
 
     @Test
-    public void testDecoratorTimeUptime() {
+    void testDecoratorTimeUptime() {
         String decorator = "2020-03-10T08:03:29.311-0400: 0.373:";
         assertTrue(decorator.matches(JdkRegEx.DECORATOR), "'" + decorator + "' " + "not a valid decorator.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkUtil.java
@@ -13,10 +13,10 @@
 package org.eclipselabs.garbagecat.util.jdk;
 
 import static org.eclipselabs.garbagecat.util.Memory.bytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Calendar;
 
@@ -25,7 +25,7 @@ import org.eclipselabs.garbagecat.domain.TimeWarpException;
 import org.eclipselabs.garbagecat.domain.jdk.ParNewEvent;
 import org.eclipselabs.garbagecat.domain.jdk.ParallelScavengeEvent;
 import org.eclipselabs.garbagecat.util.Memory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -48,8 +48,7 @@ public class TestJdkUtil {
                 + "89399K->11655K(907328K), 0.0387074 secs]";
         String logLineConverted = "1966-08-18 19:22:04,201: [GC 1966-08-18 19:22:04,202: "
                 + "[ParNew: 86199K->8454K(91712K), 0.0375060 secs] 89399K->11655K(907328K), 0.0387074 secs]";
-        assertEquals("Timestamps not converted to date/time correctly", logLineConverted,
-                JdkUtil.convertLogEntryTimestampsToDateStamp(logLine, calendar.getTime()));
+        assertEquals(logLineConverted,JdkUtil.convertLogEntryTimestampsToDateStamp(logLine, calendar.getTime()),"Timestamps not converted to date/time correctly");
     }
 
     @Test
@@ -68,14 +67,12 @@ public class TestJdkUtil {
 
         // Test boundary
         int throughputThreshold = 50;
-        assertFalse("Event incorrectly flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertFalse(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event incorrectly flagged as a bottleneck.");
 
         // Test bottleneck
         duration2 = 501000;
         gcEvent = new ParallelScavengeEvent(logLine2, timestamp2, duration2);
-        assertTrue("Event should have been flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
 
     }
 
@@ -95,13 +92,11 @@ public class TestJdkUtil {
 
         // Test boundary
         int throughputThreshold = 41;
-        assertFalse("Event incorrectly flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertFalse(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event incorrectly flagged as a bottleneck.");
 
         // Test boundary
         throughputThreshold = 42;
-        assertTrue("Event should have been flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
     }
 
     @Test
@@ -114,8 +109,7 @@ public class TestJdkUtil {
         BlockingEvent gcEvent = new ParNewEvent(logLine);
         // Test boundary
         int throughputThreshold = 90;
-        assertTrue("Event should have been flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
     }
 
     @Test
@@ -134,17 +128,15 @@ public class TestJdkUtil {
         // Test boundary
         int throughputThreshold = 100;
 
-        assertTrue("Event should have been flagged as a bottleneck.",
-                JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+        assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
 
         // Decrease timestamp by 1 ms to 2nd event start before 1st event finishes
         timestamp2 = 10999L;
         gcEvent = new ParallelScavengeEvent(logLine2, timestamp2, duration2);
         try {
-            assertTrue("Event should have been flagged as a bottleneck.",
-                    JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+            assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
         } catch (Exception e) {
-            assertTrue("Expected TimeWarpException not thrown.", e instanceof TimeWarpException);
+            assertTrue(e instanceof TimeWarpException, "Expected TimeWarpException not thrown.");
         }
     }
 
@@ -184,114 +176,103 @@ public class TestJdkUtil {
         int throughputThreshold = 100;
 
         try {
-            assertTrue("Event should have been flagged as a bottleneck.",
-                    JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold));
+            assertTrue(JdkUtil.isBottleneck(gcEvent, priorEvent, throughputThreshold), "Event should have been flagged as a bottleneck.");
         } catch (Exception e) {
-            assertTrue("Expected TimeWarpException not thrown.", e instanceof TimeWarpException);
+            assertTrue(e instanceof TimeWarpException, "Expected TimeWarpException not thrown.");
         }
     }
 
     @Test
     public void testGetOptionValue() {
-        assertEquals("Option value not correct.", "256k", JdkUtil.getOptionValue("-Xss256k"));
-        assertEquals("Option value not correct.", "2G", JdkUtil.getOptionValue("-Xmx2G"));
-        assertEquals("Option value not correct.", "128M", JdkUtil.getOptionValue("-XX:MaxPermSize=128M"));
-        assertEquals("Option value not correct.", "3865051136",
-                JdkUtil.getOptionValue("-XX:InitialHeapSize=3865051136"));
-        assertEquals("Option value not correct.", "7730102272", JdkUtil.getOptionValue("-XX:MaxHeapSize=7730102272"));
-        assertEquals("Option value not correct.", "268435456", JdkUtil.getOptionValue("-XX:MaxPermSize=268435456"));
-        assertEquals("Option value not correct.", "67108864", JdkUtil.getOptionValue("-XX:PermSize=67108864"));
-        assertNull("Option value not correct.", JdkUtil.getOptionValue(null));
+        assertEquals("256k",JdkUtil.getOptionValue("-Xss256k"),"Option value not correct.");
+        assertEquals("2G",JdkUtil.getOptionValue("-Xmx2G"),"Option value not correct.");
+        assertEquals("128M",JdkUtil.getOptionValue("-XX:MaxPermSize=128M"),"Option value not correct.");
+        assertEquals("3865051136",JdkUtil.getOptionValue("-XX:InitialHeapSize=3865051136"),"Option value not correct.");
+        assertEquals("7730102272",JdkUtil.getOptionValue("-XX:MaxHeapSize=7730102272"),"Option value not correct.");
+        assertEquals("268435456",JdkUtil.getOptionValue("-XX:MaxPermSize=268435456"),"Option value not correct.");
+        assertEquals("67108864",JdkUtil.getOptionValue("-XX:PermSize=67108864"),"Option value not correct.");
+        assertNull(JdkUtil.getOptionValue(null),"Option value not correct.");
     }
 
     @Test
     public void testDateStampInMiddle() {
         String logLine = "85030.389: [Full GC 85030.390: [CMS2012-06-20T12:29:58.094+0200: 85030.443: "
                 + "[CMS-concurrent-preclean: 0.108/0.139 secs] [Times: user=0.14 sys=0.01, real=0.14 secs]";
-        assertTrue("Datestamp not found.", JdkUtil.isLogLineWithDateStamp(logLine));
+        assertTrue(JdkUtil.isLogLineWithDateStamp(logLine), "Datestamp not found.");
     }
 
     @Test
     public void testDoubleDateStampOddFormat() {
         String logLine = "2016-10-12T09:53:31.818+02002016-10-12T09:53:31.818+0200: : 290.944: "
                 + "[GC concurrent-root-region-scan-start]";
-        assertTrue("Datestamp not found.", JdkUtil.isLogLineWithDateStamp(logLine));
+        assertTrue(JdkUtil.isLogLineWithDateStamp(logLine), "Datestamp not found.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesNoUnits() {
         String optionSize = "45097156608";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(45097156608L),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(45097156608L),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesLowercaseB() {
         String optionSize = "12345678b";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(12345678),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(12345678),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesUppercaseB() {
         String optionSize = "12345678B";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(12345678),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(12345678),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesLowercaseK() {
         String optionSize = "1k";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1024),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1024),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesUppercaseK() {
         String optionSize = "1K";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1024),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1024),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesLowercaseM() {
         String optionSize = "1m";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1048576),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1048576),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesUppercaseM() {
         String optionSize = "1M";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1048576),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1048576),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesLowercaseG() {
         String optionSize = "1g";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1073741824),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1073741824),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testConvertOptionSizeToBytesUppercaseG() {
         String optionSize = "1G";
-        assertEquals("'" + optionSize + "' not converted to expected bytes.", bytes(1073741824),
-                Memory.fromOptionSize(optionSize));
+        assertEquals(bytes(1073741824),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
     public void testDateStampBeginning() {
         String logLine = "2017-01-30T10:06:50.070+0400: 2232356.357: [GC [PSYoungGen: 242595K->5980K(1324544K)] "
                 + "1264815K->1037853K(4121088K), 0.0173240 secs] [Times: user=0.08 sys=0.00, real=0.02 secs]";
-        assertEquals("Datestamp not parsed correctly.", "2017-01-30T10:06:50.070+0400", JdkUtil.getDateStamp(logLine));
+        assertEquals("2017-01-30T10:06:50.070+0400",JdkUtil.getDateStamp(logLine),"Datestamp not parsed correctly.");
     }
 
     @Test
     public void testDateStampMiddle() {
         String logLine = "85030.389: [Full GC 85030.390: [CMS2012-06-20T12:29:58.094+0200: 85030.443: "
                 + "[CMS-concurrent-preclean: 0.108/0.139 secs] [Times: user=0.14 sys=0.01, real=0.14 secs]";
-        assertEquals("Datestamp not parsed correctly.", "2012-06-20T12:29:58.094+0200", JdkUtil.getDateStamp(logLine));
+        assertEquals("2012-06-20T12:29:58.094+0200",JdkUtil.getDateStamp(logLine),"Datestamp not parsed correctly.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJdkUtil.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJdkUtil {
+class TestJdkUtil {
 
     @Test
-    public void testConvertLogEntryTimestampsToDate() {
+    void testConvertLogEntryTimestampsToDate() {
         // 1966-08-18 19:21:44,012
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.YEAR, 1966);
@@ -52,7 +52,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testBottleneckDetectionWholeNumbers() {
+    void testBottleneckDetectionWholeNumbers() {
 
         String logLine1 = "test1";
         long timestamp1 = 10000L;
@@ -77,7 +77,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testBottleneckDetectionFractions() {
+    void testBottleneckDetectionFractions() {
 
         String logLine1 = "test1";
         long timestamp1 = 10000L;
@@ -100,7 +100,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testBottleneckDetectionParNew() {
+    void testBottleneckDetectionParNew() {
         String previousLogLine = "56.462: [GC 56.462: [ParNew: 64768K->7168K(64768K), 0.0823950 secs] "
                 + "142030K->88353K(567808K), 0.0826320 secs] [Times: user=0.10 sys=0.00, real=0.08 secs]";
         BlockingEvent priorEvent = new ParNewEvent(previousLogLine);
@@ -113,7 +113,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testTimeWarp() {
+    void testTimeWarp() {
         String logLine1 = "test1";
         long timestamp1 = 10000L;
         int duration1 = 1000000;
@@ -144,7 +144,7 @@ public class TestJdkUtil {
      * Test small overlap of .001 is not reported.
      */
     @Test
-    public void testNoTimeWarpExceptionOneThounsandthOverlap() {
+    void testNoTimeWarpExceptionOneThounsandthOverlap() {
         String logLine1 = "test1";
         long timestamp1 = 1000L;
         int duration1 = 101;
@@ -162,7 +162,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testTimeWarpLoggingReverseOrder() {
+    void testTimeWarpLoggingReverseOrder() {
         String previousLogLine = "26536.942: [GC26536.943: [ParNew: 792678K->4248K(917504K), 0.0170310 secs] "
                 + "1139860K->351466K(6160384K), 0.0172140 secs] [Times: user=0.06 sys=0.00, real=0.02 secs]";
         BlockingEvent priorEvent = new ParNewEvent(previousLogLine);
@@ -183,7 +183,7 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testGetOptionValue() {
+    void testGetOptionValue() {
         assertEquals("256k",JdkUtil.getOptionValue("-Xss256k"),"Option value not correct.");
         assertEquals("2G",JdkUtil.getOptionValue("-Xmx2G"),"Option value not correct.");
         assertEquals("128M",JdkUtil.getOptionValue("-XX:MaxPermSize=128M"),"Option value not correct.");
@@ -195,82 +195,82 @@ public class TestJdkUtil {
     }
 
     @Test
-    public void testDateStampInMiddle() {
+    void testDateStampInMiddle() {
         String logLine = "85030.389: [Full GC 85030.390: [CMS2012-06-20T12:29:58.094+0200: 85030.443: "
                 + "[CMS-concurrent-preclean: 0.108/0.139 secs] [Times: user=0.14 sys=0.01, real=0.14 secs]";
         assertTrue(JdkUtil.isLogLineWithDateStamp(logLine), "Datestamp not found.");
     }
 
     @Test
-    public void testDoubleDateStampOddFormat() {
+    void testDoubleDateStampOddFormat() {
         String logLine = "2016-10-12T09:53:31.818+02002016-10-12T09:53:31.818+0200: : 290.944: "
                 + "[GC concurrent-root-region-scan-start]";
         assertTrue(JdkUtil.isLogLineWithDateStamp(logLine), "Datestamp not found.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesNoUnits() {
+    void testConvertOptionSizeToBytesNoUnits() {
         String optionSize = "45097156608";
         assertEquals(bytes(45097156608L),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesLowercaseB() {
+    void testConvertOptionSizeToBytesLowercaseB() {
         String optionSize = "12345678b";
         assertEquals(bytes(12345678),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesUppercaseB() {
+    void testConvertOptionSizeToBytesUppercaseB() {
         String optionSize = "12345678B";
         assertEquals(bytes(12345678),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesLowercaseK() {
+    void testConvertOptionSizeToBytesLowercaseK() {
         String optionSize = "1k";
         assertEquals(bytes(1024),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesUppercaseK() {
+    void testConvertOptionSizeToBytesUppercaseK() {
         String optionSize = "1K";
         assertEquals(bytes(1024),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesLowercaseM() {
+    void testConvertOptionSizeToBytesLowercaseM() {
         String optionSize = "1m";
         assertEquals(bytes(1048576),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesUppercaseM() {
+    void testConvertOptionSizeToBytesUppercaseM() {
         String optionSize = "1M";
         assertEquals(bytes(1048576),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesLowercaseG() {
+    void testConvertOptionSizeToBytesLowercaseG() {
         String optionSize = "1g";
         assertEquals(bytes(1073741824),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testConvertOptionSizeToBytesUppercaseG() {
+    void testConvertOptionSizeToBytesUppercaseG() {
         String optionSize = "1G";
         assertEquals(bytes(1073741824),Memory.fromOptionSize(optionSize),"'" + optionSize + "' not converted to expected bytes.");
     }
 
     @Test
-    public void testDateStampBeginning() {
+    void testDateStampBeginning() {
         String logLine = "2017-01-30T10:06:50.070+0400: 2232356.357: [GC [PSYoungGen: 242595K->5980K(1324544K)] "
                 + "1264815K->1037853K(4121088K), 0.0173240 secs] [Times: user=0.08 sys=0.00, real=0.02 secs]";
         assertEquals("2017-01-30T10:06:50.070+0400",JdkUtil.getDateStamp(logLine),"Datestamp not parsed correctly.");
     }
 
     @Test
-    public void testDateStampMiddle() {
+    void testDateStampMiddle() {
         String logLine = "85030.389: [Full GC 85030.390: [CMS2012-06-20T12:29:58.094+0200: 85030.443: "
                 + "[CMS-concurrent-preclean: 0.108/0.139 secs] [Times: user=0.14 sys=0.01, real=0.14 secs]";
         assertEquals("2012-06-20T12:29:58.094+0200",JdkUtil.getDateStamp(logLine),"Datestamp not parsed correctly.");

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJvm.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJvm.java
@@ -15,13 +15,13 @@ package org.eclipselabs.garbagecat.util.jdk;
 import static org.eclipselabs.garbagecat.util.Memory.bytes;
 import static org.eclipselabs.garbagecat.util.Memory.kilobytes;
 import static org.eclipselabs.garbagecat.util.Memory.megabytes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipselabs.garbagecat.util.Memory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -33,435 +33,431 @@ public class TestJvm {
     public void testNullJvmOptions() {
         String jvmOptions = null;
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertNotNull("Jvm object creation failed.", jvm);
+        assertNotNull(jvm,"Jvm object creation failed.");
     }
 
     @Test
     public void testGetThreadStackSizeSsSmallK() {
         String jvmOptions = "-ss128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-ss128k", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128k", jvm.getThreadStackSizeValue());
+        assertEquals("-ss128k",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("128k",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeSsBigK() {
         String jvmOptions = "-ss128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-ss128K", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128K", jvm.getThreadStackSizeValue());
+        assertEquals("-ss128K",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("128K",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeSsSmallM() {
         String jvmOptions = "-ss1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-ss1m", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1m", jvm.getThreadStackSizeValue());
+        assertEquals("-ss1m",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("1m",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeXssSmallK() {
         String jvmOptions = "-Xss128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-Xss128k", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128k", jvm.getThreadStackSizeValue());
+        assertEquals("-Xss128k",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("128k",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeXssBigK() {
         String jvmOptions = "-Xss128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-Xss128K", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128K", jvm.getThreadStackSizeValue());
+        assertEquals("-Xss128K",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("128K",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeXssSmallM() {
         String jvmOptions = "-Xss1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-Xss1m", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1m", jvm.getThreadStackSizeValue());
+        assertEquals("-Xss1m",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("1m",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeXssBigM() {
         String jvmOptions = "-Xss1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size not populated correctly.", "-Xss1M", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1M", jvm.getThreadStackSizeValue());
+        assertEquals("-Xss1M",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
+        assertEquals("1M",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeSmallK() {
         String jvmOptions = "-XX:ThreadStackSize=128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size incorrect.", "-XX:ThreadStackSize=128k", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128k", jvm.getThreadStackSizeValue());
+        assertEquals("-XX:ThreadStackSize=128k",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
+        assertEquals("128k",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeBigK() {
         String jvmOptions = "-XX:ThreadStackSize=128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size incorrect.", "-XX:ThreadStackSize=128K", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "128K", jvm.getThreadStackSizeValue());
+        assertEquals("-XX:ThreadStackSize=128K",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
+        assertEquals("128K",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size incorrect.", "-XX:ThreadStackSize=1m", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1m", jvm.getThreadStackSizeValue());
+        assertEquals("-XX:ThreadStackSize=1m",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
+        assertEquals("1m",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeBigM() {
         String jvmOptions = "-XX:ThreadStackSize=1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size incorrect.", "-XX:ThreadStackSize=1M", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1M", jvm.getThreadStackSizeValue());
+        assertEquals("-XX:ThreadStackSize=1M",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
+        assertEquals("1M",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1234567 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Thread stack size incorrect.", "-XX:ThreadStackSize=1234567", jvm.getThreadStackSizeOption());
-        assertEquals("Thread stack size value incorrect.", "1234567", jvm.getThreadStackSizeValue());
+        assertEquals("-XX:ThreadStackSize=1234567",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
+        assertEquals("1234567",jvm.getThreadStackSizeValue(),"Thread stack size value incorrect.");
     }
 
     @Test
     public void testGetThreadStackSizeOneLessThanLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048575 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertFalse("Thread stack size is not large.", jvm.hasLargeThreadStackSize());
+        assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
     public void testGetThreadStackSizeEqualsLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048576 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneGreaterLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048577 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneLessThanLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048575b -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertFalse("Thread stack size is not large.", jvm.hasLargeThreadStackSize());
+        assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
     public void testGetThreadStackSizeEqualsLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048576B -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneGreaterLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048577B -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneLessThanLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1023k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertFalse("Thread stack size is not large.", jvm.hasLargeThreadStackSize());
+        assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
     public void testGetThreadStackSizeEqualsLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1024K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneGreaterLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1025K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeEqualsLargeMegabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeOneGreaterLargeMegabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetThreadStackSizeLargeGigabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1G -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertTrue("Thread stack size is large.", jvm.hasLargeThreadStackSize());
+        assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
     public void testGetMinHeapSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xms1024m", jvm.getMinHeapOption());
-        assertEquals("Min heap value incorrect.", "1024m", jvm.getMinHeapValue());
+        assertEquals("-Xms1024m",jvm.getMinHeapOption(),"Min heap option incorrect.");
+        assertEquals("1024m",jvm.getMinHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMinHeapBigM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024M -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xms1024M", jvm.getMinHeapOption());
-        assertEquals("Min heap value incorrect.", "1024M", jvm.getMinHeapValue());
+        assertEquals("-Xms1024M",jvm.getMinHeapOption(),"Min heap option incorrect.");
+        assertEquals("1024M",jvm.getMinHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMinHeapSmallG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1g -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xms1g", jvm.getMinHeapOption());
-        assertEquals("Min heap value incorrect.", "1g", jvm.getMinHeapValue());
+        assertEquals("-Xms1g",jvm.getMinHeapOption(),"Min heap option incorrect.");
+        assertEquals("1g",jvm.getMinHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMinHeapBigG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1G -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xms1G", jvm.getMinHeapOption());
-        assertEquals("Min heap value incorrect.", "1G", jvm.getMinHeapValue());
+        assertEquals("-Xms1G",jvm.getMinHeapOption(),"Min heap option incorrect.");
+        assertEquals("1G",jvm.getMinHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMaxHeapSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xmx2048m", jvm.getMaxHeapOption());
-        assertEquals("Min heap value incorrect.", "2048m", jvm.getMaxHeapValue());
+        assertEquals("-Xmx2048m",jvm.getMaxHeapOption(),"Min heap option incorrect.");
+        assertEquals("2048m",jvm.getMaxHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMaxHeapBigM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024M -Xmx2048M";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xmx2048M", jvm.getMaxHeapOption());
-        assertEquals("Min heap value incorrect.", "2048M", jvm.getMaxHeapValue());
+        assertEquals("-Xmx2048M",jvm.getMaxHeapOption(),"Min heap option incorrect.");
+        assertEquals("2048M",jvm.getMaxHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMaxHeapSmallG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1g -Xmx2g";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xmx2g", jvm.getMaxHeapOption());
-        assertEquals("Min heap value incorrect.", "2g", jvm.getMaxHeapValue());
+        assertEquals("-Xmx2g",jvm.getMaxHeapOption(),"Min heap option incorrect.");
+        assertEquals("2g",jvm.getMaxHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testGetMaxHeapBigG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1G -Xmx2G";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min heap option incorrect.", "-Xmx2G", jvm.getMaxHeapOption());
-        assertEquals("Min heap value incorrect.", "2G", jvm.getMaxHeapValue());
+        assertEquals("-Xmx2G",jvm.getMaxHeapOption(),"Min heap option incorrect.");
+        assertEquals("2G",jvm.getMaxHeapValue(),"Min heap value incorrect.");
     }
 
     @Test
     public void testIsMinAndMaxHeapSpaceEqual() {
         Jvm jvm = new Jvm("-Xms2g -Xmx2G", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxHeapSpaceEqual());
+        assertTrue(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-Xms1G -Xmx2G", null);
-        assertFalse("Min and max heap are not equal.", jvm.isMinAndMaxHeapSpaceEqual());
+        assertFalse(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are not equal.");
         jvm = new Jvm("-Xms256k -Xmx256M", null);
-        assertFalse("Min and max heap are not equal.", jvm.isMinAndMaxHeapSpaceEqual());
+        assertFalse(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are not equal.");
     }
 
     @Test
     public void testIsMinAndMaxHeapSpaceEqualVerboseOptions() {
         Jvm jvm = new Jvm("-XX:InitialHeapSize=1234567890 -XX:MaxHeapSize=1234567890", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxHeapSpaceEqual());
+        assertTrue(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-XX:InitialHeapSize=1234567890 -XX:MaxHeapSize=1234567891", null);
-        assertFalse("Min and max heap are not equal.", jvm.isMinAndMaxHeapSpaceEqual());
+        assertFalse(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are not equal.");
     }
 
     @Test
     public void testGetMinPermSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128m -XX:MaxPermSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min permanent generation option incorrect.", "-XX:PermSize=128m", jvm.getMinPermOption());
-        assertEquals("Min permanent generation value incorrect.", "128m", jvm.getMinPermValue());
+        assertEquals("-XX:PermSize=128m",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
+        assertEquals("128m",jvm.getMinPermValue(),"Min permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMinPermBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128M -XX:MaxPermSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min permanent generation option incorrect.", "-XX:PermSize=128M", jvm.getMinPermOption());
-        assertEquals("Min permanent generation value incorrect.", "128M", jvm.getMinPermValue());
+        assertEquals("-XX:PermSize=128M",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
+        assertEquals("128M",jvm.getMinPermValue(),"Min permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMinPermSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1g -XX:MaxPermSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min permanent generation option incorrect.", "-XX:PermSize=1g", jvm.getMinPermOption());
-        assertEquals("Min permanent generation value incorrect.", "1g", jvm.getMinPermValue());
+        assertEquals("-XX:PermSize=1g",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
+        assertEquals("1g",jvm.getMinPermValue(),"Min permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMinPermBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1G -XX:MaxPermSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min permanent generation option incorrect.", "-XX:PermSize=1G", jvm.getMinPermOption());
-        assertEquals("Min permanent generation value incorrect.", "1G", jvm.getMinPermValue());
+        assertEquals("-XX:PermSize=1G",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
+        assertEquals("1G",jvm.getMinPermValue(),"Min permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMaxPermSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128m -XX:MaxPermSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max permanent generation optiion incorrect.", "-XX:MaxPermSize=128m", jvm.getMaxPermOption());
-        assertEquals("Max permanent generation value incorrect.", "128m", jvm.getMaxPermValue());
+        assertEquals("-XX:MaxPermSize=128m",jvm.getMaxPermOption(),"Max permanent generation optiion incorrect.");
+        assertEquals("128m",jvm.getMaxPermValue(),"Max permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMaxPermBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128M -XX:MaxPermSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max permanent generation option incorrect.", "-XX:MaxPermSize=128M", jvm.getMaxPermOption());
-        assertEquals("Max permanent generation value incorrect.", "128M", jvm.getMaxPermValue());
+        assertEquals("-XX:MaxPermSize=128M",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
+        assertEquals("128M",jvm.getMaxPermValue(),"Max permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMaxPermSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1g -XX:MaxPermSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max permanent generation option incorrect.", "-XX:MaxPermSize=1g", jvm.getMaxPermOption());
-        assertEquals("Max permanent generation value incorrect.", "1g", jvm.getMaxPermValue());
+        assertEquals("-XX:MaxPermSize=1g",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
+        assertEquals("1g",jvm.getMaxPermValue(),"Max permanent generation value incorrect.");
     }
 
     @Test
     public void testGetMaxPermBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1G -XX:MaxPermSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max permanent generation option incorrect.", "-XX:MaxPermSize=1G", jvm.getMaxPermOption());
-        assertEquals("Max permanent generation value incorrect.", "1G", jvm.getMaxPermValue());
+        assertEquals("-XX:MaxPermSize=1G",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
+        assertEquals("1G",jvm.getMaxPermValue(),"Max permanent generation value incorrect.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentCaseM() {
         Jvm jvm = new Jvm("-XX:PermSize=256m -XX:MaxPermSize=256M", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentCaseG() {
         Jvm jvm = new Jvm("-XX:PermSize=1G -XX:MaxPermSize=1g", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualMissingMin() {
         Jvm jvm = new Jvm("-XX:MaxPermSize=256M", null);
-        assertFalse("Min and max heap are not equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertFalse(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are not equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentUnitsMG() {
         Jvm jvm = new Jvm("-XX:PermSize=2048m -XX:MaxPermSize=2g", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentUnitsKM() {
         Jvm jvm = new Jvm("-XX:PermSize=1024K -XX:MaxPermSize=1m", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentUnitsNoneG() {
         Jvm jvm = new Jvm("-XX:PermSize=1073741824 -XX:MaxPermSize=1G", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualDifferentUnitsBG() {
         Jvm jvm = new Jvm("-XX:PermSize=1073741824b -XX:MaxPermSize=1G", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
     public void testIsMinAndMaxPermSpaceEqualVerboseOptions() {
         Jvm jvm = new Jvm("-XX:MaxPermSize=1234567890 -XX:PermSize=1234567890", null);
-        assertTrue("Min and max heap are equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-XX:MaxPermSize=1234567890 -XX:PermSize=1234567891", null);
-        assertFalse("Min and max heap are not equal.", jvm.isMinAndMaxPermSpaceEqual());
+        assertFalse(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are not equal.");
     }
 
     @Test
     public void testGetMinMetaspaceSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1g -XX:MaxMetaspaceSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min Metaspace generation option incorrect.", "-XX:MetaspaceSize=1g", jvm.getMinMetaspaceOption());
-        assertEquals("Min Metaspace generation value incorrect.", "1g", jvm.getMinMetaspaceValue());
+        assertEquals("-XX:MetaspaceSize=1g",jvm.getMinMetaspaceOption(),"Min Metaspace generation option incorrect.");
+        assertEquals("1g",jvm.getMinMetaspaceValue(),"Min Metaspace generation value incorrect.");
     }
 
     @Test
     public void testGetMinMetaspaceBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Min Metaspace generation option incorrect.", "-XX:MetaspaceSize=1G", jvm.getMinMetaspaceOption());
-        assertEquals("Min Metaspace generation value incorrect.", "1G", jvm.getMinMetaspaceValue());
+        assertEquals("-XX:MetaspaceSize=1G",jvm.getMinMetaspaceOption(),"Min Metaspace generation option incorrect.");
+        assertEquals("1G",jvm.getMinMetaspaceValue(),"Min Metaspace generation value incorrect.");
     }
 
     @Test
     public void testGetMaxMetaspaceSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max Metaspace generation optiion incorrect.", "-XX:MaxMetaspaceSize=128m",
-                jvm.getMaxMetaspaceOption());
-        assertEquals("Max Metaspace generation value incorrect.", "128m", jvm.getMaxMetaspaceValue());
+        assertEquals("-XX:MaxMetaspaceSize=128m",jvm.getMaxMetaspaceOption(),"Max Metaspace generation optiion incorrect.");
+        assertEquals("128m",jvm.getMaxMetaspaceValue(),"Max Metaspace generation value incorrect.");
     }
 
     @Test
     public void testGetMaxMetaspaceBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=128M -XX:MaxMetaspaceSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max Metaspace generation option incorrect.", "-XX:MaxMetaspaceSize=128M",
-                jvm.getMaxMetaspaceOption());
-        assertEquals("Max Metaspace generation value incorrect.", "128M", jvm.getMaxMetaspaceValue());
+        assertEquals("-XX:MaxMetaspaceSize=128M",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
+        assertEquals("128M",jvm.getMaxMetaspaceValue(),"Max Metaspace generation value incorrect.");
     }
 
     @Test
     public void testGetMaxMetaspaceSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1g -XX:MaxMetaspaceSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max Metaspace generation option incorrect.", "-XX:MaxMetaspaceSize=1g",
-                jvm.getMaxMetaspaceOption());
-        assertEquals("Max Metaspace generation value incorrect.", "1g", jvm.getMaxMetaspaceValue());
+        assertEquals("-XX:MaxMetaspaceSize=1g",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
+        assertEquals("1g",jvm.getMaxMetaspaceValue(),"Max Metaspace generation value incorrect.");
     }
 
     @Test
     public void testGetMaxMetaspaceBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max Metaspace generation option incorrect.", "-XX:MaxMetaspaceSize=1G",
-                jvm.getMaxMetaspaceOption());
-        assertEquals("Max Metaspace generation value incorrect.", "1G", jvm.getMaxMetaspaceValue());
+        assertEquals("-XX:MaxMetaspaceSize=1G",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
+        assertEquals("1G",jvm.getMaxMetaspaceValue(),"Max Metaspace generation value incorrect.");
     }
 
     @Test
@@ -469,22 +465,17 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G "
                 + "-XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Disable explicit gc option incorrect.", "-XX:+DisableExplicitGC",
-                jvm.getDisableExplicitGCOption());
+        assertEquals("-XX:+DisableExplicitGC",jvm.getDisableExplicitGCOption(),"Disable explicit gc option incorrect.");
     }
 
     @Test
     public void testRmiDgcServerGcIntervalValue() {
         String jvmOptions = "-Dsun.rmi.dgc.client.gcInterval=14400000 -Dsun.rmi.dgc.server.gcInterval=24400000";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("sun.rmi.dgc.client.gcInterval option incorrect.", "-Dsun.rmi.dgc.client.gcInterval=14400000",
-                jvm.getRmiDgcClientGcIntervalOption());
-        assertEquals("sun.rmi.dgc.client.gcInterval value incorrect.", "14400000",
-                jvm.getRmiDgcClientGcIntervalValue());
-        assertEquals("sun.rmi.dgc.server.gcInterval option incorrect.", "-Dsun.rmi.dgc.server.gcInterval=24400000",
-                jvm.getRmiDgcServerGcIntervalOption());
-        assertEquals("sun.rmi.dgc.server.gcInterval value incorrect.", "24400000",
-                jvm.getRmiDgcServerGcIntervalValue());
+        assertEquals("-Dsun.rmi.dgc.client.gcInterval=14400000",jvm.getRmiDgcClientGcIntervalOption(),"sun.rmi.dgc.client.gcInterval option incorrect.");
+        assertEquals("14400000",jvm.getRmiDgcClientGcIntervalValue(),"sun.rmi.dgc.client.gcInterval value incorrect.");
+        assertEquals("-Dsun.rmi.dgc.server.gcInterval=24400000",jvm.getRmiDgcServerGcIntervalOption(),"sun.rmi.dgc.server.gcInterval option incorrect.");
+        assertEquals("24400000",jvm.getRmiDgcServerGcIntervalValue(),"sun.rmi.dgc.server.gcInterval value incorrect.");
     }
 
     @Test
@@ -492,8 +483,7 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -Xms2048M -javaagent:byteman.jar=script:kill-3.btm,boot:byteman.jar -Xmx2048M "
                 + "-XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-javaagent option incorrect.", "-javaagent:byteman.jar=script:kill-3.btm,boot:byteman.jar",
-                jvm.getJavaagentOption());
+        assertEquals("-javaagent:byteman.jar=script:kill-3.btm,boot:byteman.jar",jvm.getJavaagentOption(),"-javaagent option incorrect.");
     }
 
     @Test
@@ -501,111 +491,105 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -Xms2048M -agentpath:C:/agent/agent.dll -Xmx2048M "
                 + "-XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-agentpath option incorrect.", "-agentpath:C:/agent/agent.dll", jvm.getAgentpathOption());
+        assertEquals("-agentpath:C:/agent/agent.dll",jvm.getAgentpathOption(),"-agentpath option incorrect.");
     }
 
     @Test
     public void testXBatch() {
         String jvmOptions = "-Xss128k -Xbatch -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-Xbatch option incorrect.", "-Xbatch", jvm.getXBatchOption());
+        assertEquals("-Xbatch",jvm.getXBatchOption(),"-Xbatch option incorrect.");
     }
 
     @Test
     public void testBackGroundCompilationDisabled() {
         String jvmOptions = "-Xss128k -XX:-BackgroundCompilation -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-BackgroundCompilation option incorrect.", "-XX:-BackgroundCompilation",
-                jvm.getDisableBackgroundCompilationOption());
+        assertEquals("-XX:-BackgroundCompilation",jvm.getDisableBackgroundCompilationOption(),"-XX:-BackgroundCompilation option incorrect.");
     }
 
     @Test
     public void testXcomp() {
         String jvmOptions = "-Xss128k -Xcomp -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-Xcomp option incorrect.", "-Xcomp", jvm.getXCompOption());
+        assertEquals("-Xcomp",jvm.getXCompOption(),"-Xcomp option incorrect.");
     }
 
     @Test
     public void testXInt() {
         String jvmOptions = "-Xss128k -Xint -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-Xint option incorrect.", "-Xint", jvm.getXIntOption());
+        assertEquals("-Xint",jvm.getXIntOption(),"-Xint option incorrect.");
     }
 
     @Test
     public void testExplicitGCInvokesConcurrent() {
         String jvmOptions = "-Xss128k -XX:+ExplicitGCInvokesConcurrent -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+ExplicitGCInvokesConcurrent option incorrect.", "-XX:+ExplicitGCInvokesConcurrent",
-                jvm.getExplicitGcInvokesConcurrentOption());
+        assertEquals("-XX:+ExplicitGCInvokesConcurrent",jvm.getExplicitGcInvokesConcurrentOption(),"-XX:+ExplicitGCInvokesConcurrent option incorrect.");
     }
 
     @Test
     public void testPrintCommandLineFlags() {
         String jvmOptions = "-Xss128k -XX:+PrintCommandLineFlags -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+PrintCommandLineFlags option incorrect.", "-XX:+PrintCommandLineFlags",
-                jvm.getPrintCommandLineFlagsOption());
+        assertEquals("-XX:+PrintCommandLineFlags",jvm.getPrintCommandLineFlagsOption(),"-XX:+PrintCommandLineFlags option incorrect.");
     }
 
     @Test
     public void testPrintGCDetails() {
         String jvmOptions = "-Xss128k -XX:+PrintGCDetails -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+PrintGCDetails option incorrect.", "-XX:+PrintGCDetails", jvm.getPrintGCDetailsOption());
+        assertEquals("-XX:+PrintGCDetails",jvm.getPrintGCDetailsOption(),"-XX:+PrintGCDetails option incorrect.");
     }
 
     @Test
     public void testUseParNewGC() {
         String jvmOptions = "-Xss128k -XX:+UseParNewGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+UseParNewGC option incorrect.", "-XX:+UseParNewGC", jvm.getUseParNewGCOption());
+        assertEquals("-XX:+UseParNewGC",jvm.getUseParNewGCOption(),"-XX:+UseParNewGC option incorrect.");
     }
 
     @Test
     public void testUseConcMarkSweepGC() {
         String jvmOptions = "-Xss128k -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+UseConcMarkSweepGC option incorrect.", "-XX:+UseConcMarkSweepGC",
-                jvm.getUseConcMarkSweepGCOption());
+        assertEquals("-XX:+UseConcMarkSweepGC",jvm.getUseConcMarkSweepGCOption(),"-XX:+UseConcMarkSweepGC option incorrect.");
     }
 
     @Test
     public void testCMSClassUnloadingEnabled() {
         String jvmOptions = "-Xss128k -XX:+CMSClassUnloadingEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+CMSClassUnloadingEnabled option incorrect.", "-XX:+CMSClassUnloadingEnabled",
-                jvm.getCMSClassUnloadingEnabled());
+        assertEquals("-XX:+CMSClassUnloadingEnabled",jvm.getCMSClassUnloadingEnabled(),"-XX:+CMSClassUnloadingEnabled option incorrect.");
     }
 
     @Test
     public void testCMSClassUnloadingDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSClassUnloadingEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-CMSClassUnloadingEnabled option incorrect.", "-XX:-CMSClassUnloadingEnabled",
-                jvm.getCMSClassUnloadingDisabled());
+        assertEquals("-XX:-CMSClassUnloadingEnabled",jvm.getCMSClassUnloadingDisabled(),"-XX:-CMSClassUnloadingEnabled option incorrect.");
     }
 
     @Test
     public void testPrintReferenceGC() {
         String jvmOptions = "-Xss128k -XX:+PrintReferenceGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+PrintReferenceGC option incorrect.", "-XX:+PrintReferenceGC", jvm.getPrintReferenceGC());
+        assertEquals("-XX:+PrintReferenceGC",jvm.getPrintReferenceGC(),"-XX:+PrintReferenceGC option incorrect.");
     }
 
     @Test
     public void testPrintGCCause() {
         String jvmOptions = "-Xss128k -XX:+PrintGCCause -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+PrintGCCause option incorrect.", "-XX:+PrintGCCause", jvm.getPrintGCCause());
+        assertEquals("-XX:+PrintGCCause",jvm.getPrintGCCause(),"-XX:+PrintGCCause option incorrect.");
     }
 
     @Test
     public void testPrintGCCauseDisabled() {
         String jvmOptions = "-Xss128k -XX:-PrintGCCause -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-PrintGCCause option incorrect.", "-XX:-PrintGCCause", jvm.getPrintGCCauseDisabled());
+        assertEquals("-XX:-PrintGCCause",jvm.getPrintGCCauseDisabled(),"-XX:-PrintGCCause option incorrect.");
     }
 
     /**
@@ -617,7 +601,7 @@ public class TestJvm {
                 + "Oct  2 2015 03:26:24 by \"java_re\" with unknown MS VC++:1600";
         Jvm jvm = new Jvm(null, null);
         jvm.setVersion(version);
-        assertEquals("JDK7 not identified", 7, jvm.JdkNumber());
+        assertEquals(7,jvm.JdkNumber(),"JDK7 not identified");
     }
 
     /**
@@ -629,7 +613,7 @@ public class TestJvm {
                 + "Oct  2 2015 03:26:24 by \"java_re\" with unknown MS VC++:1600";
         Jvm jvm = new Jvm(null, null);
         jvm.setVersion(version);
-        assertEquals("JDK7 not identified", 91, jvm.JdkUpdate());
+        assertEquals(91,jvm.JdkUpdate(),"JDK7 not identified");
     }
 
     /**
@@ -641,7 +625,7 @@ public class TestJvm {
                 + "built on Jan 29 2016 17:39:45 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         Jvm jvm = new Jvm(null, null);
         jvm.setVersion(version);
-        assertEquals("JDK8 not identified", 8, jvm.JdkNumber());
+        assertEquals(8,jvm.JdkNumber(),"JDK8 not identified");
     }
 
     /**
@@ -653,30 +637,28 @@ public class TestJvm {
                 + "built on Jan 29 2016 17:39:45 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         Jvm jvm = new Jvm(null, null);
         jvm.setVersion(version);
-        assertEquals("JDK8 not identified", 73, jvm.JdkUpdate());
+        assertEquals(73,jvm.JdkUpdate(),"JDK8 not identified");
     }
 
     @Test
     public void testTieredCompilation() {
         String jvmOptions = "-Xss128k -XX:+TieredCompilation -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+TieredCompilation option incorrect.", "-XX:+TieredCompilation", jvm.getTieredCompilation());
+        assertEquals("-XX:+TieredCompilation",jvm.getTieredCompilation(),"-XX:+TieredCompilation option incorrect.");
     }
 
     @Test
     public void testPrintStringDeduplicationStatistics() {
         String jvmOptions = "-Xss128k -XX:+PrintStringDeduplicationStatistics -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+TieredCompilation option incorrect.", "-XX:+PrintStringDeduplicationStatistics",
-                jvm.getPrintStringDeduplicationStatistics());
+        assertEquals("-XX:+PrintStringDeduplicationStatistics",jvm.getPrintStringDeduplicationStatistics(),"-XX:+TieredCompilation option incorrect.");
     }
 
     @Test
     public void testCmsInitiatingOccupancyFraction() {
         String jvmOptions = "-Xss128k -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:CMSInitiatingOccupancyFraction option incorrect.", "-XX:CMSInitiatingOccupancyFraction=70",
-                jvm.getCMSInitiatingOccupancyFraction());
+        assertEquals("-XX:CMSInitiatingOccupancyFraction=70",jvm.getCMSInitiatingOccupancyFraction(),"-XX:CMSInitiatingOccupancyFraction option incorrect.");
     }
 
     @Test
@@ -684,24 +666,21 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly "
                 + "-XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+UseCMSInitiatingOccupancyOnly option incorrect.", "-XX:+UseCMSInitiatingOccupancyOnly",
-                jvm.getCMSInitiatingOccupancyOnlyEnabled());
+        assertEquals("-XX:+UseCMSInitiatingOccupancyOnly",jvm.getCMSInitiatingOccupancyOnlyEnabled(),"-XX:+UseCMSInitiatingOccupancyOnly option incorrect.");
     }
 
     @Test
     public void testBiasedLockingDisabled() {
         String jvmOptions = "-Xss128k -XX:-UseBiasedLocking -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-UseBiasedLocking option incorrect.", "-XX:-UseBiasedLocking",
-                jvm.getBiasedLockingDisabled());
+        assertEquals("-XX:-UseBiasedLocking",jvm.getBiasedLockingDisabled(),"-XX:-UseBiasedLocking option incorrect.");
     }
 
     @Test
     public void testPrintApplicationConcurrentTime() {
         String jvmOptions = "-Xss128k -XX:+PrintGCApplicationConcurrentTime -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-PrintGCApplicationConcurrentTime option incorrect.", "-XX:+PrintGCApplicationConcurrentTime",
-                jvm.getPrintGcApplicationConcurrentTime());
+        assertEquals("-XX:+PrintGCApplicationConcurrentTime",jvm.getPrintGcApplicationConcurrentTime(),"-XX:-PrintGCApplicationConcurrentTime option incorrect.");
     }
 
     @Test
@@ -712,7 +691,7 @@ public class TestJvm {
                 + "JRE (1.8.0_65-b17), built on Oct  6 2015 17:16:12 by \"java_re\" with gcc 4.3.0 20080428 "
                 + "(Red Hat 4.3.0-8)";
         jvm.setVersion(version);
-        assertTrue("Jvm not identified as 64-bit.", jvm.is64Bit());
+        assertTrue(jvm.is64Bit(), "Jvm not identified as 64-bit.");
     }
 
     @Test
@@ -723,7 +702,7 @@ public class TestJvm {
                 + "JRE (1.8.0_65-b17), built on Oct  6 2015 17:16:12 by \"java_re\" with gcc 4.3.0 20080428 "
                 + "(Red Hat 4.3.0-8)";
         jvm.setVersion(version);
-        assertFalse("Jvm incorrectly not identified as 64-bit.", jvm.is64Bit());
+        assertFalse(jvm.is64Bit(), "Jvm incorrectly not identified as 64-bit.");
     }
 
     @Test
@@ -747,58 +726,56 @@ public class TestJvm {
     public void testPrintTenuringDistribution() {
         String jvmOptions = "-Xss128k -XX:+PrintTenuringDistribution -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+PrintTenuringDistribution option incorrect.", "-XX:+PrintTenuringDistribution",
-                jvm.getPrintTenuringDistribution());
+        assertEquals("-XX:+PrintTenuringDistribution",jvm.getPrintTenuringDistribution(),"-XX:+PrintTenuringDistribution option incorrect.");
     }
 
     @Test
     public void testMaxHeapBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max heap bytes incorrect.", bytes(2147483648L), jvm.getMaxHeapBytes());
+        assertEquals(bytes(2147483648L),jvm.getMaxHeapBytes(),"Max heap bytes incorrect.");
     }
 
     @Test
     public void testMaxHeapBytesUnknown() {
         String jvmOptions = "-Xss128k -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max heap bytes incorrect.", bytes(0L), jvm.getMaxHeapBytes());
+        assertEquals(bytes(0L),jvm.getMaxHeapBytes(),"Max heap bytes incorrect.");
     }
 
     @Test
     public void testMaxPermBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxPermSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max perm space bytes incorrect.", bytes(1342177280), jvm.getMaxPermBytes());
+        assertEquals(bytes(1342177280),jvm.getMaxPermBytes(),"Max perm space bytes incorrect.");
     }
 
     @Test
     public void testMaxPermBytesUnknown() {
         String jvmOptions = "-Xss128k";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max perm space bytes incorrect.", bytes(0L), jvm.getMaxPermBytes());
+        assertEquals(bytes(0L),jvm.getMaxPermBytes(),"Max perm space bytes incorrect.");
     }
 
     @Test
     public void testMaxMetaspaceBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max metaspace bytes incorrect.", bytes(1342177280), jvm.getMaxMetaspaceBytes());
+        assertEquals(bytes(1342177280),jvm.getMaxMetaspaceBytes(),"Max metaspace bytes incorrect.");
     }
 
     @Test
     public void testMaxMetaspaceBytesUnknown() {
         String jvmOptions = "-Xss128k";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Max metaspace bytes incorrect.", bytes(0L), jvm.getMaxMetaspaceBytes());
+        assertEquals(bytes(0L),jvm.getMaxMetaspaceBytes(),"Max metaspace bytes incorrect.");
     }
 
     @Test
     public void testgetCompressedClassSpaceSizeBytes() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Compressed class space size bytes incorrect.", bytes(805306368),
-                jvm.getCompressedClassSpaceSizeBytes());
+        assertEquals(bytes(805306368),jvm.getCompressedClassSpaceSizeBytes(),"Compressed class space size bytes incorrect.");
     }
 
     @Test
@@ -855,7 +832,7 @@ public class TestJvm {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:G1MixedGCLiveThresholdPercent=85 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:G1MixedGCLiveThresholdPercent=NN not found.", jvm.getG1MixedGCLiveThresholdPercent());
-        assertEquals("G1MixedGCLiveThresholdPercent incorrect.", "85", jvm.getG1MixedGCLiveThresholdPercentValue());
+        assertEquals("85",jvm.getG1MixedGCLiveThresholdPercentValue(),"G1MixedGCLiveThresholdPercent incorrect.");
     }
 
     @Test
@@ -863,7 +840,7 @@ public class TestJvm {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:G1HeapWastePercent=5 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:G1HeapWastePercent=NN not found.", jvm.getG1HeapWastePercent());
-        assertEquals("G1HeapWastePercent incorrect.", "5", jvm.getG1HeapWastePercentValue());
+        assertEquals("5",jvm.getG1HeapWastePercentValue(),"G1HeapWastePercent incorrect.");
     }
 
     @Test
@@ -878,8 +855,8 @@ public class TestJvm {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192 -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
-        assertEquals("Log file size value incorrect.", "8192", jvm.getGcLogFileSizeValue());
-        assertEquals("Log file size bytes incorrect.", kilobytes(8), jvm.getGcLogFileSizeBytes());
+        assertEquals("8192",jvm.getGcLogFileSizeValue(),"Log file size value incorrect.");
+        assertEquals(kilobytes(8),jvm.getGcLogFileSizeBytes(),"Log file size bytes incorrect.");
     }
 
     @Test
@@ -887,8 +864,8 @@ public class TestJvm {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192k -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
-        assertEquals("Log file size value incorrect.", "8192k", jvm.getGcLogFileSizeValue());
-        assertEquals("Log file size bytes incorrect.", megabytes(8), jvm.getGcLogFileSizeBytes());
+        assertEquals("8192k",jvm.getGcLogFileSizeValue(),"Log file size value incorrect.");
+        assertEquals(megabytes(8),jvm.getGcLogFileSizeBytes(),"Log file size bytes incorrect.");
     }
 
     @Test
@@ -896,8 +873,8 @@ public class TestJvm {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192K -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
-        assertEquals("Log file size value incorrect.", "8192K", jvm.getGcLogFileSizeValue());
-        assertEquals("Log file size bytes incorrect.", megabytes(8), jvm.getGcLogFileSizeBytes());
+        assertEquals("8192K",jvm.getGcLogFileSizeValue(),"Log file size value incorrect.");
+        assertEquals(megabytes(8),jvm.getGcLogFileSizeBytes(),"Log file size bytes incorrect.");
     }
 
     @Test
@@ -905,8 +882,8 @@ public class TestJvm {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=5m -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
-        assertEquals("Log file size value incorrect.", "5m", jvm.getGcLogFileSizeValue());
-        assertEquals("Log file size bytes incorrect.", Memory.megabytes(5), jvm.getGcLogFileSizeBytes());
+        assertEquals("5m",jvm.getGcLogFileSizeValue(),"Log file size value incorrect.");
+        assertEquals(Memory.megabytes(5),jvm.getGcLogFileSizeBytes(),"Log file size bytes incorrect.");
     }
 
     @Test
@@ -914,8 +891,8 @@ public class TestJvm {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=5M -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
-        assertEquals("Log file size value incorrect.", "5M", jvm.getGcLogFileSizeValue());
-        assertEquals("Log file size bytes incorrect.", megabytes(5), jvm.getGcLogFileSizeBytes());
+        assertEquals("5M",jvm.getGcLogFileSizeValue(),"Log file size value incorrect.");
+        assertEquals(megabytes(5),jvm.getGcLogFileSizeBytes(),"Log file size bytes incorrect.");
     }
 
     @Test
@@ -929,24 +906,21 @@ public class TestJvm {
     public void testCmsParallelInitialMarkDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSParallelInitialMarkEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-CMSParallelInitialMarkEnabled option incorrect.", "-XX:-CMSParallelInitialMarkEnabled",
-                jvm.getCmsParallelInitialMarkDisabled());
+        assertEquals("-XX:-CMSParallelInitialMarkEnabled",jvm.getCmsParallelInitialMarkDisabled(),"-XX:-CMSParallelInitialMarkEnabled option incorrect.");
     }
 
     @Test
     public void testCmsParallelRemarkDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSParallelRemarkEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:-CMSParallelRemarkEnabled option incorrect.", "-XX:-CMSParallelRemarkEnabled",
-                jvm.getCmsParallelRemarkDisabled());
+        assertEquals("-XX:-CMSParallelRemarkEnabled",jvm.getCmsParallelRemarkDisabled(),"-XX:-CMSParallelRemarkEnabled option incorrect.");
     }
 
     @Test
     public void testG1SummarizeRSetStatsEnabled() {
         String jvmOptions = "-Xss128k -XX:+UnlockExperimentalVMOptions -XX:+G1SummarizeRSetStats -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("-XX:+G1SummarizeRSetStats option incorrect.", "-XX:+G1SummarizeRSetStats",
-                jvm.getG1SummarizeRSetStatsEnabled());
+        assertEquals("-XX:+G1SummarizeRSetStats",jvm.getG1SummarizeRSetStatsEnabled(),"-XX:+G1SummarizeRSetStats option incorrect.");
     }
 
     @Test
@@ -955,7 +929,7 @@ public class TestJvm {
                 + "-XX:G1SummarizeRSetStatsPeriod=1 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:G1SummarizeRSetStatsPeriod=NNN not found.", jvm.getG1SummarizeRSetStatsPeriod());
-        assertEquals("G1SummarizeRSetStatsPeriod incorrect.", "1", jvm.getG1SummarizeRSetStatsPeriodValue());
+        assertEquals("1",jvm.getG1SummarizeRSetStatsPeriodValue(),"G1SummarizeRSetStatsPeriod incorrect.");
     }
 
     @Test
@@ -963,7 +937,7 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:HeapDumpPath=/path/ not found.", jvm.getHeapDumpPathOption());
-        assertEquals("Heap dump path value incorrect.", "/path/", jvm.getHeapDumpPathValue());
+        assertEquals("/path/",jvm.getHeapDumpPathValue(),"Heap dump path value incorrect.");
     }
 
     @Test
@@ -971,7 +945,7 @@ public class TestJvm {
         String jvmOptions = "-Xss128k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/to/heap.dump";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:HeapDumpPath=/path/to/heap.dump not found.", jvm.getHeapDumpPathOption());
-        assertEquals("Heap dump path value incorrect.", "/path/to/heap.dump", jvm.getHeapDumpPathValue());
+        assertEquals("/path/to/heap.dump",jvm.getHeapDumpPathValue(),"Heap dump path value incorrect.");
     }
 
     @Test
@@ -979,17 +953,12 @@ public class TestJvm {
         String jvmOptions = "-Xss128K -XX:-BackgroundCompilation -Xms1024m -Xmx2048m -XX:-UseCompressedClassPointers "
                 + "-XX:-UseCompressedOops -XX:-TraceClassUnloading";
         Jvm jvm = new Jvm(jvmOptions, null);
-        assertEquals("Disabled options count incorrect.", 4, jvm.getDisabledOptions().size());
-        assertTrue("-XX:-BackgroundCompilation not identified as disabled option.",
-                jvm.getDisabledOptions().contains("-XX:-BackgroundCompilation"));
-        assertTrue("-XX:-UseCompressedClassPointers not identified as disabled option.",
-                jvm.getDisabledOptions().contains("-XX:-UseCompressedClassPointers"));
-        assertTrue("-XX:-UseCompressedOops not identified as disabled option.",
-                jvm.getDisabledOptions().contains("-XX:-UseCompressedOops"));
-        assertTrue("-XX:-TraceClassUnloading not identified as disabled option.",
-                jvm.getDisabledOptions().contains("-XX:-TraceClassUnloading"));
+        assertEquals(4,jvm.getDisabledOptions().size(),"Disabled options count incorrect.");
+        assertTrue(jvm.getDisabledOptions().contains("-XX:-BackgroundCompilation"), "-XX:-BackgroundCompilation not identified as disabled option.");
+        assertTrue(jvm.getDisabledOptions().contains("-XX:-UseCompressedClassPointers"), "-XX:-UseCompressedClassPointers not identified as disabled option.");
+        assertTrue(jvm.getDisabledOptions().contains("-XX:-UseCompressedOops"), "-XX:-UseCompressedOops not identified as disabled option.");
+        assertTrue(jvm.getDisabledOptions().contains("-XX:-TraceClassUnloading"), "-XX:-TraceClassUnloading not identified as disabled option.");
         assertNotNull("Unaccounted disabled options not identified.", jvm.getUnaccountedDisabledOptions());
-        assertEquals("Unaccounted disabled options incorrect.", "-XX:-TraceClassUnloading",
-                jvm.getUnaccountedDisabledOptions());
+        assertEquals("-XX:-TraceClassUnloading",jvm.getUnaccountedDisabledOptions(),"Unaccounted disabled options incorrect.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJvm.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/TestJvm.java
@@ -27,17 +27,17 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestJvm {
+class TestJvm {
 
     @Test
-    public void testNullJvmOptions() {
+    void testNullJvmOptions() {
         String jvmOptions = null;
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull(jvm,"Jvm object creation failed.");
     }
 
     @Test
-    public void testGetThreadStackSizeSsSmallK() {
+    void testGetThreadStackSizeSsSmallK() {
         String jvmOptions = "-ss128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-ss128k",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -45,7 +45,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeSsBigK() {
+    void testGetThreadStackSizeSsBigK() {
         String jvmOptions = "-ss128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-ss128K",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -53,7 +53,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeSsSmallM() {
+    void testGetThreadStackSizeSsSmallM() {
         String jvmOptions = "-ss1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-ss1m",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -61,7 +61,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeXssSmallK() {
+    void testGetThreadStackSizeXssSmallK() {
         String jvmOptions = "-Xss128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xss128k",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -69,7 +69,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeXssBigK() {
+    void testGetThreadStackSizeXssBigK() {
         String jvmOptions = "-Xss128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xss128K",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -77,7 +77,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeXssSmallM() {
+    void testGetThreadStackSizeXssSmallM() {
         String jvmOptions = "-Xss1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xss1m",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -85,7 +85,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeXssBigM() {
+    void testGetThreadStackSizeXssBigM() {
         String jvmOptions = "-Xss1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xss1M",jvm.getThreadStackSizeOption(),"Thread stack size not populated correctly.");
@@ -93,7 +93,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeSmallK() {
+    void testGetThreadStackSizeSmallK() {
         String jvmOptions = "-XX:ThreadStackSize=128k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:ThreadStackSize=128k",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
@@ -101,7 +101,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeBigK() {
+    void testGetThreadStackSizeBigK() {
         String jvmOptions = "-XX:ThreadStackSize=128K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:ThreadStackSize=128K",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
@@ -109,7 +109,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeSmallM() {
+    void testGetThreadStackSizeSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:ThreadStackSize=1m",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
@@ -117,7 +117,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeBigM() {
+    void testGetThreadStackSizeBigM() {
         String jvmOptions = "-XX:ThreadStackSize=1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:ThreadStackSize=1M",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
@@ -125,7 +125,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeNoUnits() {
+    void testGetThreadStackSizeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1234567 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:ThreadStackSize=1234567",jvm.getThreadStackSizeOption(),"Thread stack size incorrect.");
@@ -133,91 +133,91 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetThreadStackSizeOneLessThanLargeNoUnits() {
+    void testGetThreadStackSizeOneLessThanLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048575 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
-    public void testGetThreadStackSizeEqualsLargeNoUnits() {
+    void testGetThreadStackSizeEqualsLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048576 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneGreaterLargeNoUnits() {
+    void testGetThreadStackSizeOneGreaterLargeNoUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048577 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneLessThanLargeByteUnits() {
+    void testGetThreadStackSizeOneLessThanLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048575b -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
-    public void testGetThreadStackSizeEqualsLargeByteUnits() {
+    void testGetThreadStackSizeEqualsLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048576B -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneGreaterLargeByteUnits() {
+    void testGetThreadStackSizeOneGreaterLargeByteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1048577B -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneLessThanLargeKilobyteUnits() {
+    void testGetThreadStackSizeOneLessThanLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1023k -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertFalse(jvm.hasLargeThreadStackSize(), "Thread stack size is not large.");
     }
 
     @Test
-    public void testGetThreadStackSizeEqualsLargeKilobyteUnits() {
+    void testGetThreadStackSizeEqualsLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1024K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneGreaterLargeKilobyteUnits() {
+    void testGetThreadStackSizeOneGreaterLargeKilobyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1025K -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeEqualsLargeMegabyteUnits() {
+    void testGetThreadStackSizeEqualsLargeMegabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1m -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeOneGreaterLargeMegabyteUnits() {
+    void testGetThreadStackSizeOneGreaterLargeMegabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1M -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetThreadStackSizeLargeGigabyteUnits() {
+    void testGetThreadStackSizeLargeGigabyteUnits() {
         String jvmOptions = "-XX:ThreadStackSize=1G -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertTrue(jvm.hasLargeThreadStackSize(), "Thread stack size is large.");
     }
 
     @Test
-    public void testGetMinHeapSmallM() {
+    void testGetMinHeapSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xms1024m",jvm.getMinHeapOption(),"Min heap option incorrect.");
@@ -225,7 +225,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinHeapBigM() {
+    void testGetMinHeapBigM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024M -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xms1024M",jvm.getMinHeapOption(),"Min heap option incorrect.");
@@ -233,7 +233,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinHeapSmallG() {
+    void testGetMinHeapSmallG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1g -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xms1g",jvm.getMinHeapOption(),"Min heap option incorrect.");
@@ -241,7 +241,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinHeapBigG() {
+    void testGetMinHeapBigG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1G -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xms1G",jvm.getMinHeapOption(),"Min heap option incorrect.");
@@ -249,7 +249,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxHeapSmallM() {
+    void testGetMaxHeapSmallM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024m -Xmx2048m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xmx2048m",jvm.getMaxHeapOption(),"Min heap option incorrect.");
@@ -257,7 +257,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxHeapBigM() {
+    void testGetMaxHeapBigM() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1024M -Xmx2048M";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xmx2048M",jvm.getMaxHeapOption(),"Min heap option incorrect.");
@@ -265,7 +265,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxHeapSmallG() {
+    void testGetMaxHeapSmallG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1g -Xmx2g";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xmx2g",jvm.getMaxHeapOption(),"Min heap option incorrect.");
@@ -273,7 +273,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxHeapBigG() {
+    void testGetMaxHeapBigG() {
         String jvmOptions = "-XX:ThreadStackSize=128 -Xms1G -Xmx2G";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xmx2G",jvm.getMaxHeapOption(),"Min heap option incorrect.");
@@ -281,7 +281,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testIsMinAndMaxHeapSpaceEqual() {
+    void testIsMinAndMaxHeapSpaceEqual() {
         Jvm jvm = new Jvm("-Xms2g -Xmx2G", null);
         assertTrue(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-Xms1G -Xmx2G", null);
@@ -291,7 +291,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testIsMinAndMaxHeapSpaceEqualVerboseOptions() {
+    void testIsMinAndMaxHeapSpaceEqualVerboseOptions() {
         Jvm jvm = new Jvm("-XX:InitialHeapSize=1234567890 -XX:MaxHeapSize=1234567890", null);
         assertTrue(jvm.isMinAndMaxHeapSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-XX:InitialHeapSize=1234567890 -XX:MaxHeapSize=1234567891", null);
@@ -299,7 +299,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinPermSmallM() {
+    void testGetMinPermSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128m -XX:MaxPermSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:PermSize=128m",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
@@ -307,7 +307,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinPermBigM() {
+    void testGetMinPermBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128M -XX:MaxPermSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:PermSize=128M",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
@@ -315,7 +315,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinPermSmallG() {
+    void testGetMinPermSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1g -XX:MaxPermSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:PermSize=1g",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
@@ -323,7 +323,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinPermBigG() {
+    void testGetMinPermBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1G -XX:MaxPermSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:PermSize=1G",jvm.getMinPermOption(),"Min permanent generation option incorrect.");
@@ -331,7 +331,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxPermSmallM() {
+    void testGetMaxPermSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128m -XX:MaxPermSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxPermSize=128m",jvm.getMaxPermOption(),"Max permanent generation optiion incorrect.");
@@ -339,7 +339,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxPermBigM() {
+    void testGetMaxPermBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=128M -XX:MaxPermSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxPermSize=128M",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
@@ -347,7 +347,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxPermSmallG() {
+    void testGetMaxPermSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1g -XX:MaxPermSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxPermSize=1g",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
@@ -355,7 +355,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxPermBigG() {
+    void testGetMaxPermBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:PermSize=1G -XX:MaxPermSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxPermSize=1G",jvm.getMaxPermOption(),"Max permanent generation option incorrect.");
@@ -363,49 +363,49 @@ public class TestJvm {
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentCaseM() {
+    void testIsMinAndMaxPermSpaceEqualDifferentCaseM() {
         Jvm jvm = new Jvm("-XX:PermSize=256m -XX:MaxPermSize=256M", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentCaseG() {
+    void testIsMinAndMaxPermSpaceEqualDifferentCaseG() {
         Jvm jvm = new Jvm("-XX:PermSize=1G -XX:MaxPermSize=1g", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualMissingMin() {
+    void testIsMinAndMaxPermSpaceEqualMissingMin() {
         Jvm jvm = new Jvm("-XX:MaxPermSize=256M", null);
         assertFalse(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are not equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentUnitsMG() {
+    void testIsMinAndMaxPermSpaceEqualDifferentUnitsMG() {
         Jvm jvm = new Jvm("-XX:PermSize=2048m -XX:MaxPermSize=2g", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentUnitsKM() {
+    void testIsMinAndMaxPermSpaceEqualDifferentUnitsKM() {
         Jvm jvm = new Jvm("-XX:PermSize=1024K -XX:MaxPermSize=1m", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentUnitsNoneG() {
+    void testIsMinAndMaxPermSpaceEqualDifferentUnitsNoneG() {
         Jvm jvm = new Jvm("-XX:PermSize=1073741824 -XX:MaxPermSize=1G", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualDifferentUnitsBG() {
+    void testIsMinAndMaxPermSpaceEqualDifferentUnitsBG() {
         Jvm jvm = new Jvm("-XX:PermSize=1073741824b -XX:MaxPermSize=1G", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
     }
 
     @Test
-    public void testIsMinAndMaxPermSpaceEqualVerboseOptions() {
+    void testIsMinAndMaxPermSpaceEqualVerboseOptions() {
         Jvm jvm = new Jvm("-XX:MaxPermSize=1234567890 -XX:PermSize=1234567890", null);
         assertTrue(jvm.isMinAndMaxPermSpaceEqual(), "Min and max heap are equal.");
         jvm = new Jvm("-XX:MaxPermSize=1234567890 -XX:PermSize=1234567891", null);
@@ -413,7 +413,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinMetaspaceSmallG() {
+    void testGetMinMetaspaceSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1g -XX:MaxMetaspaceSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MetaspaceSize=1g",jvm.getMinMetaspaceOption(),"Min Metaspace generation option incorrect.");
@@ -421,7 +421,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMinMetaspaceBigG() {
+    void testGetMinMetaspaceBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MetaspaceSize=1G",jvm.getMinMetaspaceOption(),"Min Metaspace generation option incorrect.");
@@ -429,7 +429,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxMetaspaceSmallM() {
+    void testGetMaxMetaspaceSmallM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=128m -XX:MaxMetaspaceSize=128m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxMetaspaceSize=128m",jvm.getMaxMetaspaceOption(),"Max Metaspace generation optiion incorrect.");
@@ -437,7 +437,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxMetaspaceBigM() {
+    void testGetMaxMetaspaceBigM() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=128M -XX:MaxMetaspaceSize=128M";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxMetaspaceSize=128M",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
@@ -445,7 +445,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxMetaspaceSmallG() {
+    void testGetMaxMetaspaceSmallG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1g -XX:MaxMetaspaceSize=1g";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxMetaspaceSize=1g",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
@@ -453,7 +453,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGetMaxMetaspaceBigG() {
+    void testGetMaxMetaspaceBigG() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:MaxMetaspaceSize=1G",jvm.getMaxMetaspaceOption(),"Max Metaspace generation option incorrect.");
@@ -461,7 +461,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testDisableExplicitGc() {
+    void testDisableExplicitGc() {
         String jvmOptions = "-Xss128k -Xms2048M -Xmx2048M -XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G "
                 + "-XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -469,7 +469,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testRmiDgcServerGcIntervalValue() {
+    void testRmiDgcServerGcIntervalValue() {
         String jvmOptions = "-Dsun.rmi.dgc.client.gcInterval=14400000 -Dsun.rmi.dgc.server.gcInterval=24400000";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Dsun.rmi.dgc.client.gcInterval=14400000",jvm.getRmiDgcClientGcIntervalOption(),"sun.rmi.dgc.client.gcInterval option incorrect.");
@@ -479,7 +479,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testJavaagent() {
+    void testJavaagent() {
         String jvmOptions = "-Xss128k -Xms2048M -javaagent:byteman.jar=script:kill-3.btm,boot:byteman.jar -Xmx2048M "
                 + "-XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -487,7 +487,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testAgentpath() {
+    void testAgentpath() {
         String jvmOptions = "-Xss128k -Xms2048M -agentpath:C:/agent/agent.dll -Xmx2048M "
                 + "-XX:MetaspaceSize=1G -XX:MaxMetaspaceSize=1G -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -495,98 +495,98 @@ public class TestJvm {
     }
 
     @Test
-    public void testXBatch() {
+    void testXBatch() {
         String jvmOptions = "-Xss128k -Xbatch -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xbatch",jvm.getXBatchOption(),"-Xbatch option incorrect.");
     }
 
     @Test
-    public void testBackGroundCompilationDisabled() {
+    void testBackGroundCompilationDisabled() {
         String jvmOptions = "-Xss128k -XX:-BackgroundCompilation -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-BackgroundCompilation",jvm.getDisableBackgroundCompilationOption(),"-XX:-BackgroundCompilation option incorrect.");
     }
 
     @Test
-    public void testXcomp() {
+    void testXcomp() {
         String jvmOptions = "-Xss128k -Xcomp -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xcomp",jvm.getXCompOption(),"-Xcomp option incorrect.");
     }
 
     @Test
-    public void testXInt() {
+    void testXInt() {
         String jvmOptions = "-Xss128k -Xint -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-Xint",jvm.getXIntOption(),"-Xint option incorrect.");
     }
 
     @Test
-    public void testExplicitGCInvokesConcurrent() {
+    void testExplicitGCInvokesConcurrent() {
         String jvmOptions = "-Xss128k -XX:+ExplicitGCInvokesConcurrent -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+ExplicitGCInvokesConcurrent",jvm.getExplicitGcInvokesConcurrentOption(),"-XX:+ExplicitGCInvokesConcurrent option incorrect.");
     }
 
     @Test
-    public void testPrintCommandLineFlags() {
+    void testPrintCommandLineFlags() {
         String jvmOptions = "-Xss128k -XX:+PrintCommandLineFlags -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintCommandLineFlags",jvm.getPrintCommandLineFlagsOption(),"-XX:+PrintCommandLineFlags option incorrect.");
     }
 
     @Test
-    public void testPrintGCDetails() {
+    void testPrintGCDetails() {
         String jvmOptions = "-Xss128k -XX:+PrintGCDetails -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintGCDetails",jvm.getPrintGCDetailsOption(),"-XX:+PrintGCDetails option incorrect.");
     }
 
     @Test
-    public void testUseParNewGC() {
+    void testUseParNewGC() {
         String jvmOptions = "-Xss128k -XX:+UseParNewGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+UseParNewGC",jvm.getUseParNewGCOption(),"-XX:+UseParNewGC option incorrect.");
     }
 
     @Test
-    public void testUseConcMarkSweepGC() {
+    void testUseConcMarkSweepGC() {
         String jvmOptions = "-Xss128k -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+UseConcMarkSweepGC",jvm.getUseConcMarkSweepGCOption(),"-XX:+UseConcMarkSweepGC option incorrect.");
     }
 
     @Test
-    public void testCMSClassUnloadingEnabled() {
+    void testCMSClassUnloadingEnabled() {
         String jvmOptions = "-Xss128k -XX:+CMSClassUnloadingEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+CMSClassUnloadingEnabled",jvm.getCMSClassUnloadingEnabled(),"-XX:+CMSClassUnloadingEnabled option incorrect.");
     }
 
     @Test
-    public void testCMSClassUnloadingDisabled() {
+    void testCMSClassUnloadingDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSClassUnloadingEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-CMSClassUnloadingEnabled",jvm.getCMSClassUnloadingDisabled(),"-XX:-CMSClassUnloadingEnabled option incorrect.");
     }
 
     @Test
-    public void testPrintReferenceGC() {
+    void testPrintReferenceGC() {
         String jvmOptions = "-Xss128k -XX:+PrintReferenceGC -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintReferenceGC",jvm.getPrintReferenceGC(),"-XX:+PrintReferenceGC option incorrect.");
     }
 
     @Test
-    public void testPrintGCCause() {
+    void testPrintGCCause() {
         String jvmOptions = "-Xss128k -XX:+PrintGCCause -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintGCCause",jvm.getPrintGCCause(),"-XX:+PrintGCCause option incorrect.");
     }
 
     @Test
-    public void testPrintGCCauseDisabled() {
+    void testPrintGCCauseDisabled() {
         String jvmOptions = "-Xss128k -XX:-PrintGCCause -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-PrintGCCause",jvm.getPrintGCCauseDisabled(),"-XX:-PrintGCCause option incorrect.");
@@ -596,7 +596,7 @@ public class TestJvm {
      * Test if JDK7 by inspecting version header.
      */
     @Test
-    public void testJdk7() {
+    void testJdk7() {
         String version = "Java HotSpot(TM) 64-Bit Server VM (24.91-b03) for windows-amd64 JRE (1.7.0_91-b15), built on "
                 + "Oct  2 2015 03:26:24 by \"java_re\" with unknown MS VC++:1600";
         Jvm jvm = new Jvm(null, null);
@@ -608,7 +608,7 @@ public class TestJvm {
      * Test JDK7 update version by inspecting version header.
      */
     @Test
-    public void testJdkUpdate7() {
+    void testJdkUpdate7() {
         String version = "Java HotSpot(TM) 64-Bit Server VM (24.91-b03) for windows-amd64 JRE (1.7.0_91-b15), built on "
                 + "Oct  2 2015 03:26:24 by \"java_re\" with unknown MS VC++:1600";
         Jvm jvm = new Jvm(null, null);
@@ -620,7 +620,7 @@ public class TestJvm {
      * Test if JDK8 by inspecting version header.
      */
     @Test
-    public void testJdk8() {
+    void testJdk8() {
         String version = "Java HotSpot(TM) 64-Bit Server VM (25.73-b02) for linux-amd64 JRE (1.8.0_73-b02), "
                 + "built on Jan 29 2016 17:39:45 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         Jvm jvm = new Jvm(null, null);
@@ -632,7 +632,7 @@ public class TestJvm {
      * Test JDK8 update version by inspecting version header.
      */
     @Test
-    public void testJdkUpdate8() {
+    void testJdkUpdate8() {
         String version = "Java HotSpot(TM) 64-Bit Server VM (25.73-b02) for linux-amd64 JRE (1.8.0_73-b02), "
                 + "built on Jan 29 2016 17:39:45 by \"java_re\" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)";
         Jvm jvm = new Jvm(null, null);
@@ -641,28 +641,28 @@ public class TestJvm {
     }
 
     @Test
-    public void testTieredCompilation() {
+    void testTieredCompilation() {
         String jvmOptions = "-Xss128k -XX:+TieredCompilation -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+TieredCompilation",jvm.getTieredCompilation(),"-XX:+TieredCompilation option incorrect.");
     }
 
     @Test
-    public void testPrintStringDeduplicationStatistics() {
+    void testPrintStringDeduplicationStatistics() {
         String jvmOptions = "-Xss128k -XX:+PrintStringDeduplicationStatistics -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintStringDeduplicationStatistics",jvm.getPrintStringDeduplicationStatistics(),"-XX:+TieredCompilation option incorrect.");
     }
 
     @Test
-    public void testCmsInitiatingOccupancyFraction() {
+    void testCmsInitiatingOccupancyFraction() {
         String jvmOptions = "-Xss128k -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:CMSInitiatingOccupancyFraction=70",jvm.getCMSInitiatingOccupancyFraction(),"-XX:CMSInitiatingOccupancyFraction option incorrect.");
     }
 
     @Test
-    public void testUseCmsInitiatingOccupancyOnlyEnabled() {
+    void testUseCmsInitiatingOccupancyOnlyEnabled() {
         String jvmOptions = "-Xss128k -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly "
                 + "-XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -670,21 +670,21 @@ public class TestJvm {
     }
 
     @Test
-    public void testBiasedLockingDisabled() {
+    void testBiasedLockingDisabled() {
         String jvmOptions = "-Xss128k -XX:-UseBiasedLocking -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-UseBiasedLocking",jvm.getBiasedLockingDisabled(),"-XX:-UseBiasedLocking option incorrect.");
     }
 
     @Test
-    public void testPrintApplicationConcurrentTime() {
+    void testPrintApplicationConcurrentTime() {
         String jvmOptions = "-Xss128k -XX:+PrintGCApplicationConcurrentTime -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintGCApplicationConcurrentTime",jvm.getPrintGcApplicationConcurrentTime(),"-XX:-PrintGCApplicationConcurrentTime option incorrect.");
     }
 
     @Test
-    public void testIs64Bit() {
+    void testIs64Bit() {
         String jvmOptions = "-Xss128k -XX:+PrintGCApplicationConcurrentTime -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
         String version = "Version: Java HotSpot(TM) 64-Bit Server VM (25.65-b01) for linux-amd64 "
@@ -695,7 +695,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testIsNot64Bit() {
+    void testIsNot64Bit() {
         String jvmOptions = "-Xss128k -XX:+PrintGCApplicationConcurrentTime -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
         String version = "Version: Java HotSpot(TM) 32-Bit Server VM (25.65-b01) for linux-amd64 "
@@ -706,7 +706,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testUseCompressedClassPointers() {
+    void testUseCompressedClassPointers() {
         String jvmOptions = "-Xss128k -XX:+UseCompressedClassPointers -XX:+UseCompressedOops "
                 + "-XX:+PrintGCApplicationConcurrentTime -XX:+CMSParallelRemarkEnabled";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -714,7 +714,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testCompressedClassSpaceSize() {
+    void testCompressedClassSpaceSize() {
         String jvmOptions = "-Xss128k -XX:MetaspaceSize=1280 -XX:MaxMetaspaceSize=1280m "
                 + "-XX:CompressedClassSpaceSize=768m -XX:+PrintGCApplicationConcurrentTime "
                 + "-XX:+CMSParallelRemarkEnabled";
@@ -723,112 +723,112 @@ public class TestJvm {
     }
 
     @Test
-    public void testPrintTenuringDistribution() {
+    void testPrintTenuringDistribution() {
         String jvmOptions = "-Xss128k -XX:+PrintTenuringDistribution -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+PrintTenuringDistribution",jvm.getPrintTenuringDistribution(),"-XX:+PrintTenuringDistribution option incorrect.");
     }
 
     @Test
-    public void testMaxHeapBytes() {
+    void testMaxHeapBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(2147483648L),jvm.getMaxHeapBytes(),"Max heap bytes incorrect.");
     }
 
     @Test
-    public void testMaxHeapBytesUnknown() {
+    void testMaxHeapBytesUnknown() {
         String jvmOptions = "-Xss128k -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(0L),jvm.getMaxHeapBytes(),"Max heap bytes incorrect.");
     }
 
     @Test
-    public void testMaxPermBytes() {
+    void testMaxPermBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxPermSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(1342177280),jvm.getMaxPermBytes(),"Max perm space bytes incorrect.");
     }
 
     @Test
-    public void testMaxPermBytesUnknown() {
+    void testMaxPermBytesUnknown() {
         String jvmOptions = "-Xss128k";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(0L),jvm.getMaxPermBytes(),"Max perm space bytes incorrect.");
     }
 
     @Test
-    public void testMaxMetaspaceBytes() {
+    void testMaxMetaspaceBytes() {
         String jvmOptions = "-Xss128k -Xmx2048m -XX:MaxMetaspaceSize=1280m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(1342177280),jvm.getMaxMetaspaceBytes(),"Max metaspace bytes incorrect.");
     }
 
     @Test
-    public void testMaxMetaspaceBytesUnknown() {
+    void testMaxMetaspaceBytesUnknown() {
         String jvmOptions = "-Xss128k";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(0L),jvm.getMaxMetaspaceBytes(),"Max metaspace bytes incorrect.");
     }
 
     @Test
-    public void testgetCompressedClassSpaceSizeBytes() {
+    void testgetCompressedClassSpaceSizeBytes() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals(bytes(805306368),jvm.getCompressedClassSpaceSizeBytes(),"Compressed class space size bytes incorrect.");
     }
 
     @Test
-    public void testD64() {
+    void testD64() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-d64 not found.", jvm.getD64());
     }
 
     @Test
-    public void testPrintPromotionFailure() {
+    void testPrintPromotionFailure() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -XX:+PrintPromotionFailure -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+PrintPromotionFailure not found.", jvm.getPrintPromotionFailureEnabled());
     }
 
     @Test
-    public void testUseMembar() {
+    void testUseMembar() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -XX:+UseMembar -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+UseMembar not found.", jvm.getUseMembarEnabled());
     }
 
     @Test
-    public void testPrintAdaptiveResizePolicyDisabled() {
+    void testPrintAdaptiveResizePolicyDisabled() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -XX:-PrintAdaptiveSizePolicy -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:-PrintAdaptiveSizePolicy not found.", jvm.getPrintAdaptiveResizePolicyDisabled());
     }
 
     @Test
-    public void testPrintAdaptiveResizePolicyEnabled() {
+    void testPrintAdaptiveResizePolicyEnabled() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -XX:+PrintAdaptiveSizePolicy -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+PrintAdaptiveSizePolicy not found.", jvm.getPrintAdaptiveResizePolicyEnabled());
     }
 
     @Test
-    public void testUnlockExperimentalVmOptionsEnabled() {
+    void testUnlockExperimentalVmOptionsEnabled() {
         String jvmOptions = "-XX:CompressedClassSpaceSize=768m -XX:+UnlockExperimentalVMOptions -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+UnlockExperimentalVMOptions not found.", jvm.getUnlockExperimentalVmOptionsEnabled());
     }
 
     @Test
-    public void testUseFastUnorderedTimeStampsEnabled() {
+    void testUseFastUnorderedTimeStampsEnabled() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:+UseFastUnorderedTimeStamps -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+UseFastUnorderedTimeStamps not found.", jvm.getUseFastUnorderedTimeStampsEnabled());
     }
 
     @Test
-    public void testG1MixedGcLiveThresholdPercent() {
+    void testG1MixedGcLiveThresholdPercent() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:G1MixedGCLiveThresholdPercent=85 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:G1MixedGCLiveThresholdPercent=NN not found.", jvm.getG1MixedGCLiveThresholdPercent());
@@ -836,7 +836,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testG1HeapWastePercent() {
+    void testG1HeapWastePercent() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:G1HeapWastePercent=5 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:G1HeapWastePercent=NN not found.", jvm.getG1HeapWastePercent());
@@ -844,14 +844,14 @@ public class TestJvm {
     }
 
     @Test
-    public void testUseGcLogFileRotationEnabled() {
+    void testUseGcLogFileRotationEnabled() {
         String jvmOptions = "-XX:+UnlockExperimentalVMOptions -XX:+UseGCLogFileRotation -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+UseGCLogFileRotation not found.", jvm.getUseGcLogFileRotationEnabled());
     }
 
     @Test
-    public void testGcLogFileSizeSetBytes() {
+    void testGcLogFileSizeSetBytes() {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192 -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
@@ -860,7 +860,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGcLogFileSizeSetSmallK() {
+    void testGcLogFileSizeSetSmallK() {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192k -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
@@ -869,7 +869,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGcLogFileSizeSetLargeK() {
+    void testGcLogFileSizeSetLargeK() {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=8192K -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
@@ -878,7 +878,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGcLogFileSizeSetSmallM() {
+    void testGcLogFileSizeSetSmallM() {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=5m -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
@@ -887,7 +887,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testGcLogFileSizeSetLargeM() {
+    void testGcLogFileSizeSetLargeM() {
         String jvmOptions = "-XX:+UseGCLogFileRotation -XX:GCLogFileSize=5M -XX:NumberOfGCLogFiles=5";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:GCLogFileSize not found.", jvm.getGcLogFileSize());
@@ -896,35 +896,35 @@ public class TestJvm {
     }
 
     @Test
-    public void testUseG1Gc() {
+    void testUseG1Gc() {
         String jvmOptions = "-Xmx2048m -XX:+UseG1GC -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:+UseG1GC not found.", jvm.getUseG1Gc());
     }
 
     @Test
-    public void testCmsParallelInitialMarkDisabled() {
+    void testCmsParallelInitialMarkDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSParallelInitialMarkEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-CMSParallelInitialMarkEnabled",jvm.getCmsParallelInitialMarkDisabled(),"-XX:-CMSParallelInitialMarkEnabled option incorrect.");
     }
 
     @Test
-    public void testCmsParallelRemarkDisabled() {
+    void testCmsParallelRemarkDisabled() {
         String jvmOptions = "-Xss128k -XX:-CMSParallelRemarkEnabled -XX:+DisableExplicitGC";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:-CMSParallelRemarkEnabled",jvm.getCmsParallelRemarkDisabled(),"-XX:-CMSParallelRemarkEnabled option incorrect.");
     }
 
     @Test
-    public void testG1SummarizeRSetStatsEnabled() {
+    void testG1SummarizeRSetStatsEnabled() {
         String jvmOptions = "-Xss128k -XX:+UnlockExperimentalVMOptions -XX:+G1SummarizeRSetStats -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertEquals("-XX:+G1SummarizeRSetStats",jvm.getG1SummarizeRSetStatsEnabled(),"-XX:+G1SummarizeRSetStats option incorrect.");
     }
 
     @Test
-    public void testG1SummarizeRSetStatsPeriod() {
+    void testG1SummarizeRSetStatsPeriod() {
         String jvmOptions = "-Xss128k -XX:+UnlockExperimentalVMOptions -XX:+G1SummarizeRSetStats "
                 + "-XX:G1SummarizeRSetStatsPeriod=1 -d64";
         Jvm jvm = new Jvm(jvmOptions, null);
@@ -933,7 +933,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testHeapDumpPathDir() {
+    void testHeapDumpPathDir() {
         String jvmOptions = "-Xss128k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:HeapDumpPath=/path/ not found.", jvm.getHeapDumpPathOption());
@@ -941,7 +941,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testHeapDumpPathFilename() {
+    void testHeapDumpPathFilename() {
         String jvmOptions = "-Xss128k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/path/to/heap.dump";
         Jvm jvm = new Jvm(jvmOptions, null);
         assertNotNull("-XX:HeapDumpPath=/path/to/heap.dump not found.", jvm.getHeapDumpPathOption());
@@ -949,7 +949,7 @@ public class TestJvm {
     }
 
     @Test
-    public void testDisabledOptions() {
+    void testDisabledOptions() {
         String jvmOptions = "-Xss128K -XX:-BackgroundCompilation -Xms1024m -Xmx2048m -XX:-UseCompressedClassPointers "
                 + "-XX:-UseCompressedOops -XX:-TraceClassUnloading";
         Jvm jvm = new Jvm(jvmOptions, null);

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedRegEx.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedRegEx.java
@@ -12,9 +12,9 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.util.jdk.unified;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -25,78 +25,78 @@ public class TestUnifiedRegEx {
     @Test
     public void testTimestampUnifiedLogging() {
         String timestamp = "0.002s";
-        assertTrue("'" + timestamp + "' is a valid timestamp.", timestamp.matches(UnifiedRegEx.UPTIME));
+        assertTrue(timestamp.matches(UnifiedRegEx.UPTIME), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
     public void testDurationJdk9() {
         String duration = "2.969ms";
-        assertTrue("'" + duration + "' is a valid duration.", duration.matches(UnifiedRegEx.DURATION));
+        assertTrue(duration.matches(UnifiedRegEx.DURATION), "'" + duration + "' is a valid duration.");
     }
 
     @Test
     public void testDurationJdk9WithSpace() {
         String duration = "15.91 ms";
-        assertTrue("'" + duration + "' is a valid duration.", duration.matches(UnifiedRegEx.DURATION));
+        assertTrue(duration.matches(UnifiedRegEx.DURATION), "'" + duration + "' is a valid duration.");
     }
 
     @Test
     public void testGcEventId() {
         String id = "GC(1326)";
-        assertTrue("'" + id + "' is a valid GC event id.", id.matches(UnifiedRegEx.GC_EVENT_NUMBER));
+        assertTrue(id.matches(UnifiedRegEx.GC_EVENT_NUMBER), "'" + id + "' is a valid GC event id.");
     }
 
     @Test
     public void testGcEventId7Digits() {
         String id = "GC(1234567)";
-        assertTrue("'" + id + "' is a valid GC event id.", id.matches(UnifiedRegEx.GC_EVENT_NUMBER));
+        assertTrue(id.matches(UnifiedRegEx.GC_EVENT_NUMBER), "'" + id + "' is a valid GC event id.");
     }
 
     @Test
     public void testDecoratorUptime() {
         String decorator = "[25.016s]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorUptimeMillis() {
         String decorator = "[25016ms]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorUptimeMillis9Digits() {
         String decorator = "[100159717ms]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorTime() {
         String decorator = "[2020-02-14T15:21:55.207-0500]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorTimeUptime() {
         String decorator = "[2020-02-14T15:21:55.207-0500][25.016s]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorTimeUptimemillis() {
         String decorator = "[2020-02-14T15:21:55.207-0500][25016ms]";
-        assertTrue("Time decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorSafepoint() {
         String decorator = "[0.031s][info][safepoint    ]";
-        assertTrue("Decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Decorator " + decorator + " not recognized.");
     }
 
     @Test
     public void testDecoratorGcCds() {
         String decorator = "[0.004s][info][gc,cds       ]";
-        assertTrue("Decorator " + decorator + " not recognized.", decorator.matches(UnifiedRegEx.DECORATOR));
+        assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Decorator " + decorator + " not recognized.");
     }
 }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedRegEx.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedRegEx.java
@@ -20,82 +20,82 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedRegEx {
+class TestUnifiedRegEx {
 
     @Test
-    public void testTimestampUnifiedLogging() {
+    void testTimestampUnifiedLogging() {
         String timestamp = "0.002s";
         assertTrue(timestamp.matches(UnifiedRegEx.UPTIME), "'" + timestamp + "' is a valid timestamp.");
     }
 
     @Test
-    public void testDurationJdk9() {
+    void testDurationJdk9() {
         String duration = "2.969ms";
         assertTrue(duration.matches(UnifiedRegEx.DURATION), "'" + duration + "' is a valid duration.");
     }
 
     @Test
-    public void testDurationJdk9WithSpace() {
+    void testDurationJdk9WithSpace() {
         String duration = "15.91 ms";
         assertTrue(duration.matches(UnifiedRegEx.DURATION), "'" + duration + "' is a valid duration.");
     }
 
     @Test
-    public void testGcEventId() {
+    void testGcEventId() {
         String id = "GC(1326)";
         assertTrue(id.matches(UnifiedRegEx.GC_EVENT_NUMBER), "'" + id + "' is a valid GC event id.");
     }
 
     @Test
-    public void testGcEventId7Digits() {
+    void testGcEventId7Digits() {
         String id = "GC(1234567)";
         assertTrue(id.matches(UnifiedRegEx.GC_EVENT_NUMBER), "'" + id + "' is a valid GC event id.");
     }
 
     @Test
-    public void testDecoratorUptime() {
+    void testDecoratorUptime() {
         String decorator = "[25.016s]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorUptimeMillis() {
+    void testDecoratorUptimeMillis() {
         String decorator = "[25016ms]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorUptimeMillis9Digits() {
+    void testDecoratorUptimeMillis9Digits() {
         String decorator = "[100159717ms]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorTime() {
+    void testDecoratorTime() {
         String decorator = "[2020-02-14T15:21:55.207-0500]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorTimeUptime() {
+    void testDecoratorTimeUptime() {
         String decorator = "[2020-02-14T15:21:55.207-0500][25.016s]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorTimeUptimemillis() {
+    void testDecoratorTimeUptimemillis() {
         String decorator = "[2020-02-14T15:21:55.207-0500][25016ms]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Time decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorSafepoint() {
+    void testDecoratorSafepoint() {
         String decorator = "[0.031s][info][safepoint    ]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Decorator " + decorator + " not recognized.");
     }
 
     @Test
-    public void testDecoratorGcCds() {
+    void testDecoratorGcCds() {
         String decorator = "[0.004s][info][gc,cds       ]";
         assertTrue(decorator.matches(UnifiedRegEx.DECORATOR), "Decorator " + decorator + " not recognized.");
     }

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedUtil.java
@@ -26,80 +26,80 @@ import org.junit.jupiter.api.Test;
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
  * 
  */
-public class TestUnifiedUtil {
+class TestUnifiedUtil {
 
     @Test
-    public void testUsingSerialIsUnifiedLogging() {
+    void testUsingSerialIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SERIAL);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SERIAL.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUsingParallelIsUnifiedLogging() {
+    void testUsingParallelIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_PARALLEL);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_PARALLEL.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUsingCmsIsUnifiedLogging() {
+    void testUsingCmsIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_CMS);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_CMS.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUsingG1IsUnifiedLogging() {
+    void testUsingG1IsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_G1);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_G1.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedYoungIsUnifiedLogging() {
+    void testUnifiedYoungIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_YOUNG);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedOldIsUnifiedLogging() {
+    void testUnifiedOldIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_OLD);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedCmsInitialMarkIsUnifiedLogging() {
+    void testUnifiedCmsInitialMarkIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CMS_INITIAL_MARK);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedCmsConcurrentIsUnifiedLogging() {
+    void testUnifiedCmsConcurrentIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedG1ConcurrentIsUnifiedLogging() {
+    void testUnifiedG1ConcurrentIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnifiedRemarkIsUnifiedLogging() {
+    void testUnifiedRemarkIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_REMARK);
         assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " should be identified as unified.");
     }
 
     @Test
-    public void testUnknownIsNotUnifiedLogging() {
+    void testUnknownIsNotUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNKNOWN);
         assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNKNOWN.toString() + " should not be identified as unified.");

--- a/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/jdk/unified/TestUnifiedUtil.java
@@ -12,15 +12,15 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.util.jdk.unified;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author <a href="mailto:mmillson@redhat.com">Mike Millson</a>
@@ -32,87 +32,76 @@ public class TestUnifiedUtil {
     public void testUsingSerialIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_SERIAL);
-        assertTrue(JdkUtil.LogEventType.USING_SERIAL.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_SERIAL.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUsingParallelIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_PARALLEL);
-        assertTrue(JdkUtil.LogEventType.USING_PARALLEL.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_PARALLEL.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUsingCmsIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_CMS);
-        assertTrue(JdkUtil.LogEventType.USING_CMS.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_CMS.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUsingG1IsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.USING_G1);
-        assertTrue(JdkUtil.LogEventType.USING_G1.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.USING_G1.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedYoungIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_YOUNG);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_YOUNG.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedOldIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_OLD);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_OLD.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_OLD.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedCmsInitialMarkIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CMS_INITIAL_MARK);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CMS_INITIAL_MARK.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedCmsConcurrentIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedG1ConcurrentIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_CONCURRENT);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_CONCURRENT.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnifiedRemarkIsUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNIFIED_REMARK);
-        assertTrue(JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " should be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertTrue(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNIFIED_REMARK.toString() + " should be identified as unified.");
     }
 
     @Test
     public void testUnknownIsNotUnifiedLogging() {
         List<LogEventType> eventTypes = new ArrayList<LogEventType>();
         eventTypes.add(LogEventType.UNKNOWN);
-        assertFalse(JdkUtil.LogEventType.UNKNOWN.toString() + " should not be identified as unified.",
-                UnifiedUtil.isUnifiedLogging(eventTypes));
+        assertFalse(UnifiedUtil.isUnifiedLogging(eventTypes), JdkUtil.LogEventType.UNKNOWN.toString() + " should not be identified as unified.");
     }
 }


### PR DESCRIPTION
- reference Assertions instead of Assert
- reference jupiter Test annotation
- removed public modifier from test classes
- removed public modifier from test methods

(additionally migrated remaining Iterator usages to enhanced for loops)