### PR TITLE
inserting events at positions based on their timestamps

### DIFF
--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -185,8 +185,16 @@ public class JvmDao {
     }
 
     public void addBlockingEvent(BlockingEvent event) {
+        blockingEvents.add(insertPosition(event), event);
+    }
+
+    private int insertPosition(BlockingEvent event) {
+        int size = blockingEvents.size();
+        if (size > 0 && COMPARE_BY_TIMESTAMP.compare(blockingEvents.get(size - 1), event) > 0) {
+            return size;
+        }
         int index = binarySearch(blockingEvents, event, COMPARE_BY_TIMESTAMP);
-        blockingEvents.add(index >= 0 ? index + 1 : -index - 1, event);
+        return index >= 0 ? index + 1 : -index - 1;
     }
 
     public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {

--- a/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
+++ b/src/main/java/org/eclipselabs/garbagecat/hsql/JvmDao.java
@@ -190,11 +190,12 @@ public class JvmDao {
 
     private int insertPosition(BlockingEvent event) {
         int size = blockingEvents.size();
-        if (size > 0 && COMPARE_BY_TIMESTAMP.compare(blockingEvents.get(size - 1), event) > 0) {
+        if (size > 0 && COMPARE_BY_TIMESTAMP.compare(blockingEvents.get(size - 1), event) <= 0) {
             return size;
         }
-        int index = binarySearch(blockingEvents, event, COMPARE_BY_TIMESTAMP);
-        return index >= 0 ? index + 1 : -index - 1;
+        // here we could raise an Exception: Add param boolean reorderingAllowed to method 
+        // if (!reorderingAllowed) throw new TimeWarpException("bad order")
+        return -binarySearch(blockingEvents, event, COMPARE_BY_TIMESTAMP) - 1;
     }
 
     public void addStoppedTimeEvent(ApplicationStoppedTimeEvent event) {


### PR DESCRIPTION
Based on the comment regarding performance, here's another approach to investigate: 
Instead of having sorted streams when accessing the list, insert the events based on there timestamp at the right index when adding them to the list. Of course the more often the list is read/accessed the more performance you will gain. I guess that performance will increase even if it's accessed just once because creating a sorted stream is a relatively expensive operation since the underlying collection has to be sorted in memory before the first element can be accessed. 

However, there are some semantic changes due to this change: There have been several statemens that blindly accesses head/tail elements in the list which is on `master` the sequence the elements were added and on `sortedlist` the first or last element based on the events' timestamps. However: All test are green so it seems that this already was the expected behavior. 
Could you please verify using some big gc logs since I only can do some repeating tests with some small gc logs can of course lead to completely different measurements. 