### PR TITLE
Purge of hsqldb

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,77 @@
+Eclipse Public License -v 1.0
+=============================
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+### 1. Definitions
+
+“Contribution” means:
+* **a)** in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+* **b)** in the case of each subsequent Contributor:
+	* **i)** changes to the Program, and
+	* **ii)** additions to the Program; 
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: **(i)** are separate modules of software distributed in conjunction with the Program under their own license agreement, and **(ii)** are not derivative works of the Program.
+
+“Contributor” means any person or entity that distributes the Program.
+
+“Licensed Patents ” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+“Program” means the Contributions distributed in accordance with this Agreement.
+
+“Recipient” means anyone who receives the Program under this Agreement, including all Contributors.
+
+### 2. Grant of Rights
+
+**a)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+
+**b)** Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+
+**c)** Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+
+**d)** Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+
+### 3. Requirements
+
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+* **a)** it complies with the terms and conditions of this Agreement; and
+* **b)** its license agreement:
+	* **i)** effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+	* **ii)** effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+	* **iii)** states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+	* **iv)** states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange. 
+
+When the Program is made available in source code form:
+* **a)** it must be made available under this Agreement; and
+* **b)** a copy of this Agreement must be included with each copy of the Program. 
+
+Contributors may not remove or alter any copyright notices contained within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+### 4. Commercial Distribution
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: **a)** promptly notify the Commercial Contributor in writing of such claim, and **b)** allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+### 5. No Warranty
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+### 6. Disclaimer of Liability
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### 7. General
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.
+
+

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A command line tool that parses Java garbage collection logging and does analysi
 ## Supports ##
 
 OpenJDK derivatives:
-* Red Hat build of OpenJDK
-* Oracle JDK
 * AdoptOpenJDK
 * Azul
+* Oracle JDK
+* Red Hat build of OpenJDK
 * etc.
 
 ### Recommended GC Logging Options ###

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ A command line tool that parses Java garbage collection logging and does analysi
 
 ## Supports ##
 
-  * OpenJDK
-  * Sun/Oracle JDK 1.5 and higher
+OpenJDK derivatives:
+* Red Hat build of OpenJDK
+* Oracle JDK
+* AdoptOpenJDK
+* Azul
+* etc.
 
 ### Recommended GC Logging Options ###
 
@@ -97,26 +101,26 @@ Download the latest Maven: [http://maven.apache.org/download.html](http://maven.
 Copy the download to where you want to install it and unzip it. For example:
 
 ```
-cp ~/Downloads/apache-maven-3.6.3-bin.tar.gz ~/opt/
-cd ~/opt/
-tar -xvzf apache-maven-3.6.3-bin.tar.gz
-rm apache-maven-3.6.3-bin.tar.gz
+$ cp ~/Downloads/apache-maven-3.6.3-bin.tar.gz ~/opt/
+$ cd ~/opt/
+$ tar -xvzf apache-maven-3.6.3-bin.tar.gz
+$ rm apache-maven-3.6.3-bin.tar.gz
 ```
 
 Get source:
 
 ```
-git clone https://github.com/mgm3746/garbagecat.git
+$ git clone https://github.com/mgm3746/garbagecat.git
 ```
 
 Build it:
 
 ```
-cd garbagecat
-/opt/apache-maven-3.6.3/bin/mvn clean (rebuilding)
-/opt/apache-maven-3.6.3/bin/mvn assembly:assembly
-export JAVA_HOME=/usr/lib/jvm/java/ (or wherever a JDK is installed)
-/opt/apache-maven-3.6.3/bin/mvn javadoc:javadoc
+$ cd garbagecat
+$ /opt/apache-maven-3.6.3/bin/mvn clean (rebuilding)
+$ /opt/apache-maven-3.6.3/bin/mvn assembly:assembly
+$ export JAVA_HOME=/usr/lib/jvm/java/ (or wherever a JDK is installed)
+$ /opt/apache-maven-3.6.3/bin/mvn javadoc:javadoc
 ```
 
 If you get the following error:
@@ -127,13 +131,13 @@ If you get the following error:
 Run the following command:
 
 ```
-/opt/apache-maven-3.6.3/bin/mvn -U -fn clean install
+$ /opt/apache-maven-3.6.3/bin/mvn -U -fn clean install
 ```
 
 ## Usage ##
 
 ```
-java -jar garbagecat-3.0.1-SNAPSHOT.jar --help
+$ java -jar garbagecat-3.0.1-SNAPSHOT.jar --help
 usage: garbagecat [OPTION]... [FILE]
  -h,--help                  help
  -j,--jvmoptions <arg>      JVM options used during JVM run
@@ -160,70 +164,77 @@ Notes:
   1. If threshold is not defined, it defaults to 90.
   1. Throughput = (Time spent not doing gc) / (Total Time). Throughput of 100 means no time spent doing gc (good). Throughput of 0 means all time spent doing gc (bad).
 
-## Report ##
+## Example ##
+
+https://github.com/mgm3746/garbagecat/tree/master/src/test/gc-example.log
 
 ```
+$ java -jar garbagecat.jar -v -l /path/to/garbagecat/src/test/gc-example.log
+```
+
+### Report ###
+
+```
+gc-example.log
 ========================================
-Running garbagecat version: 3.0.2-SNAPSHOT
-Latest garbagecat version/tag: v3.0.1
+Running garbagecat version: 3.0.6-SNAPSHOT
+Latest garbagecat version/tag: v3.0.5
 ========================================
-Throughput less than 90%
+Throughput less than 20%
 ----------------------------------------
-...
-2017-01-12T05:17:38.064-0500: 2163.994: [GC remark, 0.0614813 secs] [Times: user=1.48 sys=0.01, real=0.06 secs]
-2017-01-12T05:17:38.126-0500: 2164.057: [GC cleanup 24G->23G(42G), 0.0188102 secs] [Times: user=0.49 sys=0.00, real=0.02 secs]
-...
-2017-01-12T05:21:43.121-0500: 2409.051: [GC remark, 0.0317641 secs] [Times: user=0.81 sys=0.00, real=0.03 secs]
-2017-01-12T05:21:43.153-0500: 2409.084: [GC cleanup 21G->21G(42G), 0.0174042 secs] [Times: user=0.45 sys=0.00, real=0.02 secs]
+2016-10-10T18:47:59.652-0700: 251.989: [GC (Allocation Failure) 2016-10-10T18:47:59.652-0700: 251.989: [ParNew: 145807K->13146K(153344K), 0.0868632 secs] 1534115K->1401453K(8371584K), 0.0872680 secs] [Times: user=0.18 sys=0.00, real=0.09 secs]
+2016-10-10T18:47:59.741-0700: 252.078: [GC (GCLocker Initiated GC) 2016-10-10T18:47:59.741-0700: 252.078: [ParNew: 13469K->2777K(153344K), 0.0824395 secs] 1401777K->1403693K(8371584K), 0.0827643 secs] [Times: user=0.16 sys=0.00, real=0.09 secs]
 ...
 ========================================
 JVM:
 ----------------------------------------
-Version: Java HotSpot(TM) 64-Bit Server VM (25.45-b02) for linux-amd64 JRE (1.8.0_45-b14), built on Apr 10 2015 10:07:45 by "java_re" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)
-Options: -XX:CompressedClassSpaceSize=1073741824 -XX:+DoEscapeAnalysis -XX:GCLogFileSize=2097152 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/fi/logs/rpdswafir1/rpdswafir1-ahs1-tcs1 -XX:InitialHeapSize=45097156608 -XX:MaxGCPauseMillis=500 -XX:MaxHeapSize=45097156608 -XX:MaxMetaspaceSize=5368709120 -XX:MetaspaceSize=5368709120 -XX:NumberOfGCLogFiles=5 -XX:+PrintGC -XX:+PrintGCApplicationStoppedTime -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:ThreadStackSize=256 -XX:-UseCompressedOops -XX:+UseG1GC -XX:-UseGCLogFileRotation -XX:+UseLargePages
-Memory: Memory: 4k page, physical 528792532k(351929072k free), swap 30736380k(30736380k free)
+Version: Java HotSpot(TM) 64-Bit Server VM (25.102-b14) for linux-amd64 JRE (1.8.0_102-b14), built on Jun 22 2016 18:43:17 by "java_re" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)
+Options: -XX:CMSInitiatingOccupancyFraction=80 -XX:+CMSParallelRemarkEnabled -XX:+DisableExplicitGC -XX:+DoEscapeAnalysis -XX:ErrorFile=/home/jbcures/errors/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/jboss/app-files/crash/cures/ -XX:InitialHeapSize=8589934592 -XX:MaxHeapSize=8589934592 -XX:MaxNewSize=174485504 -XX:MaxTenuringThreshold=6 -XX:NewSize=174485504 -XX:OldPLABSize=16 -XX:OldSize=348971008 -XX:ParallelGCThreads=2 -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseCMSInitiatingOccupancyOnly -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseConcMarkSweepGC -XX:+UseParNewGC
+Memory: Memory: 4k page, physical 32878232k(18756444k free), swap 4194300k(4194300k free)
 ========================================
 SUMMARY:
 ----------------------------------------
-# GC Events: 99
-Event Types: G1_YOUNG_PAUSE, G1_YOUNG_INITIAL_MARK, G1_CONCURRENT, G1_REMARK, G1_CLEANUP, G1_MIXED_PAUSE
-# Parallel Events: 75
-# Parallel Events with Low Parallelism: 0
-Max Heap Occupancy: 38063309K
-Max Heap Space: 44040192K
-GC Throughput: 100%
-GC Max Pause: 0.682 secs
-GC Total Pause: 17.702 secs
-Stopped Time Throughput: 100%
-Stopped Time Max Pause: 0.683 secs
-Stopped Time Total: 18.756 secs
-GC/Stopped Ratio: 94%
-First Datestamp: 2017-01-12T04:41:34.411-0500
-First Timestamp: 0.341 secs
-Last Datestamp: 2017-01-12T06:50:33.313-0500
-Last Timestamp: 7739.244 secs
+# GC Events: 36546
+Event Types: PAR_NEW, CMS_INITIAL_MARK, CMS_CONCURRENT, CMS_REMARK, CMS_SERIAL_OLD
+# Parallel Events: 36545
+# Inverted Parallelism: 2
+Max Inverted Parallelism: 2016-10-11T08:06:39.037-0700: 48171.374: [GC (CMS Initial Mark) [1 CMS-initial-mark: 6578959K(8218240K)] 6599305K(8371584K), 0.0118105 secs] [Times: user=0.01 sys=0.00, real=0.02 secs]
+NewRatio: 54
+Max Heap Occupancy: 7092037K
+Max Heap After GC: 6988066K
+Max Heap Space: 8371584K
+Max Metaspace Occupancy: 167164K
+Max Metaspace After GC: 167164K
+Max Metaspace Space: 1204224K
+GC Throughput: 96%
+GC Max Pause: 7.527 secs
+GC Total Pause: 2623.499 secs
+First Datestamp: 2016-10-10T18:43:49.025-0700
+First Timestamp: 1.362 secs
+Last Datestamp: 2016-10-11T12:34:47.720-0700
+Last Timestamp: 64260.057 secs
 ========================================
 ANALYSIS:
 ----------------------------------------
 error
 ----------------------------------------
-*Compressed class pointers space size is set (-XX:CompressedClassSpaceSize), and heap >= 32G. Remove -XX:CompressedClassSpaceSize, as compressed object references should not be used on heaps >= 32G.
-*Humongous objects are being allocated on an old version of the JDK that is not able to fully reclaim humongous objects during young collections. Upgrade to JDK8 update 60 or later.
+*The CMS_SERIAL_OLD collector is being invoked for one of the following reasons: (1) Fragmentation. The concurrent low pause collector does not compact. When fragmentation becomes an issue a serial collection compacts the heap. If the old generation has available space, the cause is likely fragmentation. Fragmentation can be avoided by increasing the heap size. (2) Metaspace class metadata or compressed class pointers allocation failure. The GC attempts to free/resize metaspace. (3) Resizing perm gen. If perm gen occupancy is near perm gen allocation, the cause is likely perm gen. Perm gen resizing can be avoided by setting the minimum perm gen size equal to the the maximum perm gen size. For example: -XX:PermSize=256M -XX:MaxPermSize=256M. (4) Undetermined reasons. Possibly the JVM requires a certain amount of heap or combination of resources that is not being met, and consequently the concurrent low pause collector is not used despite being specified with the -XX:+UseConcMarkSweepGC option. The CMS_SERIAL_OLD collector is a serial (single-threaded) collector, which means it will take a very long time to collect a large heap. For optimal performance, tune to avoid serial collections.
+...
 ----------------------------------------
 warn
 ----------------------------------------
-*Many environments (e.g. JBoss versions prior to EAP6) cause the RMI subsystem to be loaded. RMI manages Distributed Garbage Collection (DGC) by calling System.gc() to clean up unreachable remote objects, resulting in unnecessary major (full) garbage collection that can seriously impact performance. The default interval changed from 1 minute to 1 hour in JDK6 update 45. DGC is required to prevent memory leaks when making remote method calls or exporting remote objects like EJBs; however, test explicitly setting the DGC client and server intervals to longer intervals to minimize the impact of explicit garbage collection. For example, 4 hours (values in milliseconds): -Dsun.rmi.dgc.client.gcInterval=14400000 -Dsun.rmi.dgc.server.gcInterval=14400000. Or if not making remote method calls and not exporting remote objects like EJBs (everything runs in the same JVM), disable explicit garbage collection altogether with -XX:+DisableExplicitGC.
-*Consider adding -XX:+ExplicitGCInvokesConcurrent so explicit garbage collection is handled concurrently by the CMS and G1 collectors. Or if not making remote method calls and not exporting remote objects like EJBs (everything runs in the same JVM), disable explicit garbage collection altogether with -XX:+DisableExplicitGC.
-*Number of GC log files is defined (-XX:NumberOfGCLogFiles), yet GC log file rotation is disabled. Either remove -XX:NumberOfGCLogFiles or enable GC log file rotation with -XX:+UseGCLogFileRotation.
+*CMS remark low parallelism: (1) If using JDK7 or earlier, add -XX:+CMSParallelRemarkEnabled, as remark is single-threaded by default in JDK7 and earlier. (2) Check if multi-threaded remark is disabled with -XX:-CMSParallelRemarkEnabled, and replace with -XX:+CMSParallelRemarkEnabled. (4) Add -XX:+ParallelRefProcEnabled to enable multi-threaded reference processing if the "weak refs processing" time is a significant amount of the total CMS remark time. (5) Check for swapping and if the number of GC threads (-XX:ParallelGCThreads=<n>) is appropriate for the number of cpu/cores and any processes sharing cpu.
+...
 ----------------------------------------
 info
 ----------------------------------------
-*Last log line not identified. This is typically caused by the gc log being copied while the JVM is in the middle of logging an event, resulting in truncated logging. If it is not due to truncated logging, report the unidentified logging line: https://github.com/mgm3746/garbagecat/issues.
-*GC log file rotation is disabled (-XX:-UseGCLogFileRotation). Consider enabling rotation to protect disk space.
+*GC log file rotation is not enabled. Consider enabling rotation (-XX:+UseGCLogFileRotation -XX:GCLogFileSize=N[K|M|G] -XX:NumberOfGCLogFiles=N) to protect disk spac
+...
 ========================================
-1 UNIDENTIFIED LOG LINE(S):
+80 UNIDENTIFIED LOG LINE(S):
 ----------------------------------------
-2017-01-12T06:50:34.314-0500: 7740.244
+2016-10-10T19:17:37.771-0700: 2030.108: [GC (Allocation Failure) 2016-10-10T19:17:37.771-0700: 2030.108: [ParNew2016-10-10T19:17:37.773-0700: 2030.110: [CMS-concurrent-abortable-preclean: 0.050/0.150 secs] [Times: user=0.11 sys=0.03, real=0.15 secs]
+...
 ========================================
 ```
 
@@ -238,15 +249,10 @@ Notes:
   1. There is a limit of 1000 unidentified log lines that will be reported. If there are any unidentified logging lines, try running again with the -p preprocess option enabled. Note that it is fairly common for the last line to be truncated, and this is not an issue.
   1. Please report unidentified log lines by opening an issue and zipping up and attaching the garbage collection logging: https://github.com/mgm3746/garbagecat/issues.
 
-## Example ##
-
-https://github.com/mgm3746/garbagecat/tree/master/src/test/data/gc.log
-
-```
-java -jar garbagecat.jar /path/to/gc.log
-```
+### Analysis ###
 
 The bottom of the report shows 80 unidentified lines:
+
 ```
 ========================================
 80 UNIDENTIFIED LOG LINE(S):
@@ -259,13 +265,13 @@ The bottom of the report shows 80 unidentified lines:
 Run with the preprocess flag:
 
 ```
-java -jar garbagecat.jar -p /path/to/gc.log
+$ java -jar garbagecat.jar -v -l -p ~/path/to/garbagecat/src/test/gc-example.log
 ```
 
 There are no unidentified log lines after preprocessing. However, there are many bottlenecks where throughput is < 90% (default). To get a better idea of bottlenecks, run with -t 50 to see stretches where more time is spent running gc/jvm threads than application threads.
 
 ```
-java -jar garbagecat.jar -t 50 -p /path/to/gc.log
+$ java -jar garbagecat.jar -v -l -p -t 50 ~/path/to/garbagecat/src/test/gc-example.log
 ```
 
 There are still a lot of bottlenecks reported; however, none are for a very long stretch. For example, the following lines show 3 gc events where more time was spent doing gc than running application threads, but it covers less than 1 second: 62339.274 --> 62339.684:
@@ -290,16 +296,18 @@ SUMMARY:
 # GC Events: 36586
 Event Types: PAR_NEW, CMS_INITIAL_MARK, CMS_CONCURRENT, CMS_REMARK, CMS_SERIAL_OLD
 # Parallel Events: 36585
-# Parallel Events with Low Parallelism: 78
-Parallel Event with Lowest Parallelism: 2016-10-10T19:17:36.730-0700: 2029.067: [GC (CMS Initial Mark) [1 CMS-initial-mark: 6579305K(8218240K)] 6609627K(8371584K), 0.0088184 secs] [Times: user=0.01 sys=0.00, real=0.01 secs]
+# Inverted Parallelism: 2
+Max Inverted Parallelism: 2016-10-11T08:06:39.037-0700: 48171.374: [GC (CMS Initial Mark) [1 CMS-initial-mark: 6578959K(8218240K)] 6599305K(8371584K), 0.0118105 secs] [Times: user=0.01 sys=0.00, real=0.02 secs]
 NewRatio: 54
 Max Heap Occupancy: 7092037K
+Max Heap After GC: 6988066K
 Max Heap Space: 8371584K
-Max Perm/Metaspace Occupancy: 167164K
-Max Perm/Metaspace Space: 1204224K
+Max Metaspace Occupancy: 167164K
+Max Metaspace After GC: 167164K
+Max Metaspace Space: 1204224K
 GC Throughput: 96%
 GC Max Pause: 7.527 secs
-GC Total Pause: 2608.102 secs
+GC Total Pause: 2626.402 secs
 First Datestamp: 2016-10-10T18:43:49.025-0700
 First Timestamp: 1.362 secs
 Last Datestamp: 2016-10-11T12:34:47.720-0700
@@ -315,20 +323,23 @@ ANALYSIS:
 ----------------------------------------
 error
 ----------------------------------------
-*The CMS_SERIAL_OLD collector is being invoked for one of the following reasons: (1) Fragmentation. The concurrent low pause collector does not compact. When fragmentation becomes an issue a serial collection compacts the heap. If the old generation has available space, the cause is likely fragmentation. Fragmentation can be avoided by increasing the heap size. (2) Resizing Perm/Metaspace. If Perm/Metaspace occupancy is near Perm/Metaspace allocation, the cause is likely Perm/Metaspace. Perm/Metaspace resizing can be avoided by setting the minimum Perm/Metaspace size equal to the the maximum Perm/Metaspace size. For example: -XX:PermSize=256M -XX:MaxPermSize=256M (Perm) or -XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=512M (Metaspace). (3) Undetermined reasons. Possibly the JVM requires a certain amount of heap or combination of resources that is not being met, and consequently the concurrent low pause collector is not used despite being specified with the -XX:+UseConcMarkSweepGC option. The CMS_SERIAL_OLD collector is a serial (single-threaded) collector, which means it will take a very long time to collect a large heap. For optimal performance, tune to avoid serial collections.
-*CMS promotion failed. A young generation collection is not able to complete because there is not enough space in the old generation for promotion. The old generation has available space, but it is not contiguous. When fragmentation is an issue, the concurrent low pause collector invokes a slow (single-threaded) serial collector to compact the heap. Tune to avoid fragmentation: (1) Increase the heap size. (2) Use -XX:CMSInitiatingOccupancyFraction=NN (default 92) to run the CMS cycle more frequently to increase sweeping of dead objects in the old generation to free lists (e.g. -XX:CMSInitiatingOccupancyFraction=85 -XX:+UseCMSInitiatingOccupancyOnly). (3) Do heap dump analysis to determine if there is unintended object retention that can be addressed to decrease heap demands. Or move to a collector that handles fragmentation more efficiently: (1) G1 compacts the young and old generations during evacuation using a multi-threaded collector. (2) Shenandoah compacts concurrently. Temporarily add -XX:PrintFLSStatistics=1 and -XX:+PrintPromotionFailure to get additional insight into fragmentation.
+*The CMS_SERIAL_OLD collector is being invoked for one of the following reasons: (1) Fragmentation. The concurrent low pause collector does not compact. When fragmentation becomes an issue a serial collection compacts the heap. If the old generation has available space, the cause is likely fragmentation. Fragmentation can be avoided by increasing the heap size. (2) Metaspace class metadata or compressed class pointers allocation failure. The GC attempts to free/resize metaspace. (3) Resizing perm gen. If perm gen occupancy is near perm gen allocation, the cause is likely perm gen. Perm gen resizing can be avoided by setting the minimum perm gen size equal to the the maximum perm gen size. For example: -XX:PermSize=256M -XX:MaxPermSize=256M. (4) Undetermined reasons. Possibly the JVM requires a certain amount of heap or combination of resources that is not being met, and consequently the concurrent low pause collector is not used despite being specified with the -XX:+UseConcMarkSweepGC option. The CMS_SERIAL_OLD collector is a serial (single-threaded) collector, which means it will take a very long time to collect a large heap. For optimal performance, tune to avoid serial collections.
+*CMS promotion failed. A young generation collection is not able to complete because there is not enough space in the old generation for promotion. The old generation has available space, but it is not contiguous. When fragmentation is an issue, the concurrent low pause collector invokes a slow (single-threaded) serial collector to compact the heap. Tune to avoid fragmentation: (1) Increase the heap size. (2) Use -XX:CMSInitiatingOccupancyFraction=N (default 92) to run the CMS cycle more frequently to increase sweeping of dead objects in the old generation to free lists (e.g. -XX:CMSInitiatingOccupancyFraction=85 -XX:+UseCMSInitiatingOccupancyOnly). (3) Do heap dump analysis to determine if there is unintended object retention that can be addressed to decrease heap demands. Or move to a collector that handles fragmentation more efficiently: (1) G1 compacts the young and old generations during evacuation using a multi-threaded collector. (2) Shenandoah compacts concurrently. Temporarily add -XX:PrintFLSStatistics=1 and -XX:+PrintPromotionFailure to get additional insight into fragmentation.
 ----------------------------------------
 warn
 ----------------------------------------
-*The Metaspace size should be explicitly set. The Metaspace size is unlimited by default and will auto increase in size up to what the OS will allow, so not setting it can swamp the OS. Explicitly set the Metaspace size. For example: -XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=512M.
-*Explicit garbage collection has been disabled with -XX:+DisableExplicitGC. That is fine if the JVM is not making remote method calls and not exporting remote objects like EJBs (everything runs in the same JVM). If there are remote objects, do not use -XX:+DisableExplicitGC, as it can result in a memory leak. It is also possible the application depends on explicit garbage collection in some other way. If explicit garbage collection is required, remove -XX:+DisableExplicitGC and set sun.rmi.dgc.client.gcInterval and sun.rmi.dgc.server.gcInterval to values longer than the default 1 hour. Also add -XX:+ExplicitGCInvokesConcurrent so explicit garbage collection is handled concurrently if using the CMS or G1 collectors. For example, 4 hours (values in milliseconds): -Dsun.rmi.dgc.client.gcInterval=14400000 -Dsun.rmi.dgc.server.gcInterval=14400000 -XX:+ExplicitGCInvokesConcurrent.
+*CMS remark low parallelism: (1) If using JDK7 or earlier, add -XX:+CMSParallelRemarkEnabled, as remark is single-threaded by default in JDK7 and earlier. (2) Check if multi-threaded remark is disabled with -XX:-CMSParallelRemarkEnabled, and replace with -XX:+CMSParallelRemarkEnabled. (4) Add -XX:+ParallelRefProcEnabled to enable multi-threaded reference processing if the "weak refs processing" time is a significant amount of the total CMS remark time. (5) Check for swapping and if the number of GC threads (-XX:ParallelGCThreads=<n>) is appropriate for the number of cpu/cores and any processes sharing cpu.
+*CMS initial mark low parallelism: (1) If using JDK6 or earlier, initial mark is single-threaded. Consider upgrading to JDK7 or later for multi-threaded initial mark. (2) If using JDK7, add -XX:+CMSParallelInitialMarkEnabled, as initial mark is single-threaded by default in JDK7. (3) Check if multi-threaded remark is disabled with -XX:-CMSParallelInitialMarkEnabled, and replace with -XX:+CMSParallelInitialMarkEnabled. (3) Check for swapping and if the number of GC threads (-XX:ParallelGCThreads=<n>) is appropriate for the number of cpu/cores and any processes sharing cpu.
+*Explicit garbage collection has been disabled with -XX:+DisableExplicitGC. The JVM uses explicit garbage collection to manage direct memory (to free space when MaxDirectMemorySize is reached) and the Remote Method Invocation (RMI) system (to clean up unreachable remote objects). Disabling it for those use cases can cause a memory leak. Verify the application does not use direct memory (e.g. java.nio.DirectByteBuffer), does not make remote method calls or export remote objects like EJBs (everything runs in the same JVM), and does not depend on explicit garbage collection in some other way. Known applications that use direct memory: JBoss EAP7 (IO subsystem). If explicit garbage collection is required, remove -XX:+DisableExplicitGC, and if using the CMS or G1 collector, add -XX:+ExplicitGCInvokesConcurrent so explicit garbage collection is handled concurrently.
 *The CMS collector does not always collect Perm/Metaspace by default (e.g. prior to JDK 1.8). Add -XX:+CMSClassUnloadingEnabled to collect Perm/Metaspace in the CMS concurrent cycle and avoid Perm/Metaspace collections being done by a slow (single threaded) serial collector.
-*-XX:+PrintGCApplicationStoppedTime missing. Required to determine overall throughput and identify throughput and pause issues not related to garbage collection, as many JVM operations besides garbage collection require all threads to reach a safepoint to execute.
+*A heap dump file name has been specified with the -XX:HeapDumpPath (e.g. -XX:HeapDumpPath=/mydir/heapdump.hprof). Generally you only want to specify a directory (e.g. -XX:HeapDumpPath=/mydir/) and let the JVM use the default file name, which includes the process id. If you specify a file name, heap dumps will overwrite each other. Unless disk space is a concern, you typically do not want to overwrite heap dumps and lose data. Reference: https://access.redhat.com/solutions/21109
+*Application stopped time missing. Enable with -XX:+PrintGCApplicationStoppedTime (<= JDK8) or with safepoint logging at info level (e.g. -Xlog:gc*,safepoint=info:file=gc.log:uptime:filecount=4,filesize=50M). Required to determine overall throughput and identify throughput and pause issues not related to garbage collection, as many JVM operations besides garbage collection require all threads to reach a safepoint to execute. Reference: https://access.redhat.com/solutions/18656
+*There is evidence of inverted parallelism. With parallel (multi-threaded) collector events, the "user" + "sys" time should be approximately equal to the "real" (wall) time multiplied by the # of GC threads. For example, if there are 3 GC threads we would expect a parallel collection that takes 1 second of "real" time to take approximately 3 seconds of "user" + "sys" time. The parallelism is 3x. If the parallelism is 1x ("user" + "sys" = "real"), the parallel collection is not offering any efficiency over a serial (single-threaded) collection. When "user" + "sys" < "real", the parallelism is inverted. Inverted parallelism can be a sign of high i/o (e.g. disk or network access) or not enough CPU (e.g. GC threads competing with each other or other processes). Check for swapping and if the number of GC threads (-XX:ParallelGCThreads=<n>) is appropriate for the number of cpu/cores and any processes sharing cpu.
 ----------------------------------------
 info
 ----------------------------------------
-*When UseCompressedOops and UseCompressedClassesPointers (JDK 1.8 u40+) are enabled (default) the Metaspace reported in the GC logging is the sum of two native memory spaces: (1) class metadata. (2) compressed class pointers. It is recommended to explicitly set the compressed class pointers space. For example: -XX:CompressedClassSpaceSize=1G.
-*GC log file rotation is not enabled. Consider enabling rotation (-XX:+UseGCLogFileRotation -XX:GCLogFileSize=N -XX:NumberOfGCLogFiles=N) to protect disk space.
+*GC log file rotation is not enabled. Consider enabling rotation (-XX:+UseGCLogFileRotation -XX:GCLogFileSize=N[K|M|G] -XX:NumberOfGCLogFiles=N) to protect disk space.
+*The number of times an object is copied between survivor spaces is being set with -XX:MaxTenuringThreshold=N (0-15). 0 = disabled. 15 (default) = promote when the survivor space fills. Unless testing has shown this improves performance, consider removing this option to allow the default value to be applied.
 ========================================
 ```
 

--- a/README.md
+++ b/README.md
@@ -347,4 +347,4 @@ info
 
 Copyright (c) 2008-2021 Mike Millson
 
-All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://java_home tokenwww.eclipse.org/legal/epl-v10.html.                                                                                                             
+All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at [http://www.eclipse.org/legal/epl-v10.html](http://www.eclipse.org/legal/epl-v10.html).

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>1.8.0.7</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>garbagecat</groupId>
 	<artifactId>garbagecat</artifactId>
-	<version>3.0.6-SNAPSHOT</version>
+	<version>3.0.6-pre1</version>
 	<name>garbagecat</name>
 	<description>Java garbage collection analyzer tool.</description>
 	<url>https://github.com/mgm3746/garbagecat</url>

--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -52,706 +52,707 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
  */
 public class JvmDao {
 
-	private static class Pst {
-
-		private long timeStamp;
-		private String eventName;
-		private int duration;
-		private Memory youngSpace;
-		private Memory youngOccupancyInit;
-		private Memory youngOccupancyEnd;
-		private Memory oldSpace;
-		private Memory oldOccupancyInit;
-		private Memory oldOccupancyEnd;
-		private Memory combinedSpace;
-		private Memory combinedOccupancyInit;
-		private Memory combinedOccupancyEnd;
-		private Memory permSpace;
-		private Memory permOccupancyInit;
-		private Memory permOccupancyEnd;
-		private String logEntry;
-
-		public long getTimeStamp() {
-			return timeStamp;
-		}
-
-		public String getEventName() {
-			return eventName;
-		}
-
-		public int getDuration() {
-			return duration;
-		}
-
-		public Memory getYoungSpace() {
-			return youngSpace;
-		}
-
-		public Memory getYoungOccupancyInit() {
-			return youngOccupancyInit;
-		}
-
-		public Memory getYoungOccupancyEnd() {
-			return youngOccupancyEnd;
-		}
-
-		public Memory getOldSpace() {
-			return oldSpace;
-		}
-
-		public Memory getOldOccupancyInit() {
-			return oldOccupancyInit;
-		}
-
-		public Memory getOldOccupancyEnd() {
-			return oldOccupancyEnd;
-		}
-
-		public Memory getCombinedSpace() {
-			return combinedSpace;
-		}
-
-		public Memory getCombinedOccupancyInit() {
-			return combinedOccupancyInit;
-		}
-
-		public Memory getCombinedOccupancyEnd() {
-			return combinedOccupancyEnd;
-		}
-
-		public Memory getPermSpace() {
-			return permSpace;
-		}
-
-		public Memory getPermOccupancyInit() {
-			return permOccupancyInit;
-		}
-
-		public Memory getPermOccupancyEnd() {
-			return permOccupancyEnd;
-		}
-
-		public String getLogEntry() {
-			return logEntry;
-		}
-
-	}
-
-	/**
-	 * List of all event types associate with JVM run.
-	 */
-	List<LogEventType> eventTypes = new ArrayList<>();
-
-	/**
-	 * Analysis property keys.
-	 */
-	private List<Analysis> analysis = new ArrayList<>();
-
-	/**
-	 * Collector families for JVM run.
-	 */
-	List<CollectorFamily> collectorFamilies = new ArrayList<>();
-
-	/**
-	 * Logging lines that do not match any known GC events.
-	 */
-	private List<String> unidentifiedLogLines = new ArrayList<>();
-
-	/**
-	 * Batch blocking database inserts for improved performance.
-	 */
-	private List<Pst> blockingEvents = new ArrayList<>();
-
-	/**
-	 * Batch stopped time database inserts for improved performance.
-	 */
-	private List<ApplicationStoppedTimeEvent> stoppedTimeEvents = new ArrayList<>();
-
-	/**
-	 * The JVM options for the JVM run.
-	 */
-	private String options;
-
-	/**
-	 * JVM version.
-	 */
-	private String version;
-
-	/**
-	 * JVM memory information.
-	 */
-	private String memory;
-
-	/**
-	 * Physical memory (bytes).
-	 */
-	private long physicalMemory;
-
-	/**
-	 * Physical memory free (bytes).
-	 */
-	private long physicalMemoryFree;
-
-	/**
-	 * Swap size (bytes).
-	 */
-	// prevent false positives of Analysis.INFO_SWAP_DISABLED
-	private long swap = -1;
-
-	/**
-	 * Swap free (bytes).
-	 */
-	private long swapFree;
-
-	/**
-	 * Number of <code>ParallelCollection</code> events.
-	 */
-	private long parallelCount;
-
-	/**
-	 * Number of <code>ParallelCollection</code> with "inverted" parallelism.
-	 */
-	private long invertedParallelismCount;
-
-	/**
-	 * <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
-	 */
-	private LogEvent worstInvertedParallelismEvent;
-
-	/**
-	 * Used for tracking max heap space outside of <code>BlockingEvent</code>s.
-	 */
-	private int maxHeapSpaceNonBlocking;
-
-	/**
-	 * Used for tracking max heap occupancy outside of <code>BlockingEvent</code>s.
-	 */
-	private int maxHeapOccupancyNonBlocking;
-
-	/**
-	 * Used for tracking max perm space outside of <code>BlockingEvent</code>s.
-	 */
-	private int maxPermSpaceNonBlocking;
-
-	/**
-	 * Used for tracking max perm occupancy outside of <code>BlockingEvent</code>s.
-	 */
-	private int maxPermOccupancyNonBlocking;
-
-	private static boolean created;
-
-	public JvmDao() {
-		if (created) {
-			cleanup();
-		} else {
-			created = true;
-		}
-	}
-
-	public List<String> getUnidentifiedLogLines() {
-		return unidentifiedLogLines;
-	}
-
-	public List<LogEventType> getEventTypes() {
-		return eventTypes;
-	}
-
-	public List<Analysis> getAnalysis() {
-		return analysis;
-	}
-
-	public void addAnalysis(Analysis analysis) {
-		if (!this.analysis.contains(analysis)) {
-			this.analysis.add(analysis);
-		}
-	}
-
-	public List<CollectorFamily> getCollectorFamilies() {
-		return collectorFamilies;
-	}
-
-	public void addBlockingEvent(BlockingEvent event) {
-		blockingEvents.add(intern(event));
-	}
-
-	public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {
-		stoppedTimeEvents.add(event);
-	}
-
-	/**
-	 * @return The JVM options.
-	 */
-	public String getOptions() {
-		return options;
-	}
-
-	/**
-	 * @param options The JVM options to set.
-	 */
-	public void setOptions(String options) {
-		this.options = options;
-	}
-
-	/**
-	 * @return The JVM version information.
-	 */
-	public String getVersion() {
-		return version;
-	}
-
-	/**
-	 * @param version The JVM version information to set.
-	 */
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	/**
-	 * @return The JVM memory information.
-	 */
-	public String getMemory() {
-		return memory;
-	}
-
-	/**
-	 * @param memory The JVM memory information to set.
-	 */
-	public void setMemory(String memory) {
-		this.memory = memory;
-	}
-
-	/**
-	 * @return The JVM environment physical memory (bytes).
-	 */
-	public long getPhysicalMemory() {
-		return physicalMemory;
-	}
-
-	/**
-	 * @param physicalMemory The JVM physical memory to set.
-	 */
-	public void setPhysicalMemory(long physicalMemory) {
-		this.physicalMemory = physicalMemory;
-	}
-
-	/**
-	 * @return The JVM environment physical free memory (bytes).
-	 */
-	public long getPhysicalMemoryFree() {
-		return physicalMemoryFree;
-	}
-
-	/**
-	 * @param physicalMemoryFree The JVM physical free memory to set.
-	 */
-	public void setPhysicalMemoryFree(long physicalMemoryFree) {
-		this.physicalMemoryFree = physicalMemoryFree;
-	}
-
-	/**
-	 * @return The JVM environment swap size (bytes).
-	 */
-	public long getSwap() {
-		return swap;
-	}
-
-	/**
-	 * @param swap The JVM swap to set.
-	 */
-	public void setSwap(long swap) {
-		this.swap = swap;
-	}
-
-	/**
-	 * @return The JVM environment swap free (bytes).
-	 */
-	public long getSwapFree() {
-		return swapFree;
-	}
-
-	/**
-	 * @param swapFree The JVM swap free to set.
-	 */
-	public void setSwapFree(long swapFree) {
-		this.swapFree = swapFree;
-	}
-
-	/**
-	 * @return The number of <code>ParallelCollection</code> events.
-	 */
-	public long getParallelCount() {
-		return parallelCount;
-	}
-
-	/**
-	 * @param parallelCount The number of <code>ParallelCollection</code> events.
-	 */
-	public void setParallelCount(long parallelCount) {
-		this.parallelCount = parallelCount;
-	}
-
-	/**
-	 * @return The number of "inverted" parallelism events.
-	 */
-	public long getInvertedParallelismCount() {
-		return invertedParallelismCount;
-	}
-
-	/**
-	 * @param invertedParallelismCount The number of "low" parallelism events.
-	 */
-	public void setInvertedParallelismCount(long invertedParallelismCount) {
-		this.invertedParallelismCount = invertedParallelismCount;
-	}
-
-	/**
-	 * @return The <code>ParallelCollection</code> event with the lowest "inverted"
-	 *         parallelism.
-	 */
-	public LogEvent getWorstInvertedParallelismEvent() {
-		return worstInvertedParallelismEvent;
-	}
-
-	/**
-	 * @param worstInvertedParallelismEvent The <code>ParallelCollection</code>
-	 *                                      event with the lowest "inverted"
-	 *                                      parallelism.
-	 */
-	public void setWorstInvertedParallelismEvent(LogEvent worstInvertedParallelismEvent) {
-		this.worstInvertedParallelismEvent = worstInvertedParallelismEvent;
-	}
-
-	/**
-	 * @return The maximum heap space in non <code>BlockingEvent</code>s.
-	 */
-	public int getMaxHeapSpaceNonBlocking() {
-		return maxHeapSpaceNonBlocking;
-	}
-
-	/**
-	 * @param maxHeapSpaceNonBlocking The maximum heap space in non
-	 *                                <code>BlockingEvent</code>s.
-	 */
-	public void setMaxHeapSpaceNonBlocking(int maxHeapSpaceNonBlocking) {
-		this.maxHeapSpaceNonBlocking = maxHeapSpaceNonBlocking;
-	}
-
-	/**
-	 * @return The maximum heap occupancy in non <code>BlockingEvent</code>s.
-	 */
-	public int getMaxHeapOccupancyNonBlocking() {
-		return maxHeapOccupancyNonBlocking;
-	}
-
-	/**
-	 * @param maxHeapOccupancyNonBlocking The maximum heap occupancy in non
-	 *                                    <code>BlockingEvent</code>s.
-	 */
-	public void setMaxHeapOccupancyNonBlocking(int maxHeapOccupancyNonBlocking) {
-		this.maxHeapOccupancyNonBlocking = maxHeapOccupancyNonBlocking;
-	}
-
-	/**
-	 * @return The maximum perm space in non <code>BlockingEvent</code>s.
-	 */
-	public int getMaxPermSpaceNonBlocking() {
-		return maxPermSpaceNonBlocking;
-	}
-
-	/**
-	 * @param maxPermSpaceNonBlocking The maximum perm space in non
-	 *                                <code>BlockingEvent</code>s.
-	 */
-	public void setMaxPermSpaceNonBlocking(int maxPermSpaceNonBlocking) {
-		this.maxPermSpaceNonBlocking = maxPermSpaceNonBlocking;
-	}
-
-	/**
-	 * @return The maximum perm occupancy in non <code>BlockingEvent</code>s.
-	 */
-	public int getMaxPermOccupancyNonBlocking() {
-		return maxPermOccupancyNonBlocking;
-	}
-
-	/**
-	 * @param maxPermOccupancyNonBlocking The maximum perm occupancy in non
-	 *                                    <code>BlockingEvent</code>s.
-	 */
-	public void setMaxPermOccupancyNonBlocking(int maxPermOccupancyNonBlocking) {
-		this.maxPermOccupancyNonBlocking = maxPermOccupancyNonBlocking;
-	}
-
-	private static Pst intern(BlockingEvent event) {
-		Pst pst = new Pst();
-		pst.timeStamp = event.getTimestamp();
-		pst.eventName = event.getName();
-		pst.duration = event.getDuration();
-		pst.logEntry = event.getLogEntry();
-		if (event instanceof YoungData) {
-			YoungData youngData = (YoungData) event;
-			pst.youngSpace = youngData.getYoungSpace();
-			pst.youngOccupancyInit = youngData.getYoungOccupancyInit();
-			pst.youngOccupancyEnd = youngData.getYoungOccupancyEnd();
-		}
-		if (event instanceof OldData) {
-			OldData oldData = (OldData) event;
-			pst.oldSpace = oldData.getOldSpace();
-			pst.oldOccupancyInit = oldData.getOldOccupancyInit();
-			pst.oldOccupancyEnd = oldData.getOldOccupancyEnd();
-		}
-		if (event instanceof CombinedData) {
-			CombinedData combinedData = (CombinedData) event;
-			pst.combinedSpace = combinedData.getCombinedSpace();
-			pst.combinedOccupancyInit = combinedData.getCombinedOccupancyInit();
-			pst.combinedOccupancyEnd = combinedData.getCombinedOccupancyEnd();
-		}
-		if (event instanceof PermMetaspaceData) {
-			PermMetaspaceData permMetaspaceData = (PermMetaspaceData) event;
-			pst.permSpace = permMetaspaceData.getPermSpace();
-			pst.permOccupancyInit = permMetaspaceData.getPermOccupancyInit();
-			pst.permOccupancyEnd = permMetaspaceData.getPermOccupancyEnd();
-		}
-		return pst;
-	}
-
-	/**
-	 * The maximum GC blocking event pause time.
-	 * 
-	 * @return maximum pause duration (milliseconds).
-	 */
-	public synchronized int getMaxGcPause() {
-		return convertMicrosToMillis(
-				ints(this.blockingEvents, Pst::getDuration).mapToInt(Integer::valueOf).max().orElse(0)).intValue();
-	}
-
-	/**
-	 * The total blocking event pause time.
-	 * 
-	 * @return total pause duration (milliseconds).
-	 */
-	public synchronized long getTotalGcPause() {
-		return convertMicrosToMillis(ints(this.blockingEvents, Pst::getDuration).collect(summingLong(Long::valueOf))).longValue();
-	}
-
-	private static <T> Stream<Integer> ints(List<T> list, Function<T, Integer> function) {
-		return list.stream().map(function).filter(Objects::nonNull);
-	}
-
-	private static <T> LongStream longs(List<T> list, Function<T, Memory> function) {
-		return list.stream().map(function).filter(Objects::nonNull).mapToLong(m -> m.getValue(KILOBYTES));
-	}
-
-	/**
-	 * The first blocking event.
-	 * 
-	 * TODO: Should this consider non-blocking events?
-	 * 
-	 * @return The first blocking event.
-	 */
-	public synchronized BlockingEvent getFirstGcEvent() {
-		return this.blockingEvents.isEmpty() ? null
-				: (BlockingEvent) JdkUtil.parseLogLine(this.blockingEvents.get(0).getLogEntry());
-	}
-
-	/**
-	 * Retrieve the last blocking event.
-	 * 
-	 * TODO: Should this consider non-blocking events?
-	 * 
-	 * @return The last blocking event.
-	 */
-	public synchronized BlockingEvent getLastGcEvent() {
-		// Retrieve last event from batch or database.
-		return this.blockingEvents.isEmpty() ? null
-				: (BlockingEvent) JdkUtil
-						.parseLogLine(this.blockingEvents.get(blockingEvents.size() - 1).getLogEntry());
-	}
-
-	/**
-	 * Delete table(s). Useful when running in server mode during development.
-	 */
-	public synchronized void cleanup() {
-		this.blockingEvents.clear();
-		JvmDao.created = false;
-	}
-
-	/**
-	 * Retrieve all <code>BlockingEvent</code>s.
-	 * 
-	 * @return <code>List</code> of events.
-	 */
-	public synchronized List<BlockingEvent> getBlockingEvents() {
-		return this.blockingEvents.stream().sorted(comparing(Pst::getTimeStamp))
-				.map(pst -> hydrateBlockingEvent(determineEventType(pst.getEventName()), pst.getLogEntry(),
-						pst.getTimeStamp(), pst.getDuration()))
-				.collect(toList());
-	}
-
-	/**
-	 * Retrieve all <code>BlockingEvent</code>s of the specified type.
-	 * 
-	 * @param eventType The event type to retrieve.
-	 * @return <code>List</code> of events.
-	 */
-	public synchronized List<BlockingEvent> getBlockingEvents(LogEventType eventType) {
-		return this.blockingEvents.stream().filter(e -> e.getEventName().equals(eventType.toString()))
-				.sorted(comparing(Pst::getTimeStamp))
-				.map(pst -> hydrateBlockingEvent(eventType, pst.getLogEntry(), pst.getTimeStamp(), pst.getDuration()))
-				.collect(toList());
-	}
-
-	/**
-	 * The total number of blocking events.
-	 * 
-	 * @return total number of blocking events.
-	 */
-	public synchronized int getBlockingEventCount() {
-		return this.blockingEvents.size();
-	}
-
-	/**
-	 * The maximum young space size during the JVM run.
-	 * 
-	 * @return maximum young space size (kilobytes).
-	 */
-	public synchronized int getMaxYoungSpace() {
-		return (int) longs(this.blockingEvents, Pst::getYoungSpace).max().orElse(0);
-	}
-
-	/**
-	 * The maximum old space size during the JVM run.
-	 * 
-	 * @return maximum old space size (kilobytes).
-	 */
-	public synchronized int getMaxOldSpace() {
-		return (int) longs(this.blockingEvents, Pst::getOldSpace).max().orElse(0);
-	}
-
-	/**
-	 * The maximum heap space size during the JVM run.
-	 * 
-	 * @return maximum heap size (kilobytes).
-	 */
-	public synchronized int getMaxHeapSpace() {
-		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungSpace(), t.getOldSpace()))
-				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
-	}
-
-	/**
-	 * The maximum heap occupancy during the JVM run.
-	 * 
-	 * @return maximum heap occupancy (kilobytes).
-	 */
-	public synchronized int getMaxHeapOccupancy() {
-		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyInit(), t.getOldOccupancyInit()))
-				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
-	}
-
-	private static Memory add(Memory m1, Memory m2) {
-		return m1 == null ? nullSafe(m2) : m1.plus(nullSafe(m2));
-	}
-
-	private static Memory nullSafe(Memory memory) {
-		return memory == null ? ZERO : memory;
-	}
-
-	/**
-	 * The maximum heap after GC during the JVM run.
-	 * 
-	 * @return maximum heap after GC (kilobytes).
-	 */
-	public synchronized int getMaxHeapAfterGc() {
-		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyEnd(), t.getOldOccupancyEnd()))
-				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
-	}
-
-	/**
-	 * The maximum perm/metaspace size during the JVM run.
-	 * 
-	 * @return maximum perm/metaspace footprint (kilobytes).
-	 */
-	public synchronized int getMaxPermSpace() {
-		return (int) longs(this.blockingEvents, Pst::getPermSpace).max().orElse(0);
-	}
-
-	/**
-	 * The maximum perm/metaspace occupancy during the JVM run.
-	 * 
-	 * @return maximum perm/metaspac occupancy (kilobytes).
-	 */
-	public synchronized int getMaxPermOccupancy() {
-		return (int) longs(this.blockingEvents, Pst::getPermOccupancyInit).max().orElse(0);
-	}
-
-	/**
-	 * The maximum perm/metaspace after GC during the JVM run.
-	 * 
-	 * @return maximum perm/metaspac after GC (kilobytes).
-	 */
-	public synchronized int getMaxPermAfterGc() {
-		return (int) longs(this.blockingEvents, Pst::getPermOccupancyEnd).max().orElse(0);
-	}
-
-	/**
-	 * The first stopped event.
-	 * 
-	 * @return The time first stopped event.
-	 */
-	public synchronized ApplicationStoppedTimeEvent getFirstStoppedEvent() {
-		return stoppedTimeEvents.isEmpty() ? null
-				: (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(stoppedTimeEvents.get(0).getLogEntry());
-	}
-
-	/**
-	 * Retrieve the last stopped event.
-	 * 
-	 * @return The last stopped event.
-	 */
-	public synchronized ApplicationStoppedTimeEvent getLastStoppedEvent() {
-		// Retrieve last event from batch or database.
-		return stoppedTimeEvents.isEmpty() ? queryStoppedLastEvent()
-				: stoppedTimeEvents.get(stoppedTimeEvents.size() - 1);
-	}
-
-	/**
-	 * Retrieve the last stopped event from the database.
-	 * 
-	 * @return The last stopped event in database.
-	 */
-
-	private synchronized ApplicationStoppedTimeEvent queryStoppedLastEvent() {
-		return stoppedTimeEvents.isEmpty() ? null
-				: (ApplicationStoppedTimeEvent) JdkUtil
-						.parseLogLine(stoppedTimeEvents.get(stoppedTimeEvents.size() - 1).getLogEntry());
-	}
-
-	/**
-	 * The maximum stopped time event pause time.
-	 * 
-	 * @return maximum pause duration (milliseconds).
-	 */
-	public synchronized int getMaxStoppedTime() {
-		return convertMicrosToMillis(
-				ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration).collect(summingLong(Long::valueOf))).intValue();
-	}
-
-	/**
-	 * The total stopped time event pause time.
-	 * 
-	 * @return total pause duration (milliseconds).
-	 */
-	public synchronized int getTotalStoppedTime() {
-		return convertMicrosToMillis(ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration)
-				.collect(summingLong(Long::valueOf))).intValue();
-	}
-
-	/**
-	 * The total number of stopped time events.
-	 * 
-	 * @return total number of stopped time events.
-	 */
-	public synchronized int getStoppedTimeEventCount() {
-		return this.stoppedTimeEvents.size();
-	}
+    private static class Pst {
+
+        private long timeStamp;
+        private String eventName;
+        private int duration;
+        private Memory youngSpace;
+        private Memory youngOccupancyInit;
+        private Memory youngOccupancyEnd;
+        private Memory oldSpace;
+        private Memory oldOccupancyInit;
+        private Memory oldOccupancyEnd;
+        private Memory combinedSpace;
+        private Memory combinedOccupancyInit;
+        private Memory combinedOccupancyEnd;
+        private Memory permSpace;
+        private Memory permOccupancyInit;
+        private Memory permOccupancyEnd;
+        private String logEntry;
+
+        public long getTimeStamp() {
+            return timeStamp;
+        }
+
+        public String getEventName() {
+            return eventName;
+        }
+
+        public int getDuration() {
+            return duration;
+        }
+
+        public Memory getYoungSpace() {
+            return youngSpace;
+        }
+
+        public Memory getYoungOccupancyInit() {
+            return youngOccupancyInit;
+        }
+
+        public Memory getYoungOccupancyEnd() {
+            return youngOccupancyEnd;
+        }
+
+        public Memory getOldSpace() {
+            return oldSpace;
+        }
+
+        public Memory getOldOccupancyInit() {
+            return oldOccupancyInit;
+        }
+
+        public Memory getOldOccupancyEnd() {
+            return oldOccupancyEnd;
+        }
+
+        public Memory getCombinedSpace() {
+            return combinedSpace;
+        }
+
+        public Memory getCombinedOccupancyInit() {
+            return combinedOccupancyInit;
+        }
+
+        public Memory getCombinedOccupancyEnd() {
+            return combinedOccupancyEnd;
+        }
+
+        public Memory getPermSpace() {
+            return permSpace;
+        }
+
+        public Memory getPermOccupancyInit() {
+            return permOccupancyInit;
+        }
+
+        public Memory getPermOccupancyEnd() {
+            return permOccupancyEnd;
+        }
+
+        public String getLogEntry() {
+            return logEntry;
+        }
+
+    }
+
+    /**
+     * List of all event types associate with JVM run.
+     */
+    List<LogEventType> eventTypes = new ArrayList<>();
+
+    /**
+     * Analysis property keys.
+     */
+    private List<Analysis> analysis = new ArrayList<>();
+
+    /**
+     * Collector families for JVM run.
+     */
+    List<CollectorFamily> collectorFamilies = new ArrayList<>();
+
+    /**
+     * Logging lines that do not match any known GC events.
+     */
+    private List<String> unidentifiedLogLines = new ArrayList<>();
+
+    /**
+     * Batch blocking database inserts for improved performance.
+     */
+    private List<Pst> blockingEvents = new ArrayList<>();
+
+    /**
+     * Batch stopped time database inserts for improved performance.
+     */
+    private List<ApplicationStoppedTimeEvent> stoppedTimeEvents = new ArrayList<>();
+
+    /**
+     * The JVM options for the JVM run.
+     */
+    private String options;
+
+    /**
+     * JVM version.
+     */
+    private String version;
+
+    /**
+     * JVM memory information.
+     */
+    private String memory;
+
+    /**
+     * Physical memory (bytes).
+     */
+    private long physicalMemory;
+
+    /**
+     * Physical memory free (bytes).
+     */
+    private long physicalMemoryFree;
+
+    /**
+     * Swap size (bytes).
+     */
+    // prevent false positives of Analysis.INFO_SWAP_DISABLED
+    private long swap = -1;
+
+    /**
+     * Swap free (bytes).
+     */
+    private long swapFree;
+
+    /**
+     * Number of <code>ParallelCollection</code> events.
+     */
+    private long parallelCount;
+
+    /**
+     * Number of <code>ParallelCollection</code> with "inverted" parallelism.
+     */
+    private long invertedParallelismCount;
+
+    /**
+     * <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
+     */
+    private LogEvent worstInvertedParallelismEvent;
+
+    /**
+     * Used for tracking max heap space outside of <code>BlockingEvent</code>s.
+     */
+    private int maxHeapSpaceNonBlocking;
+
+    /**
+     * Used for tracking max heap occupancy outside of <code>BlockingEvent</code>s.
+     */
+    private int maxHeapOccupancyNonBlocking;
+
+    /**
+     * Used for tracking max perm space outside of <code>BlockingEvent</code>s.
+     */
+    private int maxPermSpaceNonBlocking;
+
+    /**
+     * Used for tracking max perm occupancy outside of <code>BlockingEvent</code>s.
+     */
+    private int maxPermOccupancyNonBlocking;
+
+    private static boolean created;
+
+    public JvmDao() {
+        if (created) {
+            cleanup();
+        } else {
+            created = true;
+        }
+    }
+
+    public List<String> getUnidentifiedLogLines() {
+        return unidentifiedLogLines;
+    }
+
+    public List<LogEventType> getEventTypes() {
+        return eventTypes;
+    }
+
+    public List<Analysis> getAnalysis() {
+        return analysis;
+    }
+
+    public void addAnalysis(Analysis analysis) {
+        if (!this.analysis.contains(analysis)) {
+            this.analysis.add(analysis);
+        }
+    }
+
+    public List<CollectorFamily> getCollectorFamilies() {
+        return collectorFamilies;
+    }
+
+    public void addBlockingEvent(BlockingEvent event) {
+        blockingEvents.add(intern(event));
+    }
+
+    public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {
+        stoppedTimeEvents.add(event);
+    }
+
+    /**
+     * @return The JVM options.
+     */
+    public String getOptions() {
+        return options;
+    }
+
+    /**
+     * @param options The JVM options to set.
+     */
+    public void setOptions(String options) {
+        this.options = options;
+    }
+
+    /**
+     * @return The JVM version information.
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @param version The JVM version information to set.
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * @return The JVM memory information.
+     */
+    public String getMemory() {
+        return memory;
+    }
+
+    /**
+     * @param memory The JVM memory information to set.
+     */
+    public void setMemory(String memory) {
+        this.memory = memory;
+    }
+
+    /**
+     * @return The JVM environment physical memory (bytes).
+     */
+    public long getPhysicalMemory() {
+        return physicalMemory;
+    }
+
+    /**
+     * @param physicalMemory The JVM physical memory to set.
+     */
+    public void setPhysicalMemory(long physicalMemory) {
+        this.physicalMemory = physicalMemory;
+    }
+
+    /**
+     * @return The JVM environment physical free memory (bytes).
+     */
+    public long getPhysicalMemoryFree() {
+        return physicalMemoryFree;
+    }
+
+    /**
+     * @param physicalMemoryFree The JVM physical free memory to set.
+     */
+    public void setPhysicalMemoryFree(long physicalMemoryFree) {
+        this.physicalMemoryFree = physicalMemoryFree;
+    }
+
+    /**
+     * @return The JVM environment swap size (bytes).
+     */
+    public long getSwap() {
+        return swap;
+    }
+
+    /**
+     * @param swap The JVM swap to set.
+     */
+    public void setSwap(long swap) {
+        this.swap = swap;
+    }
+
+    /**
+     * @return The JVM environment swap free (bytes).
+     */
+    public long getSwapFree() {
+        return swapFree;
+    }
+
+    /**
+     * @param swapFree The JVM swap free to set.
+     */
+    public void setSwapFree(long swapFree) {
+        this.swapFree = swapFree;
+    }
+
+    /**
+     * @return The number of <code>ParallelCollection</code> events.
+     */
+    public long getParallelCount() {
+        return parallelCount;
+    }
+
+    /**
+     * @param parallelCount The number of <code>ParallelCollection</code> events.
+     */
+    public void setParallelCount(long parallelCount) {
+        this.parallelCount = parallelCount;
+    }
+
+    /**
+     * @return The number of "inverted" parallelism events.
+     */
+    public long getInvertedParallelismCount() {
+        return invertedParallelismCount;
+    }
+
+    /**
+     * @param invertedParallelismCount The number of "low" parallelism events.
+     */
+    public void setInvertedParallelismCount(long invertedParallelismCount) {
+        this.invertedParallelismCount = invertedParallelismCount;
+    }
+
+    /**
+     * @return The <code>ParallelCollection</code> event with the lowest "inverted"
+     *         parallelism.
+     */
+    public LogEvent getWorstInvertedParallelismEvent() {
+        return worstInvertedParallelismEvent;
+    }
+
+    /**
+     * @param worstInvertedParallelismEvent The <code>ParallelCollection</code>
+     *                                      event with the lowest "inverted"
+     *                                      parallelism.
+     */
+    public void setWorstInvertedParallelismEvent(LogEvent worstInvertedParallelismEvent) {
+        this.worstInvertedParallelismEvent = worstInvertedParallelismEvent;
+    }
+
+    /**
+     * @return The maximum heap space in non <code>BlockingEvent</code>s.
+     */
+    public int getMaxHeapSpaceNonBlocking() {
+        return maxHeapSpaceNonBlocking;
+    }
+
+    /**
+     * @param maxHeapSpaceNonBlocking The maximum heap space in non
+     *                                <code>BlockingEvent</code>s.
+     */
+    public void setMaxHeapSpaceNonBlocking(int maxHeapSpaceNonBlocking) {
+        this.maxHeapSpaceNonBlocking = maxHeapSpaceNonBlocking;
+    }
+
+    /**
+     * @return The maximum heap occupancy in non <code>BlockingEvent</code>s.
+     */
+    public int getMaxHeapOccupancyNonBlocking() {
+        return maxHeapOccupancyNonBlocking;
+    }
+
+    /**
+     * @param maxHeapOccupancyNonBlocking The maximum heap occupancy in non
+     *                                    <code>BlockingEvent</code>s.
+     */
+    public void setMaxHeapOccupancyNonBlocking(int maxHeapOccupancyNonBlocking) {
+        this.maxHeapOccupancyNonBlocking = maxHeapOccupancyNonBlocking;
+    }
+
+    /**
+     * @return The maximum perm space in non <code>BlockingEvent</code>s.
+     */
+    public int getMaxPermSpaceNonBlocking() {
+        return maxPermSpaceNonBlocking;
+    }
+
+    /**
+     * @param maxPermSpaceNonBlocking The maximum perm space in non
+     *                                <code>BlockingEvent</code>s.
+     */
+    public void setMaxPermSpaceNonBlocking(int maxPermSpaceNonBlocking) {
+        this.maxPermSpaceNonBlocking = maxPermSpaceNonBlocking;
+    }
+
+    /**
+     * @return The maximum perm occupancy in non <code>BlockingEvent</code>s.
+     */
+    public int getMaxPermOccupancyNonBlocking() {
+        return maxPermOccupancyNonBlocking;
+    }
+
+    /**
+     * @param maxPermOccupancyNonBlocking The maximum perm occupancy in non
+     *                                    <code>BlockingEvent</code>s.
+     */
+    public void setMaxPermOccupancyNonBlocking(int maxPermOccupancyNonBlocking) {
+        this.maxPermOccupancyNonBlocking = maxPermOccupancyNonBlocking;
+    }
+
+    private static Pst intern(BlockingEvent event) {
+        Pst pst = new Pst();
+        pst.timeStamp = event.getTimestamp();
+        pst.eventName = event.getName();
+        pst.duration = event.getDuration();
+        pst.logEntry = event.getLogEntry();
+        if (event instanceof YoungData) {
+            YoungData youngData = (YoungData) event;
+            pst.youngSpace = youngData.getYoungSpace();
+            pst.youngOccupancyInit = youngData.getYoungOccupancyInit();
+            pst.youngOccupancyEnd = youngData.getYoungOccupancyEnd();
+        }
+        if (event instanceof OldData) {
+            OldData oldData = (OldData) event;
+            pst.oldSpace = oldData.getOldSpace();
+            pst.oldOccupancyInit = oldData.getOldOccupancyInit();
+            pst.oldOccupancyEnd = oldData.getOldOccupancyEnd();
+        }
+        if (event instanceof CombinedData) {
+            CombinedData combinedData = (CombinedData) event;
+            pst.combinedSpace = combinedData.getCombinedSpace();
+            pst.combinedOccupancyInit = combinedData.getCombinedOccupancyInit();
+            pst.combinedOccupancyEnd = combinedData.getCombinedOccupancyEnd();
+        }
+        if (event instanceof PermMetaspaceData) {
+            PermMetaspaceData permMetaspaceData = (PermMetaspaceData) event;
+            pst.permSpace = permMetaspaceData.getPermSpace();
+            pst.permOccupancyInit = permMetaspaceData.getPermOccupancyInit();
+            pst.permOccupancyEnd = permMetaspaceData.getPermOccupancyEnd();
+        }
+        return pst;
+    }
+
+    /**
+     * The maximum GC blocking event pause time.
+     * 
+     * @return maximum pause duration (milliseconds).
+     */
+    public synchronized int getMaxGcPause() {
+        return convertMicrosToMillis(
+                ints(this.blockingEvents, Pst::getDuration).mapToInt(Integer::valueOf).max().orElse(0)).intValue();
+    }
+
+    /**
+     * The total blocking event pause time.
+     * 
+     * @return total pause duration (milliseconds).
+     */
+    public synchronized long getTotalGcPause() {
+        return convertMicrosToMillis(ints(this.blockingEvents, Pst::getDuration).collect(summingLong(Long::valueOf)))
+                .longValue();
+    }
+
+    private static <T> Stream<Integer> ints(List<T> list, Function<T, Integer> function) {
+        return list.stream().map(function).filter(Objects::nonNull);
+    }
+
+    private static <T> LongStream longs(List<T> list, Function<T, Memory> function) {
+        return list.stream().map(function).filter(Objects::nonNull).mapToLong(m -> m.getValue(KILOBYTES));
+    }
+
+    /**
+     * The first blocking event.
+     * 
+     * TODO: Should this consider non-blocking events?
+     * 
+     * @return The first blocking event.
+     */
+    public synchronized BlockingEvent getFirstGcEvent() {
+        return this.blockingEvents.isEmpty() ? null
+                : (BlockingEvent) JdkUtil.parseLogLine(this.blockingEvents.get(0).getLogEntry());
+    }
+
+    /**
+     * Retrieve the last blocking event.
+     * 
+     * TODO: Should this consider non-blocking events?
+     * 
+     * @return The last blocking event.
+     */
+    public synchronized BlockingEvent getLastGcEvent() {
+        // Retrieve last event from batch or database.
+        return this.blockingEvents.isEmpty() ? null
+                : (BlockingEvent) JdkUtil
+                        .parseLogLine(this.blockingEvents.get(blockingEvents.size() - 1).getLogEntry());
+    }
+
+    /**
+     * Delete table(s). Useful when running in server mode during development.
+     */
+    public synchronized void cleanup() {
+        this.blockingEvents.clear();
+        JvmDao.created = false;
+    }
+
+    /**
+     * Retrieve all <code>BlockingEvent</code>s.
+     * 
+     * @return <code>List</code> of events.
+     */
+    public synchronized List<BlockingEvent> getBlockingEvents() {
+        return this.blockingEvents.stream().sorted(comparing(Pst::getTimeStamp))
+                .map(pst -> hydrateBlockingEvent(determineEventType(pst.getEventName()), pst.getLogEntry(),
+                        pst.getTimeStamp(), pst.getDuration()))
+                .collect(toList());
+    }
+
+    /**
+     * Retrieve all <code>BlockingEvent</code>s of the specified type.
+     * 
+     * @param eventType The event type to retrieve.
+     * @return <code>List</code> of events.
+     */
+    public synchronized List<BlockingEvent> getBlockingEvents(LogEventType eventType) {
+        return this.blockingEvents.stream().filter(e -> e.getEventName().equals(eventType.toString()))
+                .sorted(comparing(Pst::getTimeStamp))
+                .map(pst -> hydrateBlockingEvent(eventType, pst.getLogEntry(), pst.getTimeStamp(), pst.getDuration()))
+                .collect(toList());
+    }
+
+    /**
+     * The total number of blocking events.
+     * 
+     * @return total number of blocking events.
+     */
+    public synchronized int getBlockingEventCount() {
+        return this.blockingEvents.size();
+    }
+
+    /**
+     * The maximum young space size during the JVM run.
+     * 
+     * @return maximum young space size (kilobytes).
+     */
+    public synchronized int getMaxYoungSpace() {
+        return (int) longs(this.blockingEvents, Pst::getYoungSpace).max().orElse(0);
+    }
+
+    /**
+     * The maximum old space size during the JVM run.
+     * 
+     * @return maximum old space size (kilobytes).
+     */
+    public synchronized int getMaxOldSpace() {
+        return (int) longs(this.blockingEvents, Pst::getOldSpace).max().orElse(0);
+    }
+
+    /**
+     * The maximum heap space size during the JVM run.
+     * 
+     * @return maximum heap size (kilobytes).
+     */
+    public synchronized int getMaxHeapSpace() {
+        return (int) this.blockingEvents.stream().map(t -> add(t.getYoungSpace(), t.getOldSpace()))
+                .mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+    }
+
+    /**
+     * The maximum heap occupancy during the JVM run.
+     * 
+     * @return maximum heap occupancy (kilobytes).
+     */
+    public synchronized int getMaxHeapOccupancy() {
+        return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyInit(), t.getOldOccupancyInit()))
+                .mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+    }
+
+    private static Memory add(Memory m1, Memory m2) {
+        return m1 == null ? nullSafe(m2) : m1.plus(nullSafe(m2));
+    }
+
+    private static Memory nullSafe(Memory memory) {
+        return memory == null ? ZERO : memory;
+    }
+
+    /**
+     * The maximum heap after GC during the JVM run.
+     * 
+     * @return maximum heap after GC (kilobytes).
+     */
+    public synchronized int getMaxHeapAfterGc() {
+        return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyEnd(), t.getOldOccupancyEnd()))
+                .mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+    }
+
+    /**
+     * The maximum perm/metaspace size during the JVM run.
+     * 
+     * @return maximum perm/metaspace footprint (kilobytes).
+     */
+    public synchronized int getMaxPermSpace() {
+        return (int) longs(this.blockingEvents, Pst::getPermSpace).max().orElse(0);
+    }
+
+    /**
+     * The maximum perm/metaspace occupancy during the JVM run.
+     * 
+     * @return maximum perm/metaspac occupancy (kilobytes).
+     */
+    public synchronized int getMaxPermOccupancy() {
+        return (int) longs(this.blockingEvents, Pst::getPermOccupancyInit).max().orElse(0);
+    }
+
+    /**
+     * The maximum perm/metaspace after GC during the JVM run.
+     * 
+     * @return maximum perm/metaspac after GC (kilobytes).
+     */
+    public synchronized int getMaxPermAfterGc() {
+        return (int) longs(this.blockingEvents, Pst::getPermOccupancyEnd).max().orElse(0);
+    }
+
+    /**
+     * The first stopped event.
+     * 
+     * @return The time first stopped event.
+     */
+    public synchronized ApplicationStoppedTimeEvent getFirstStoppedEvent() {
+        return stoppedTimeEvents.isEmpty() ? null
+                : (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(stoppedTimeEvents.get(0).getLogEntry());
+    }
+
+    /**
+     * Retrieve the last stopped event.
+     * 
+     * @return The last stopped event.
+     */
+    public synchronized ApplicationStoppedTimeEvent getLastStoppedEvent() {
+        // Retrieve last event from batch or database.
+        return stoppedTimeEvents.isEmpty() ? queryStoppedLastEvent()
+                : stoppedTimeEvents.get(stoppedTimeEvents.size() - 1);
+    }
+
+    /**
+     * Retrieve the last stopped event from the database.
+     * 
+     * @return The last stopped event in database.
+     */
+
+    private synchronized ApplicationStoppedTimeEvent queryStoppedLastEvent() {
+        return stoppedTimeEvents.isEmpty() ? null
+                : (ApplicationStoppedTimeEvent) JdkUtil
+                        .parseLogLine(stoppedTimeEvents.get(stoppedTimeEvents.size() - 1).getLogEntry());
+    }
+
+    /**
+     * The maximum stopped time event pause time.
+     * 
+     * @return maximum pause duration (milliseconds).
+     */
+    public synchronized int getMaxStoppedTime() {
+        return convertMicrosToMillis(ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration)
+                .collect(summingLong(Long::valueOf))).intValue();
+    }
+
+    /**
+     * The total stopped time event pause time.
+     * 
+     * @return total pause duration (milliseconds).
+     */
+    public synchronized int getTotalStoppedTime() {
+        return convertMicrosToMillis(ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration)
+                .collect(summingLong(Long::valueOf))).intValue();
+    }
+
+    /**
+     * The total number of stopped time events.
+     * 
+     * @return total number of stopped time events.
+     */
+    public synchronized int getStoppedTimeEventCount() {
+        return this.stoppedTimeEvents.size();
+    }
 
 }

--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -425,9 +425,8 @@ public class JvmDao {
      * @return The first blocking event.
      */
     public synchronized BlockingEvent getFirstGcEvent() {
-        // TODO return directly?
-        return this.blockingEvents.isEmpty() ? null
-                : (BlockingEvent) JdkUtil.parseLogLine(this.blockingEvents.get(0).getLogEntry());
+        // TODO JdkUtil#parseLogLine no longer needed?
+        return this.blockingEvents.isEmpty() ? null : this.blockingEvents.get(0);
     }
 
     /**
@@ -439,10 +438,8 @@ public class JvmDao {
      */
     public synchronized BlockingEvent getLastGcEvent() {
         // Retrieve last event from batch or database.
-        // TODO return directly?
-        return this.blockingEvents.isEmpty() ? null
-                : (BlockingEvent) JdkUtil
-                        .parseLogLine(this.blockingEvents.get(blockingEvents.size() - 1).getLogEntry());
+        // TODO JdkUtil#parseLogLine no longer needed?
+        return this.blockingEvents.isEmpty() ? null : this.blockingEvents.get(blockingEvents.size() - 1);
     }
 
     /**
@@ -476,7 +473,7 @@ public class JvmDao {
 
     private static BlockingEvent toBlockingEvent(BlockingEvent e) {
         return e;
-        // TODO hydrateBlockingEvent no longer needed
+        // TODO JdkUtil#hydrateBlockingEvent no longer needed
         // return hydrateBlockingEvent(determineEventType(e.getName()), e.getLogEntry(),
         // e.getTimestamp(), e.getDuration());
     }

--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -34,7 +34,6 @@ import org.eclipselabs.garbagecat.domain.YoungData;
 import org.eclipselabs.garbagecat.domain.jdk.ApplicationStoppedTimeEvent;
 import org.eclipselabs.garbagecat.util.Memory;
 import org.eclipselabs.garbagecat.util.jdk.Analysis;
-import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.CollectorFamily;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
 
@@ -583,8 +582,7 @@ public class JvmDao {
      * @return The time first stopped event.
      */
     public synchronized ApplicationStoppedTimeEvent getFirstStoppedEvent() {
-        return stoppedTimeEvents.isEmpty() ? null
-                : (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(stoppedTimeEvents.get(0).getLogEntry());
+        return stoppedTimeEvents.isEmpty() ? null : stoppedTimeEvents.get(0);
     }
 
     /**
@@ -594,8 +592,7 @@ public class JvmDao {
      */
     public synchronized ApplicationStoppedTimeEvent getLastStoppedEvent() {
         // Retrieve last event from batch or database.
-        return stoppedTimeEvents.isEmpty() ? queryStoppedLastEvent()
-                : stoppedTimeEvents.get(stoppedTimeEvents.size() - 1);
+        return stoppedTimeEvents.isEmpty() ? null : stoppedTimeEvents.get(stoppedTimeEvents.size() - 1);
     }
 
     /**
@@ -603,12 +600,6 @@ public class JvmDao {
      * 
      * @return The last stopped event in database.
      */
-
-    private synchronized ApplicationStoppedTimeEvent queryStoppedLastEvent() {
-        return stoppedTimeEvents.isEmpty() ? null
-                : (ApplicationStoppedTimeEvent) JdkUtil
-                        .parseLogLine(stoppedTimeEvents.get(stoppedTimeEvents.size() - 1).getLogEntry());
-    }
 
     /**
      * The maximum stopped time event pause time.

--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -12,16 +12,22 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.hsql;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.summingLong;
+import static java.util.stream.Collectors.toList;
+import static org.eclipselabs.garbagecat.util.Memory.ZERO;
 import static org.eclipselabs.garbagecat.util.Memory.Unit.KILOBYTES;
+import static org.eclipselabs.garbagecat.util.jdk.JdkMath.convertMicrosToMillis;
+import static org.eclipselabs.garbagecat.util.jdk.JdkUtil.determineEventType;
+import static org.eclipselabs.garbagecat.util.jdk.JdkUtil.hydrateBlockingEvent;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import org.eclipselabs.garbagecat.domain.BlockingEvent;
 import org.eclipselabs.garbagecat.domain.CombinedData;
@@ -32,7 +38,6 @@ import org.eclipselabs.garbagecat.domain.YoungData;
 import org.eclipselabs.garbagecat.domain.jdk.ApplicationStoppedTimeEvent;
 import org.eclipselabs.garbagecat.util.Memory;
 import org.eclipselabs.garbagecat.util.jdk.Analysis;
-import org.eclipselabs.garbagecat.util.jdk.JdkMath;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.CollectorFamily;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
@@ -47,1364 +52,706 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
  */
 public class JvmDao {
 
-    /**
-     * SQL statement(s) to create table(s).
-     * 
-     * Notes:
-     * 
-     * 1) combined_space is given its own column, even though in most cases it can be computed from young_space +
-     * old_space, because some logging events log combined new + old sizes.
-     * 
-     */
-    private static final String[] TABLES_CREATE_SQL = {
-            "create table blocking_event (id integer identity, "
-                    + "time_stamp bigint, event_name varchar(64), duration integer, young_space integer, "
-                    + "old_space integer, combined_space integer, perm_space integer, young_occupancy_init integer, "
-                    + "old_occupancy_init integer, combined_occupancy_init integer, perm_occupancy_init integer, "
-                    + "young_occupancy_end integer, old_occupancy_end integer, combined_occupancy_end integer, "
-                    + "perm_occupancy_end integer, log_entry varchar(500))",
-            "create table application_stopped_time (id integer identity, "
-                    + "time_stamp bigint, event_name varchar(64), duration bigint, log_entry varchar(500))" };
-
-    /**
-     * SQL statement(s) to delete table(s).
-     */
-    private static final String[] TABLES_DELETE_SQL = { "delete from blocking_event ",
-            "delete from application_stopped_time " };
-
-    /**
-     * The database connection.
-     */
-    private static Connection connection;
-
-    /**
-     * List of all event types associate with JVM run.
-     */
-    List<LogEventType> eventTypes;
-
-    /**
-     * Analysis property keys.
-     */
-    private List<Analysis> analysis;
-
-    /**
-     * Collector families for JVM run.
-     */
-    List<CollectorFamily> collectorFamilies;
-
-    /**
-     * Logging lines that do not match any known GC events.
-     */
-    private List<String> unidentifiedLogLines;
-
-    /**
-     * The number of inserts to batch before persisting to database.
-     */
-    private static int batchSize = 100;
-
-    /**
-     * Batch blocking database inserts for improved performance.
-     */
-    private List<BlockingEvent> blockingBatch;
-
-    /**
-     * Batch stopped time database inserts for improved performance.
-     */
-    private List<ApplicationStoppedTimeEvent> stoppedTimeBatch;
-
-    /**
-     * The JVM options for the JVM run.
-     */
-    private String options;
-
-    /**
-     * JVM version.
-     */
-    private String version;
-
-    /**
-     * JVM memory information.
-     */
-    private String memory;
-
-    /**
-     * Physical memory (bytes).
-     */
-    private long physicalMemory;
-
-    /**
-     * Physical memory free (bytes).
-     */
-    private long physicalMemoryFree;
-
-    /**
-     * Swap size (bytes).
-     */
-    private long swap;
-
-    /**
-     * Swap free (bytes).
-     */
-    private long swapFree;
-
-    /**
-     * Number of <code>ParallelCollection</code> events.
-     */
-    private long parallelCount;
-
-    /**
-     * Number of <code>ParallelCollection</code> with "inverted" parallelism.
-     */
-    private long invertedParallelismCount;
-
-    /**
-     * <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
-     */
-    private LogEvent worstInvertedParallelismEvent;
-
-    /**
-     * Used for tracking max heap space outside of <code>BlockingEvent</code>s.
-     */
-    private int maxHeapSpaceNonBlocking;
-
-    /**
-     * Used for tracking max heap occupancy outside of <code>BlockingEvent</code>s.
-     */
-    private int maxHeapOccupancyNonBlocking;
-
-    /**
-     * Used for tracking max perm space outside of <code>BlockingEvent</code>s.
-     */
-    private int maxPermSpaceNonBlocking;
-
-    /**
-     * Used for tracking max perm occupancy outside of <code>BlockingEvent</code>s.
-     */
-    private int maxPermOccupancyNonBlocking;
-
-    public JvmDao() {
-        try {
-            // Load database driver.
-            Class.forName("org.hsqldb.jdbcDriver");
-        } catch (ClassNotFoundException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Failed to load HSQLDB JDBC driver.");
-        }
-
-        try {
-            // Connect to database.
-
-            // Database server for development
-            // connection = DriverManager.getConnection("jdbc:hsqldb:hsql://localhost/xdb", "sa",
-            // "");
-
-            // In-process standalone mode for deployment.
-            connection = DriverManager.getConnection("jdbc:hsqldb:mem:gcdb", "sa", "");
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error accessing database.");
-        }
-
-        // Create tables
-        Statement statement = null;
-        try {
-            statement = connection.createStatement();
-            for (int i = 0; i < TABLES_CREATE_SQL.length; i++) {
-                statement.executeUpdate(TABLES_CREATE_SQL[i]);
-            }
-        } catch (SQLException e) {
-            if (e.getMessage().startsWith("Table already exists")) {
-                cleanup();
-            } else {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error creating tables.");
-            }
-        } finally {
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-
-        eventTypes = new ArrayList<LogEventType>();
-        collectorFamilies = new ArrayList<CollectorFamily>();
-        analysis = new ArrayList<Analysis>();
-        unidentifiedLogLines = new ArrayList<String>();
-        blockingBatch = new ArrayList<BlockingEvent>();
-        stoppedTimeBatch = new ArrayList<ApplicationStoppedTimeEvent>();
-        // prevent false positives of Analysis.INFO_SWAP_DISABLED
-        swap = -1;
-    }
-
-    public List<String> getUnidentifiedLogLines() {
-        return unidentifiedLogLines;
-    }
-
-    public List<LogEventType> getEventTypes() {
-        return eventTypes;
-    }
-
-    public List<Analysis> getAnalysis() {
-        return analysis;
-    }
-
-    public void addAnalysis(Analysis analysis) {
-        if (!this.analysis.contains(analysis)) {
-            this.analysis.add(analysis);
-        }
-    }
-
-    public List<CollectorFamily> getCollectorFamilies() {
-        return collectorFamilies;
-    }
-
-    public void addBlockingEvent(BlockingEvent event) {
-        if (blockingBatch.size() == batchSize) {
-            processBlockingBatch();
-        }
-        blockingBatch.add(event);
-    }
-
-    public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {
-        if (stoppedTimeBatch.size() == batchSize) {
-            processStoppedTimeBatch();
-        }
-        stoppedTimeBatch.add(event);
-    }
-
-    /**
-     * @return The JVM options.
-     */
-    public String getOptions() {
-        return options;
-    }
-
-    /**
-     * @param options
-     *            The JVM options to set.
-     */
-    public void setOptions(String options) {
-        this.options = options;
-    }
-
-    /**
-     * @return The JVM version information.
-     */
-    public String getVersion() {
-        return version;
-    }
-
-    /**
-     * @param version
-     *            The JVM version information to set.
-     */
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * @return The JVM memory information.
-     */
-    public String getMemory() {
-        return memory;
-    }
-
-    /**
-     * @param memory
-     *            The JVM memory information to set.
-     */
-    public void setMemory(String memory) {
-        this.memory = memory;
-    }
-
-    /**
-     * @return The JVM environment physical memory (bytes).
-     */
-    public long getPhysicalMemory() {
-        return physicalMemory;
-    }
-
-    /**
-     * @param physicalMemory
-     *            The JVM physical memory to set.
-     */
-    public void setPhysicalMemory(long physicalMemory) {
-        this.physicalMemory = physicalMemory;
-    }
-
-    /**
-     * @return The JVM environment physical free memory (bytes).
-     */
-    public long getPhysicalMemoryFree() {
-        return physicalMemoryFree;
-    }
-
-    /**
-     * @param physicalMemoryFree
-     *            The JVM physical free memory to set.
-     */
-    public void setPhysicalMemoryFree(long physicalMemoryFree) {
-        this.physicalMemoryFree = physicalMemoryFree;
-    }
-
-    /**
-     * @return The JVM environment swap size (bytes).
-     */
-    public long getSwap() {
-        return swap;
-    }
-
-    /**
-     * @param swap
-     *            The JVM swap to set.
-     */
-    public void setSwap(long swap) {
-        this.swap = swap;
-    }
-
-    /**
-     * @return The JVM environment swap free (bytes).
-     */
-    public long getSwapFree() {
-        return swapFree;
-    }
-
-    /**
-     * @param swapFree
-     *            The JVM swap free to set.
-     */
-    public void setSwapFree(long swapFree) {
-        this.swapFree = swapFree;
-    }
-
-    /**
-     * @return The number of <code>ParallelCollection</code> events.
-     */
-    public long getParallelCount() {
-        return parallelCount;
-    }
-
-    /**
-     * @param parallelCount
-     *            The number of <code>ParallelCollection</code> events.
-     */
-    public void setParallelCount(long parallelCount) {
-        this.parallelCount = parallelCount;
-    }
-
-    /**
-     * @return The number of "inverted" parallelism events.
-     */
-    public long getInvertedParallelismCount() {
-        return invertedParallelismCount;
-    }
-
-    /**
-     * @param invertedParallelismCount
-     *            The number of "low" parallelism events.
-     */
-    public void setInvertedParallelismCount(long invertedParallelismCount) {
-        this.invertedParallelismCount = invertedParallelismCount;
-    }
-
-    /**
-     * @return The <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
-     */
-    public LogEvent getWorstInvertedParallelismEvent() {
-        return worstInvertedParallelismEvent;
-    }
-
-    /**
-     * @param worstInvertedParallelismEvent
-     *            The <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
-     */
-    public void setWorstInvertedParallelismEvent(LogEvent worstInvertedParallelismEvent) {
-        this.worstInvertedParallelismEvent = worstInvertedParallelismEvent;
-    }
-
-    /**
-     * @return The maximum heap space in non <code>BlockingEvent</code>s.
-     */
-    public int getMaxHeapSpaceNonBlocking() {
-        return maxHeapSpaceNonBlocking;
-    }
-
-    /**
-     * @param maxHeapSpaceNonBlocking
-     *            The maximum heap space in non <code>BlockingEvent</code>s.
-     */
-    public void setMaxHeapSpaceNonBlocking(int maxHeapSpaceNonBlocking) {
-        this.maxHeapSpaceNonBlocking = maxHeapSpaceNonBlocking;
-    }
-
-    /**
-     * @return The maximum heap occupancy in non <code>BlockingEvent</code>s.
-     */
-    public int getMaxHeapOccupancyNonBlocking() {
-        return maxHeapOccupancyNonBlocking;
-    }
-
-    /**
-     * @param maxHeapOccupancyNonBlocking
-     *            The maximum heap occupancy in non <code>BlockingEvent</code>s.
-     */
-    public void setMaxHeapOccupancyNonBlocking(int maxHeapOccupancyNonBlocking) {
-        this.maxHeapOccupancyNonBlocking = maxHeapOccupancyNonBlocking;
-    }
-
-    /**
-     * @return The maximum perm space in non <code>BlockingEvent</code>s.
-     */
-    public int getMaxPermSpaceNonBlocking() {
-        return maxPermSpaceNonBlocking;
-    }
-
-    /**
-     * @param maxPermSpaceNonBlocking
-     *            The maximum perm space in non <code>BlockingEvent</code>s.
-     */
-    public void setMaxPermSpaceNonBlocking(int maxPermSpaceNonBlocking) {
-        this.maxPermSpaceNonBlocking = maxPermSpaceNonBlocking;
-    }
-
-    /**
-     * @return The maximum perm occupancy in non <code>BlockingEvent</code>s.
-     */
-    public int getMaxPermOccupancyNonBlocking() {
-        return maxPermOccupancyNonBlocking;
-    }
-
-    /**
-     * @param maxPermOccupancyNonBlocking
-     *            The maximum perm occupancy in non <code>BlockingEvent</code>s.
-     */
-    public void setMaxPermOccupancyNonBlocking(int maxPermOccupancyNonBlocking) {
-        this.maxPermOccupancyNonBlocking = maxPermOccupancyNonBlocking;
-    }
-
-    /**
-     * Add blocking events to database.
-     */
-    public synchronized void processBlockingBatch() {
-
-        PreparedStatement pst = null;
-        try {
-            String sqlInsertBlockingEvent = "insert into blocking_event (time_stamp, event_name, "
-                    + "duration, young_space, old_space, combined_space, perm_space, young_occupancy_init, "
-                    + "old_occupancy_init, combined_occupancy_init, perm_occupancy_init, young_occupancy_end, "
-                    + "old_occupancy_end, combined_occupancy_end, perm_occupancy_end,log_entry) "
-                    + "values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?,?,?,?,?,?,?)";
-
-            final int TIME_STAMP_INDEX = 1;
-            final int EVENT_NAME_INDEX = 2;
-            final int DURATION_INDEX = 3;
-            final int YOUNG_SPACE_INDEX = 4;
-            final int OLD_SPACE_INDEX = 5;
-            final int COMBINED_SPACE_INDEX = 6;
-            final int PERM_SPACE_INDEX = 7;
-            final int YOUNG_OCCUPANCY_INIT_INDEX = 8;
-            final int OLD_OCCUPANCY_INIT_INDEX = 9;
-            final int COMBINED_OCCUPANCY_INIT_INDEX = 10;
-            final int PERM_OCCUPANCY_INIT_INDEX = 11;
-            final int YOUNG_OCCUPANCY_END_INDEX = 12;
-            final int OLD_OCCUPANCY_END_INDEX = 13;
-            final int COMBINED_OCCUPANCY_END_INDEX = 14;
-            final int PERM_OCCUPANCY_END_INDEX = 15;
-            final int LOG_ENTRY_INDEX = 16;
-
-            pst = connection.prepareStatement(sqlInsertBlockingEvent);
-
-            for (int i = 0; i < blockingBatch.size(); i++) {
-                BlockingEvent event = blockingBatch.get(i);
-                pst.setLong(TIME_STAMP_INDEX, event.getTimestamp());
-                pst.setString(EVENT_NAME_INDEX, event.getName());
-                pst.setLong(DURATION_INDEX, event.getDuration());
-                if (event instanceof YoungData) {
-                    pst.setInt(YOUNG_SPACE_INDEX, kilobytes(((YoungData) event).getYoungSpace()));
-                    pst.setInt(YOUNG_OCCUPANCY_INIT_INDEX, kilobytes(((YoungData) event).getYoungOccupancyInit()));
-                    pst.setInt(YOUNG_OCCUPANCY_END_INDEX, kilobytes(((YoungData) event).getYoungOccupancyEnd()));
-                } else {
-                    pst.setInt(YOUNG_SPACE_INDEX, 0);
-                    pst.setInt(YOUNG_OCCUPANCY_INIT_INDEX, 0);
-                    pst.setInt(YOUNG_OCCUPANCY_END_INDEX, 0);
-                }
-                if (event instanceof OldData) {
-                    pst.setInt(OLD_SPACE_INDEX, kilobytes(((OldData) event).getOldSpace()));
-                    pst.setInt(OLD_OCCUPANCY_INIT_INDEX, kilobytes(((OldData) event).getOldOccupancyInit()));
-                    pst.setInt(OLD_OCCUPANCY_END_INDEX, kilobytes(((OldData) event).getOldOccupancyEnd()));
-                } else {
-                    pst.setInt(OLD_SPACE_INDEX, 0);
-                    pst.setInt(OLD_OCCUPANCY_INIT_INDEX, 0);
-                    pst.setInt(OLD_OCCUPANCY_END_INDEX, 0);
-                }
-                if (event instanceof CombinedData) {
-                    pst.setInt(COMBINED_SPACE_INDEX, kilobytes(((CombinedData) event).getCombinedSpace()));
-                    pst.setInt(COMBINED_OCCUPANCY_INIT_INDEX,
-                            kilobytes(((CombinedData) event).getCombinedOccupancyInit()));
-                    pst.setInt(COMBINED_OCCUPANCY_END_INDEX,
-                            kilobytes(((CombinedData) event).getCombinedOccupancyEnd()));
-                } else {
-                    pst.setInt(COMBINED_SPACE_INDEX, 0);
-                    pst.setInt(COMBINED_OCCUPANCY_INIT_INDEX, 0);
-                    pst.setInt(COMBINED_OCCUPANCY_END_INDEX, 0);
-                }
-                if (event instanceof PermMetaspaceData) {
-                    pst.setInt(PERM_SPACE_INDEX, kilobytes(((PermMetaspaceData) event).getPermSpace()));
-                    pst.setInt(PERM_OCCUPANCY_INIT_INDEX,
-                            kilobytes(((PermMetaspaceData) event).getPermOccupancyInit()));
-                    pst.setInt(PERM_OCCUPANCY_END_INDEX, kilobytes(((PermMetaspaceData) event).getPermOccupancyEnd()));
-                } else {
-                    pst.setInt(PERM_SPACE_INDEX, 0);
-                    pst.setInt(PERM_OCCUPANCY_INIT_INDEX, 0);
-                    pst.setInt(PERM_OCCUPANCY_END_INDEX, 0);
-                }
-                pst.setString(LOG_ENTRY_INDEX, event.getLogEntry());
-                pst.addBatch();
-            }
-            pst.executeBatch();
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error inserting blocking event.");
-        } finally {
-            blockingBatch.clear();
-            try {
-                pst.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closingPreparedStatement.");
-            }
-        }
-    }
-
-    private static int kilobytes(Memory memory) {
-        return (int) (memory == null ? 0 : memory.getValue(KILOBYTES));
-    }
-
-    /**
-     * Add stopped time events to database.
-     */
-    public synchronized void processStoppedTimeBatch() {
-
-        PreparedStatement pst = null;
-        try {
-            String sqlInsertStoppedEvent = "insert into application_stopped_time (time_stamp, event_name, "
-                    + "duration, log_entry) " + "values(?, ?, ?, ?)";
-
-            final int TIME_STAMP_INDEX = 1;
-            final int EVENT_NAME_INDEX = 2;
-            final int DURATION_INDEX = 3;
-            final int LOG_ENTRY_INDEX = 4;
-
-            pst = connection.prepareStatement(sqlInsertStoppedEvent);
-
-            for (int i = 0; i < stoppedTimeBatch.size(); i++) {
-                ApplicationStoppedTimeEvent event = stoppedTimeBatch.get(i);
-                pst.setLong(TIME_STAMP_INDEX, event.getTimestamp());
-                pst.setString(EVENT_NAME_INDEX, event.getName());
-                pst.setInt(DURATION_INDEX, event.getDuration());
-                pst.setString(LOG_ENTRY_INDEX, event.getLogEntry());
-                pst.addBatch();
-            }
-            pst.executeBatch();
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error inserting stopped time event.");
-        } finally {
-            stoppedTimeBatch.clear();
-            try {
-                pst.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closingPreparedStatement.");
-            }
-        }
-    }
-
-    /**
-     * The maximum GC blocking event pause time.
-     * 
-     * @return maximum pause duration (milliseconds).
-     */
-    public synchronized int getMaxGcPause() {
-        int maxPause = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(duration) from blocking_event");
-            if (rs.next()) {
-                maxPause = JdkMath.convertMicrosToMillis(rs.getInt(1)).intValue();
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determine maximum pause time.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return maxPause;
-    }
-
-    /**
-     * The total blocking event pause time.
-     * 
-     * @return total pause duration (milliseconds).
-     */
-    public synchronized long getTotalGcPause() {
-        long totalPause = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select sum(duration) from blocking_event");
-            if (rs.next()) {
-                totalPause = JdkMath.convertMicrosToMillis(rs.getLong(1)).longValue();
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining total pause time.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return totalPause;
-    }
-
-    /**
-     * The first blocking event.
-     * 
-     * TODO: Should this consider non-blocking events?
-     * 
-     * @return The first blocking event.
-     */
-    public synchronized BlockingEvent getFirstGcEvent() {
-        BlockingEvent event = null;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery(
-                    "select log_entry from blocking_event where id = " + "(select min(id) from blocking_event)");
-            if (rs.next()) {
-                event = (BlockingEvent) JdkUtil.parseLogLine(rs.getString(1));
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining first blocking event.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return event;
-    }
-
-    /**
-     * Retrieve the last blocking event.
-     * 
-     * TODO: Should this consider non-blocking events?
-     * 
-     * @return The last blocking event.
-     */
-    public synchronized BlockingEvent getLastGcEvent() {
-        BlockingEvent event = null;
-        // Retrieve last event from batch or database.
-        if (!blockingBatch.isEmpty()) {
-            event = blockingBatch.get(blockingBatch.size() - 1);
-        } else {
-            event = queryGcLastEvent();
-        }
-        return event;
-    }
-
-    /**
-     * Retrieve the last blocking event.
-     * 
-     * TODO: Should this consider non-blocking events?
-     * 
-     * @return The last blocking event in database.
-     */
-
-    private synchronized BlockingEvent queryGcLastEvent() {
-        BlockingEvent event = null;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery(
-                    "select log_entry from blocking_event where id = " + "(select max(id) from blocking_event)");
-            if (rs.next()) {
-                event = (BlockingEvent) JdkUtil.parseLogLine(rs.getString(1));
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining last blocking event.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return event;
-    }
-
-    /**
-     * Delete table(s). Useful when running in server mode during development.
-     */
-    public synchronized void cleanup() {
-        Statement statement = null;
-        try {
-            statement = connection.createStatement();
-            for (int i = 0; i < TABLES_DELETE_SQL.length; i++) {
-                statement.executeUpdate(TABLES_DELETE_SQL[i]);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error deleting rows from tables.");
-        } finally {
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-    }
-
-    /**
-     * Retrieve all <code>BlockingEvent</code>s.
-     * 
-     * @return <code>List</code> of events.
-     */
-    public synchronized List<BlockingEvent> getBlockingEvents() {
-        List<BlockingEvent> events = new ArrayList<BlockingEvent>();
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            StringBuffer sql = new StringBuffer();
-            sql.append("select time_stamp, event_name, duration, log_entry from blocking_event"
-                    + " order by time_stamp asc, id asc");
-            rs = statement.executeQuery(sql.toString());
-            while (rs.next()) {
-                LogEventType eventType = JdkUtil.determineEventType(rs.getString(2));
-                BlockingEvent event = JdkUtil.hydrateBlockingEvent(eventType, rs.getString(4), rs.getLong(1),
-                        rs.getInt(3));
-                events.add(event);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error retrieving blocking events.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return events;
-    }
-
-    /**
-     * Retrieve all <code>BlockingEvent</code>s of the specified type.
-     * 
-     * @param eventType
-     *            The event type to retrieve.
-     * @return <code>List</code> of events.
-     */
-    public synchronized List<BlockingEvent> getBlockingEvents(LogEventType eventType) {
-        List<BlockingEvent> events = new ArrayList<BlockingEvent>();
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            StringBuffer sql = new StringBuffer();
-            sql.append("select time_stamp, duration, log_entry from blocking_event where event_name='");
-            sql.append(eventType);
-            sql.append("' order by time_stamp asc");
-            rs = statement.executeQuery(sql.toString());
-            while (rs.next()) {
-                BlockingEvent event = JdkUtil.hydrateBlockingEvent(eventType, rs.getString(3), rs.getLong(1),
-                        rs.getInt(2));
-                events.add(event);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error retrieving blocking events.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return events;
-    }
-
-    /**
-     * The total number of blocking events.
-     * 
-     * @return total number of blocking events.
-     */
-    public synchronized int getBlockingEventCount() {
-        int count = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select count(id) from blocking_event");
-            if (rs.next()) {
-                count = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining blocking event count.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return count;
-    }
-
-    /**
-     * The maximum young space size during the JVM run.
-     * 
-     * @return maximum young space size (kilobytes).
-     */
-    public synchronized int getMaxYoungSpace() {
-        int space = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(young_space) from blocking_event");
-            if (rs.next()) {
-                space = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max young space.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return space;
-    }
-
-    /**
-     * The maximum old space size during the JVM run.
-     * 
-     * @return maximum old space size (kilobytes).
-     */
-    public synchronized int getMaxOldSpace() {
-        int space = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(old_space) from blocking_event");
-            if (rs.next()) {
-                space = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max old space.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return space;
-    }
-
-    /**
-     * The maximum heap space size during the JVM run.
-     * 
-     * @return maximum heap size (kilobytes).
-     */
-    public synchronized int getMaxHeapSpace() {
-        int space = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement
-                    .executeQuery("select max(young_space + old_space " + "+ combined_space) from blocking_event");
-            if (rs.next()) {
-                space = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max heap space.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return space;
-    }
-
-    /**
-     * The maximum heap occupancy during the JVM run.
-     * 
-     * @return maximum heap occupancy (kilobytes).
-     */
-    public synchronized int getMaxHeapOccupancy() {
-        int occupancy = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(young_occupancy_init + old_occupancy_init "
-                    + "+ combined_occupancy_init) from blocking_event");
-            if (rs.next()) {
-                occupancy = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max heap occupancy.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return occupancy;
-    }
-
-    /**
-     * The maximum heap after GC during the JVM run.
-     * 
-     * @return maximum heap after GC (kilobytes).
-     */
-    public synchronized int getMaxHeapAfterGc() {
-        int occupancy = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(young_occupancy_end + old_occupancy_end "
-                    + "+ combined_occupancy_end) from blocking_event");
-            if (rs.next()) {
-                occupancy = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max heap after GC.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return occupancy;
-    }
-
-    /**
-     * The maximum perm/metaspace size during the JVM run.
-     * 
-     * @return maximum perm/metaspace footprint (kilobytes).
-     */
-    public synchronized int getMaxPermSpace() {
-        int space = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(perm_space) from blocking_event");
-            if (rs.next()) {
-                space = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max perm space.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return space;
-    }
-
-    /**
-     * The maximum perm/metaspace occupancy during the JVM run.
-     * 
-     * @return maximum perm/metaspac occupancy (kilobytes).
-     */
-    public synchronized int getMaxPermOccupancy() {
-        int occupancy = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(perm_occupancy_init) from blocking_event");
-            if (rs.next()) {
-                occupancy = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max perm gen occupancy.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return occupancy;
-    }
-
-    /**
-     * The maximum perm/metaspace after GC during the JVM run.
-     * 
-     * @return maximum perm/metaspac after GC (kilobytes).
-     */
-    public synchronized int getMaxPermAfterGc() {
-        int occupancy = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(perm_occupancy_end) from blocking_event");
-            if (rs.next()) {
-                occupancy = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining max perm gen after GC.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return occupancy;
-    }
-
-    /**
-     * The first stopped event.
-     * 
-     * @return The time first stopped event.
-     */
-    public synchronized ApplicationStoppedTimeEvent getFirstStoppedEvent() {
-        ApplicationStoppedTimeEvent event = null;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select log_entry from application_stopped_time where id = "
-                    + "(select min(id) from application_stopped_time)");
-            if (rs.next()) {
-                event = (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(rs.getString(1));
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining first stopped event.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return event;
-    }
-
-    /**
-     * Retrieve the last stopped event.
-     * 
-     * @return The last stopped event.
-     */
-    public synchronized ApplicationStoppedTimeEvent getLastStoppedEvent() {
-        ApplicationStoppedTimeEvent event;
-        // Retrieve last event from batch or database.
-        if (!stoppedTimeBatch.isEmpty()) {
-            event = stoppedTimeBatch.get(stoppedTimeBatch.size() - 1);
-        } else {
-            event = queryStoppedLastEvent();
-        }
-        return event;
-    }
-
-    /**
-     * Retrieve the last stopped event from the database.
-     * 
-     * @return The last stopped event in database.
-     */
-
-    private synchronized ApplicationStoppedTimeEvent queryStoppedLastEvent() {
-        ApplicationStoppedTimeEvent event = null;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select log_entry from application_stopped_time where id = "
-                    + "(select max(id) from application_stopped_time)");
-            if (rs.next()) {
-                event = (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(rs.getString(1));
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining last stopped event.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return event;
-    }
-
-    /**
-     * The maximum stopped time event pause time.
-     * 
-     * @return maximum pause duration (milliseconds).
-     */
-    public synchronized int getMaxStoppedTime() {
-        int maxStoppedTime = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select max(duration) from application_stopped_time");
-            if (rs.next()) {
-                long micros = rs.getInt(1);
-                maxStoppedTime = JdkMath.convertMicrosToMillis(micros).intValue();
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determine maximum stopped time.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return maxStoppedTime;
-    }
-
-    /**
-     * The total stopped time event pause time.
-     * 
-     * @return total pause duration (milliseconds).
-     */
-    public synchronized int getTotalStoppedTime() {
-        int totalStoppedTime = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select sum(duration) from application_stopped_time");
-            if (rs.next()) {
-                long micros = rs.getLong(1);
-                totalStoppedTime = JdkMath.convertMicrosToMillis(micros).intValue();
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining total stopped time.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return totalStoppedTime;
-    }
-
-    /**
-     * The total number of stopped time events.
-     * 
-     * @return total number of stopped time events.
-     */
-    public synchronized int getStoppedTimeEventCount() {
-        int count = 0;
-        Statement statement = null;
-        ResultSet rs = null;
-        try {
-            statement = connection.createStatement();
-            rs = statement.executeQuery("select count(id) from application_stopped_time");
-            if (rs.next()) {
-                count = rs.getInt(1);
-            }
-        } catch (SQLException e) {
-            System.err.println(e.getMessage());
-            throw new RuntimeException("Error determining stopped time event count.");
-        } finally {
-            try {
-                rs.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing ResultSet.");
-            }
-            try {
-                statement.close();
-            } catch (SQLException e) {
-                System.err.println(e.getMessage());
-                throw new RuntimeException("Error closing Statement.");
-            }
-        }
-        return count;
-    }
+	private static class Pst {
+
+		private long timeStamp;
+		private String eventName;
+		private int duration;
+		private Memory youngSpace;
+		private Memory youngOccupancyInit;
+		private Memory youngOccupancyEnd;
+		private Memory oldSpace;
+		private Memory oldOccupancyInit;
+		private Memory oldOccupancyEnd;
+		private Memory combinedSpace;
+		private Memory combinedOccupancyInit;
+		private Memory combinedOccupancyEnd;
+		private Memory permSpace;
+		private Memory permOccupancyInit;
+		private Memory permOccupancyEnd;
+		private String logEntry;
+
+		public long getTimeStamp() {
+			return timeStamp;
+		}
+
+		public String getEventName() {
+			return eventName;
+		}
+
+		public int getDuration() {
+			return duration;
+		}
+
+		public Memory getYoungSpace() {
+			return youngSpace;
+		}
+
+		public Memory getYoungOccupancyInit() {
+			return youngOccupancyInit;
+		}
+
+		public Memory getYoungOccupancyEnd() {
+			return youngOccupancyEnd;
+		}
+
+		public Memory getOldSpace() {
+			return oldSpace;
+		}
+
+		public Memory getOldOccupancyInit() {
+			return oldOccupancyInit;
+		}
+
+		public Memory getOldOccupancyEnd() {
+			return oldOccupancyEnd;
+		}
+
+		public Memory getCombinedSpace() {
+			return combinedSpace;
+		}
+
+		public Memory getCombinedOccupancyInit() {
+			return combinedOccupancyInit;
+		}
+
+		public Memory getCombinedOccupancyEnd() {
+			return combinedOccupancyEnd;
+		}
+
+		public Memory getPermSpace() {
+			return permSpace;
+		}
+
+		public Memory getPermOccupancyInit() {
+			return permOccupancyInit;
+		}
+
+		public Memory getPermOccupancyEnd() {
+			return permOccupancyEnd;
+		}
+
+		public String getLogEntry() {
+			return logEntry;
+		}
+
+	}
+
+	/**
+	 * List of all event types associate with JVM run.
+	 */
+	List<LogEventType> eventTypes = new ArrayList<>();
+
+	/**
+	 * Analysis property keys.
+	 */
+	private List<Analysis> analysis = new ArrayList<>();
+
+	/**
+	 * Collector families for JVM run.
+	 */
+	List<CollectorFamily> collectorFamilies = new ArrayList<>();
+
+	/**
+	 * Logging lines that do not match any known GC events.
+	 */
+	private List<String> unidentifiedLogLines = new ArrayList<>();
+
+	/**
+	 * Batch blocking database inserts for improved performance.
+	 */
+	private List<Pst> blockingEvents = new ArrayList<>();
+
+	/**
+	 * Batch stopped time database inserts for improved performance.
+	 */
+	private List<ApplicationStoppedTimeEvent> stoppedTimeEvents = new ArrayList<>();
+
+	/**
+	 * The JVM options for the JVM run.
+	 */
+	private String options;
+
+	/**
+	 * JVM version.
+	 */
+	private String version;
+
+	/**
+	 * JVM memory information.
+	 */
+	private String memory;
+
+	/**
+	 * Physical memory (bytes).
+	 */
+	private long physicalMemory;
+
+	/**
+	 * Physical memory free (bytes).
+	 */
+	private long physicalMemoryFree;
+
+	/**
+	 * Swap size (bytes).
+	 */
+	// prevent false positives of Analysis.INFO_SWAP_DISABLED
+	private long swap = -1;
+
+	/**
+	 * Swap free (bytes).
+	 */
+	private long swapFree;
+
+	/**
+	 * Number of <code>ParallelCollection</code> events.
+	 */
+	private long parallelCount;
+
+	/**
+	 * Number of <code>ParallelCollection</code> with "inverted" parallelism.
+	 */
+	private long invertedParallelismCount;
+
+	/**
+	 * <code>ParallelCollection</code> event with the lowest "inverted" parallelism.
+	 */
+	private LogEvent worstInvertedParallelismEvent;
+
+	/**
+	 * Used for tracking max heap space outside of <code>BlockingEvent</code>s.
+	 */
+	private int maxHeapSpaceNonBlocking;
+
+	/**
+	 * Used for tracking max heap occupancy outside of <code>BlockingEvent</code>s.
+	 */
+	private int maxHeapOccupancyNonBlocking;
+
+	/**
+	 * Used for tracking max perm space outside of <code>BlockingEvent</code>s.
+	 */
+	private int maxPermSpaceNonBlocking;
+
+	/**
+	 * Used for tracking max perm occupancy outside of <code>BlockingEvent</code>s.
+	 */
+	private int maxPermOccupancyNonBlocking;
+
+	private static boolean created;
+
+	public JvmDao() {
+		if (created) {
+			cleanup();
+		} else {
+			created = true;
+		}
+	}
+
+	public List<String> getUnidentifiedLogLines() {
+		return unidentifiedLogLines;
+	}
+
+	public List<LogEventType> getEventTypes() {
+		return eventTypes;
+	}
+
+	public List<Analysis> getAnalysis() {
+		return analysis;
+	}
+
+	public void addAnalysis(Analysis analysis) {
+		if (!this.analysis.contains(analysis)) {
+			this.analysis.add(analysis);
+		}
+	}
+
+	public List<CollectorFamily> getCollectorFamilies() {
+		return collectorFamilies;
+	}
+
+	public void addBlockingEvent(BlockingEvent event) {
+		blockingEvents.add(intern(event));
+	}
+
+	public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {
+		stoppedTimeEvents.add(event);
+	}
+
+	/**
+	 * @return The JVM options.
+	 */
+	public String getOptions() {
+		return options;
+	}
+
+	/**
+	 * @param options The JVM options to set.
+	 */
+	public void setOptions(String options) {
+		this.options = options;
+	}
+
+	/**
+	 * @return The JVM version information.
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * @param version The JVM version information to set.
+	 */
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	/**
+	 * @return The JVM memory information.
+	 */
+	public String getMemory() {
+		return memory;
+	}
+
+	/**
+	 * @param memory The JVM memory information to set.
+	 */
+	public void setMemory(String memory) {
+		this.memory = memory;
+	}
+
+	/**
+	 * @return The JVM environment physical memory (bytes).
+	 */
+	public long getPhysicalMemory() {
+		return physicalMemory;
+	}
+
+	/**
+	 * @param physicalMemory The JVM physical memory to set.
+	 */
+	public void setPhysicalMemory(long physicalMemory) {
+		this.physicalMemory = physicalMemory;
+	}
+
+	/**
+	 * @return The JVM environment physical free memory (bytes).
+	 */
+	public long getPhysicalMemoryFree() {
+		return physicalMemoryFree;
+	}
+
+	/**
+	 * @param physicalMemoryFree The JVM physical free memory to set.
+	 */
+	public void setPhysicalMemoryFree(long physicalMemoryFree) {
+		this.physicalMemoryFree = physicalMemoryFree;
+	}
+
+	/**
+	 * @return The JVM environment swap size (bytes).
+	 */
+	public long getSwap() {
+		return swap;
+	}
+
+	/**
+	 * @param swap The JVM swap to set.
+	 */
+	public void setSwap(long swap) {
+		this.swap = swap;
+	}
+
+	/**
+	 * @return The JVM environment swap free (bytes).
+	 */
+	public long getSwapFree() {
+		return swapFree;
+	}
+
+	/**
+	 * @param swapFree The JVM swap free to set.
+	 */
+	public void setSwapFree(long swapFree) {
+		this.swapFree = swapFree;
+	}
+
+	/**
+	 * @return The number of <code>ParallelCollection</code> events.
+	 */
+	public long getParallelCount() {
+		return parallelCount;
+	}
+
+	/**
+	 * @param parallelCount The number of <code>ParallelCollection</code> events.
+	 */
+	public void setParallelCount(long parallelCount) {
+		this.parallelCount = parallelCount;
+	}
+
+	/**
+	 * @return The number of "inverted" parallelism events.
+	 */
+	public long getInvertedParallelismCount() {
+		return invertedParallelismCount;
+	}
+
+	/**
+	 * @param invertedParallelismCount The number of "low" parallelism events.
+	 */
+	public void setInvertedParallelismCount(long invertedParallelismCount) {
+		this.invertedParallelismCount = invertedParallelismCount;
+	}
+
+	/**
+	 * @return The <code>ParallelCollection</code> event with the lowest "inverted"
+	 *         parallelism.
+	 */
+	public LogEvent getWorstInvertedParallelismEvent() {
+		return worstInvertedParallelismEvent;
+	}
+
+	/**
+	 * @param worstInvertedParallelismEvent The <code>ParallelCollection</code>
+	 *                                      event with the lowest "inverted"
+	 *                                      parallelism.
+	 */
+	public void setWorstInvertedParallelismEvent(LogEvent worstInvertedParallelismEvent) {
+		this.worstInvertedParallelismEvent = worstInvertedParallelismEvent;
+	}
+
+	/**
+	 * @return The maximum heap space in non <code>BlockingEvent</code>s.
+	 */
+	public int getMaxHeapSpaceNonBlocking() {
+		return maxHeapSpaceNonBlocking;
+	}
+
+	/**
+	 * @param maxHeapSpaceNonBlocking The maximum heap space in non
+	 *                                <code>BlockingEvent</code>s.
+	 */
+	public void setMaxHeapSpaceNonBlocking(int maxHeapSpaceNonBlocking) {
+		this.maxHeapSpaceNonBlocking = maxHeapSpaceNonBlocking;
+	}
+
+	/**
+	 * @return The maximum heap occupancy in non <code>BlockingEvent</code>s.
+	 */
+	public int getMaxHeapOccupancyNonBlocking() {
+		return maxHeapOccupancyNonBlocking;
+	}
+
+	/**
+	 * @param maxHeapOccupancyNonBlocking The maximum heap occupancy in non
+	 *                                    <code>BlockingEvent</code>s.
+	 */
+	public void setMaxHeapOccupancyNonBlocking(int maxHeapOccupancyNonBlocking) {
+		this.maxHeapOccupancyNonBlocking = maxHeapOccupancyNonBlocking;
+	}
+
+	/**
+	 * @return The maximum perm space in non <code>BlockingEvent</code>s.
+	 */
+	public int getMaxPermSpaceNonBlocking() {
+		return maxPermSpaceNonBlocking;
+	}
+
+	/**
+	 * @param maxPermSpaceNonBlocking The maximum perm space in non
+	 *                                <code>BlockingEvent</code>s.
+	 */
+	public void setMaxPermSpaceNonBlocking(int maxPermSpaceNonBlocking) {
+		this.maxPermSpaceNonBlocking = maxPermSpaceNonBlocking;
+	}
+
+	/**
+	 * @return The maximum perm occupancy in non <code>BlockingEvent</code>s.
+	 */
+	public int getMaxPermOccupancyNonBlocking() {
+		return maxPermOccupancyNonBlocking;
+	}
+
+	/**
+	 * @param maxPermOccupancyNonBlocking The maximum perm occupancy in non
+	 *                                    <code>BlockingEvent</code>s.
+	 */
+	public void setMaxPermOccupancyNonBlocking(int maxPermOccupancyNonBlocking) {
+		this.maxPermOccupancyNonBlocking = maxPermOccupancyNonBlocking;
+	}
+
+	private static Pst intern(BlockingEvent event) {
+		Pst pst = new Pst();
+		pst.timeStamp = event.getTimestamp();
+		pst.eventName = event.getName();
+		pst.duration = event.getDuration();
+		pst.logEntry = event.getLogEntry();
+		if (event instanceof YoungData) {
+			YoungData youngData = (YoungData) event;
+			pst.youngSpace = youngData.getYoungSpace();
+			pst.youngOccupancyInit = youngData.getYoungOccupancyInit();
+			pst.youngOccupancyEnd = youngData.getYoungOccupancyEnd();
+		}
+		if (event instanceof OldData) {
+			OldData oldData = (OldData) event;
+			pst.oldSpace = oldData.getOldSpace();
+			pst.oldOccupancyInit = oldData.getOldOccupancyInit();
+			pst.oldOccupancyEnd = oldData.getOldOccupancyEnd();
+		}
+		if (event instanceof CombinedData) {
+			CombinedData combinedData = (CombinedData) event;
+			pst.combinedSpace = combinedData.getCombinedSpace();
+			pst.combinedOccupancyInit = combinedData.getCombinedOccupancyInit();
+			pst.combinedOccupancyEnd = combinedData.getCombinedOccupancyEnd();
+		}
+		if (event instanceof PermMetaspaceData) {
+			PermMetaspaceData permMetaspaceData = (PermMetaspaceData) event;
+			pst.permSpace = permMetaspaceData.getPermSpace();
+			pst.permOccupancyInit = permMetaspaceData.getPermOccupancyInit();
+			pst.permOccupancyEnd = permMetaspaceData.getPermOccupancyEnd();
+		}
+		return pst;
+	}
+
+	/**
+	 * The maximum GC blocking event pause time.
+	 * 
+	 * @return maximum pause duration (milliseconds).
+	 */
+	public synchronized int getMaxGcPause() {
+		return convertMicrosToMillis(
+				ints(this.blockingEvents, Pst::getDuration).mapToInt(Integer::valueOf).max().orElse(0)).intValue();
+	}
+
+	/**
+	 * The total blocking event pause time.
+	 * 
+	 * @return total pause duration (milliseconds).
+	 */
+	public synchronized long getTotalGcPause() {
+		return convertMicrosToMillis(ints(this.blockingEvents, Pst::getDuration).collect(summingLong(Long::valueOf))).longValue();
+	}
+
+	private static <T> Stream<Integer> ints(List<T> list, Function<T, Integer> function) {
+		return list.stream().map(function).filter(Objects::nonNull);
+	}
+
+	private static <T> LongStream longs(List<T> list, Function<T, Memory> function) {
+		return list.stream().map(function).filter(Objects::nonNull).mapToLong(m -> m.getValue(KILOBYTES));
+	}
+
+	/**
+	 * The first blocking event.
+	 * 
+	 * TODO: Should this consider non-blocking events?
+	 * 
+	 * @return The first blocking event.
+	 */
+	public synchronized BlockingEvent getFirstGcEvent() {
+		return this.blockingEvents.isEmpty() ? null
+				: (BlockingEvent) JdkUtil.parseLogLine(this.blockingEvents.get(0).getLogEntry());
+	}
+
+	/**
+	 * Retrieve the last blocking event.
+	 * 
+	 * TODO: Should this consider non-blocking events?
+	 * 
+	 * @return The last blocking event.
+	 */
+	public synchronized BlockingEvent getLastGcEvent() {
+		// Retrieve last event from batch or database.
+		return this.blockingEvents.isEmpty() ? null
+				: (BlockingEvent) JdkUtil
+						.parseLogLine(this.blockingEvents.get(blockingEvents.size() - 1).getLogEntry());
+	}
+
+	/**
+	 * Delete table(s). Useful when running in server mode during development.
+	 */
+	public synchronized void cleanup() {
+		this.blockingEvents.clear();
+		JvmDao.created = false;
+	}
+
+	/**
+	 * Retrieve all <code>BlockingEvent</code>s.
+	 * 
+	 * @return <code>List</code> of events.
+	 */
+	public synchronized List<BlockingEvent> getBlockingEvents() {
+		return this.blockingEvents.stream().sorted(comparing(Pst::getTimeStamp))
+				.map(pst -> hydrateBlockingEvent(determineEventType(pst.getEventName()), pst.getLogEntry(),
+						pst.getTimeStamp(), pst.getDuration()))
+				.collect(toList());
+	}
+
+	/**
+	 * Retrieve all <code>BlockingEvent</code>s of the specified type.
+	 * 
+	 * @param eventType The event type to retrieve.
+	 * @return <code>List</code> of events.
+	 */
+	public synchronized List<BlockingEvent> getBlockingEvents(LogEventType eventType) {
+		return this.blockingEvents.stream().filter(e -> e.getEventName().equals(eventType.toString()))
+				.sorted(comparing(Pst::getTimeStamp))
+				.map(pst -> hydrateBlockingEvent(eventType, pst.getLogEntry(), pst.getTimeStamp(), pst.getDuration()))
+				.collect(toList());
+	}
+
+	/**
+	 * The total number of blocking events.
+	 * 
+	 * @return total number of blocking events.
+	 */
+	public synchronized int getBlockingEventCount() {
+		return this.blockingEvents.size();
+	}
+
+	/**
+	 * The maximum young space size during the JVM run.
+	 * 
+	 * @return maximum young space size (kilobytes).
+	 */
+	public synchronized int getMaxYoungSpace() {
+		return (int) longs(this.blockingEvents, Pst::getYoungSpace).max().orElse(0);
+	}
+
+	/**
+	 * The maximum old space size during the JVM run.
+	 * 
+	 * @return maximum old space size (kilobytes).
+	 */
+	public synchronized int getMaxOldSpace() {
+		return (int) longs(this.blockingEvents, Pst::getOldSpace).max().orElse(0);
+	}
+
+	/**
+	 * The maximum heap space size during the JVM run.
+	 * 
+	 * @return maximum heap size (kilobytes).
+	 */
+	public synchronized int getMaxHeapSpace() {
+		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungSpace(), t.getOldSpace()))
+				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+	}
+
+	/**
+	 * The maximum heap occupancy during the JVM run.
+	 * 
+	 * @return maximum heap occupancy (kilobytes).
+	 */
+	public synchronized int getMaxHeapOccupancy() {
+		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyInit(), t.getOldOccupancyInit()))
+				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+	}
+
+	private static Memory add(Memory m1, Memory m2) {
+		return m1 == null ? nullSafe(m2) : m1.plus(nullSafe(m2));
+	}
+
+	private static Memory nullSafe(Memory memory) {
+		return memory == null ? ZERO : memory;
+	}
+
+	/**
+	 * The maximum heap after GC during the JVM run.
+	 * 
+	 * @return maximum heap after GC (kilobytes).
+	 */
+	public synchronized int getMaxHeapAfterGc() {
+		return (int) this.blockingEvents.stream().map(t -> add(t.getYoungOccupancyEnd(), t.getOldOccupancyEnd()))
+				.mapToLong(m -> m.getValue(KILOBYTES)).max().orElse(0);
+	}
+
+	/**
+	 * The maximum perm/metaspace size during the JVM run.
+	 * 
+	 * @return maximum perm/metaspace footprint (kilobytes).
+	 */
+	public synchronized int getMaxPermSpace() {
+		return (int) longs(this.blockingEvents, Pst::getPermSpace).max().orElse(0);
+	}
+
+	/**
+	 * The maximum perm/metaspace occupancy during the JVM run.
+	 * 
+	 * @return maximum perm/metaspac occupancy (kilobytes).
+	 */
+	public synchronized int getMaxPermOccupancy() {
+		return (int) longs(this.blockingEvents, Pst::getPermOccupancyInit).max().orElse(0);
+	}
+
+	/**
+	 * The maximum perm/metaspace after GC during the JVM run.
+	 * 
+	 * @return maximum perm/metaspac after GC (kilobytes).
+	 */
+	public synchronized int getMaxPermAfterGc() {
+		return (int) longs(this.blockingEvents, Pst::getPermOccupancyEnd).max().orElse(0);
+	}
+
+	/**
+	 * The first stopped event.
+	 * 
+	 * @return The time first stopped event.
+	 */
+	public synchronized ApplicationStoppedTimeEvent getFirstStoppedEvent() {
+		return stoppedTimeEvents.isEmpty() ? null
+				: (ApplicationStoppedTimeEvent) JdkUtil.parseLogLine(stoppedTimeEvents.get(0).getLogEntry());
+	}
+
+	/**
+	 * Retrieve the last stopped event.
+	 * 
+	 * @return The last stopped event.
+	 */
+	public synchronized ApplicationStoppedTimeEvent getLastStoppedEvent() {
+		// Retrieve last event from batch or database.
+		return stoppedTimeEvents.isEmpty() ? queryStoppedLastEvent()
+				: stoppedTimeEvents.get(stoppedTimeEvents.size() - 1);
+	}
+
+	/**
+	 * Retrieve the last stopped event from the database.
+	 * 
+	 * @return The last stopped event in database.
+	 */
+
+	private synchronized ApplicationStoppedTimeEvent queryStoppedLastEvent() {
+		return stoppedTimeEvents.isEmpty() ? null
+				: (ApplicationStoppedTimeEvent) JdkUtil
+						.parseLogLine(stoppedTimeEvents.get(stoppedTimeEvents.size() - 1).getLogEntry());
+	}
+
+	/**
+	 * The maximum stopped time event pause time.
+	 * 
+	 * @return maximum pause duration (milliseconds).
+	 */
+	public synchronized int getMaxStoppedTime() {
+		return convertMicrosToMillis(
+				ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration).collect(summingLong(Long::valueOf))).intValue();
+	}
+
+	/**
+	 * The total stopped time event pause time.
+	 * 
+	 * @return total pause duration (milliseconds).
+	 */
+	public synchronized int getTotalStoppedTime() {
+		return convertMicrosToMillis(ints(this.stoppedTimeEvents, ApplicationStoppedTimeEvent::getDuration)
+				.collect(summingLong(Long::valueOf))).intValue();
+	}
+
+	/**
+	 * The total number of stopped time events.
+	 * 
+	 * @return total number of stopped time events.
+	 */
+	public synchronized int getStoppedTimeEventCount() {
+		return this.stoppedTimeEvents.size();
+	}
+
 }

--- a/src/main/java/org/eclipselabs/garbagecat/service/GcManager.java
+++ b/src/main/java/org/eclipselabs/garbagecat/service/GcManager.java
@@ -817,13 +817,7 @@ public class GcManager {
                     }
                 }
             }
-
-            // Process final batches
-            jvmDao.processBlockingBatch();
-            jvmDao.processStoppedTimeBatch();
-        } catch (
-
-        FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
+++ b/src/test/java/org/eclipselabs/garbagecat/hsql/TestJvmDao.java
@@ -41,7 +41,6 @@ class TestJvmDao {
                 + " [Tenured: 468292K->482213K(819200K), 1.9920590 secs] 824995K->482213K(1187840K),"
                 + " [Perm : 123092K->122684K(262144K)], 1.9924510 secs]");
         jvmDao.addBlockingEvent(event3);
-        jvmDao.processBlockingBatch();
 
         // check they are the correct way around
         List<BlockingEvent> events = jvmDao.getBlockingEvents();


### PR DESCRIPTION
Because I failed upgrading hsqldb, I asked myself why hsqldb is used inside the project. 
I could not really find one so I removed it. If someone would like to write LogEntries to some kind of database it's a bad idea to purge the hsqldb from master. So please consider carefully if you like to accept this PR (and I totally understand if this PR will not be accepted). 

With the migration of the codebase to JAVA 8 and the possibility to use the Stream API things became possible to get implemented much easier than before and to replace the SQL by stream/filter/map. 

In fact I see this solution as one of many possible solutions. I just wanted to inform you about the solution done by me and offer you the possibility to adopt it, if you like to do so. 