### PR TITLE
Fix 151 alternative

### DIFF
--- a/src/main/java/org/eclipselabs/garbagecat/util/jdk/unified/UnifiedUtil.java
+++ b/src/main/java/org/eclipselabs/garbagecat/util/jdk/unified/UnifiedUtil.java
@@ -28,7 +28,7 @@ import org.eclipselabs.garbagecat.util.jdk.JdkUtil.LogEventType;
  */
 public final class UnifiedUtil {
 
-    private static final Date jvmStartDate = GcUtil.parseStartDateTime("2000-01-01 00:00:00.000");
+    private static final Date jvmStartDate = GcUtil.parseDateStamp("2000-01-01T00:00:00.000-0500");
 
     private UnifiedUtil() {
         super();


### PR DESCRIPTION
This PR fixes the failing test, see #155 

The main part is an alternative implementation for the fix of the issue. Code always should follow the [four rules of simple design](https://martinfowler.com/bliki/BeckDesignRules.html). So the highest priority is that the code should do what it should do (which the code already did after your fix). Second priority is "reveals intention" so please take a look in the previous and my implementation and decide in which implementation this aspect is fulfilled better. 

In my opinion it's clearer what your code is doing. But: The steams are processed twice. I don't think that really is a performance problem, perhaps it even isn't measurable. So please merge the PR if you think, the code done by me is better readable **or** if there is really a performance issue when consuming the list/stream twice. 

When not accepting the PR, please fix the timezone issue mentioned above. 

