### PR TITLE
fix failing test which still was timezone dependant

### DIFF
--- a/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
+++ b/src/test/java/org/eclipselabs/garbagecat/util/TestGcUtil.java
@@ -147,7 +147,7 @@ class TestGcUtil {
     @Test
     void testConvertDateStampStringToDate() {
         Date date = GcUtil.parseDateStamp("2010-02-26T09:32:12.486-0600");
-        assertEquals(parseDate("2010-02-26", "10:32:12.486"), date);
+        assertEquals(1267198332486L, date.getTime());
     }
 
     @Test


### PR DESCRIPTION
fix for last remaining failing test, see issue #147 