### PR TITLE
Added allocation rate for G1GC and cached Regex patterns

### DIFF
--- a/src/main/java/org/eclipselabs/garbagecat/Main.java
+++ b/src/main/java/org/eclipselabs/garbagecat/Main.java
@@ -33,8 +33,8 @@ import static org.eclipselabs.garbagecat.util.Constants.OPTION_THRESHOLD_SHORT;
 import static org.eclipselabs.garbagecat.util.Constants.OPTION_VERSION_LONG;
 import static org.eclipselabs.garbagecat.util.Constants.OUTPUT_FILE_NAME;
 import static org.eclipselabs.garbagecat.util.GcUtil.parseStartDateTime;
+import static org.eclipselabs.garbagecat.util.Memory.Unit.*;
 import static org.eclipselabs.garbagecat.util.Memory.ZERO;
-import static org.eclipselabs.garbagecat.util.Memory.Unit.KILOBYTES;
 import static org.eclipselabs.garbagecat.util.jdk.Analysis.INFO_PERM_GEN;
 import static org.eclipselabs.garbagecat.util.jdk.Analysis.INFO_UNACCOUNTED_OPTIONS_DISABLED;
 
@@ -56,6 +56,7 @@ import org.apache.commons.cli.ParseException;
 import org.eclipselabs.garbagecat.domain.JvmRun;
 import org.eclipselabs.garbagecat.domain.jdk.unified.SafepointEventSummary;
 import org.eclipselabs.garbagecat.service.GcManager;
+import org.eclipselabs.garbagecat.util.Memory;
 import org.eclipselabs.garbagecat.util.jdk.Analysis;
 import org.eclipselabs.garbagecat.util.jdk.JdkMath;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
@@ -371,6 +372,18 @@ public class Main {
                     printWriter.write("~");
                 }
                 printWriter.write(jvmRun.getGcThroughput() + "%" + LINE_SEPARATOR);
+
+                // As of now the allocation rate is only implemented for G1GC collector.
+                if (jvmRun.getJvm().getUseG1Gc() != null ||
+                        jvmRun.getEventTypes().contains(LogEventType.G1_YOUNG_PAUSE)) {
+                    BigDecimal allocationRate = jvmRun.getAllocationRate();
+                    if (allocationRate.longValue() > 0) {
+                        Memory gbPerSec = Memory.memory(allocationRate.longValue(), KILOBYTES);
+                        printWriter.write("Allocation Rate: " + Long.toString(gbPerSec.getValue(MEGABYTES))
+                                + " MB/sec" + LINE_SEPARATOR);
+                    }
+                }
+
                 // GC max pause
                 BigDecimal maxGcPause = JdkMath.convertMillisToSecs(jvmRun.getMaxGcPause());
                 printWriter.write("GC Pause Max: " + maxGcPause.toString() + " secs" + LINE_SEPARATOR);
@@ -397,6 +410,7 @@ public class Main {
                     printWriter.write("GC/Stopped Ratio: " + jvmRun.getGcStoppedRatio() + "%" + LINE_SEPARATOR);
                 }
             }
+
             if (jvmRun.getUnifiedSafepointEventCount() > 0) {
                 // Stopped time throughput
                 printWriter.write("Safepoint Throughput: ");

--- a/src/main/java/org/eclipselabs/garbagecat/domain/ApplicationLoggingEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/ApplicationLoggingEvent.java
@@ -14,6 +14,10 @@ package org.eclipselabs.garbagecat.domain;
 
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * APPLICATION_LOGGING
@@ -97,6 +101,8 @@ public class ApplicationLoggingEvent implements ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -106,6 +112,12 @@ public class ApplicationLoggingEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -138,8 +150,9 @@ public class ApplicationLoggingEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean isMatch = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_LIST.size(); i++) {
+            Pattern pattern = REGEX_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 isMatch = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/JvmRun.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/JvmRun.java
@@ -87,6 +87,11 @@ public class JvmRun {
     private long gcPauseTotal;
 
     /**
+     * Memory being allocated per second (kilobytes).
+     */
+    private BigDecimal allocationRate;
+
+    /**
      * Number of <code>ParallelCollection</code> with "inverted" parallelism.
      */
     private long invertedParallelismCount;
@@ -945,6 +950,18 @@ public class JvmRun {
         BigDecimal ratio = new BigDecimal(gcPauseTotal);
         ratio = ratio.divide(new BigDecimal(stoppedTimeTotal), 2, HALF_EVEN);
         return ratio.movePointRight(2).longValue();
+    }
+
+    /**
+     *
+     * @return The amount of memory allocated per time unit expressed in MB/sec
+     */
+    public BigDecimal getAllocationRate() {
+        return allocationRate;
+    }
+
+    public void setAllocationRate(BigDecimal mbPerSecond) {
+        allocationRate = mbPerSecond;
     }
 
     /**

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ClassHistogramEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ClassHistogramEvent.java
@@ -17,6 +17,10 @@ import org.eclipselabs.garbagecat.domain.TimesData;
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * CLASS_HISTOGRAM
@@ -98,6 +102,8 @@ public class ClassHistogramEvent implements ThrowAwayEvent {
              */
             "^" + REGEX_PREPROCESSED + TimesData.REGEX + "?[ ]*$" };
 
+    private static final List<Pattern> REGEX_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -107,6 +113,12 @@ public class ClassHistogramEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -140,8 +152,9 @@ public class ClassHistogramEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean isMatch = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_LIST.size(); i++) {
+            Pattern pattern = REGEX_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 isMatch = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/CmsRemarkEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/CmsRemarkEvent.java
@@ -173,6 +173,8 @@ public class CmsRemarkEvent extends CmsIncrementalModeCollector
             + "\\])?[ ]{0,1}\\[1 CMS-remark: " + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\)\\] " + JdkRegEx.SIZE_K
             + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + "?[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * Regular expression for class unloading enabled with <code>-XX:+CMSClassUnloadingEnabled</code>.
      * 
@@ -192,12 +194,16 @@ public class CmsRemarkEvent extends CmsIncrementalModeCollector
             + "\\]))( )?\\[1 CMS-remark: " + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\)\\] " + JdkRegEx.SIZE_K
             + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + "?[ ]*$";
 
+    private static final Pattern REGEX_CLASS_UNLOADING_PATTERN = Pattern.compile(REGEX_CLASS_UNLOADING);
+
     /**
      * Regular expression defining truncated logging due to -XX:+CMSScavengeBeforeRemark -XX:+PrintHeapAtGC:
      */
     private static final String REGEX_TRUNCATED = "^(" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP
             + ": \\[GC( \\((" + JdkRegEx.TRIGGER_CMS_FINAL_REMARK + ")\\)[ ]{0,1})?\\[YG occupancy: " + JdkRegEx.SIZE_K
             + " \\(" + JdkRegEx.SIZE_K + "\\)\\]$";
+
+    private static final Pattern REGEX_TRUNCATED_PATTERN = Pattern.compile(REGEX_TRUNCATED);
 
     /**
      * Create event from log entry.
@@ -325,6 +331,8 @@ public class CmsRemarkEvent extends CmsIncrementalModeCollector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX) || logLine.matches(REGEX_CLASS_UNLOADING) || logLine.matches(REGEX_TRUNCATED);
+        return REGEX_PATTERN.matcher(logLine).matches() ||
+                REGEX_CLASS_UNLOADING_PATTERN.matcher(logLine).matches() ||
+                REGEX_TRUNCATED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/CmsSerialOldEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/CmsSerialOldEvent.java
@@ -251,6 +251,8 @@ public class CmsSerialOldEvent extends CmsIncrementalModeCollector implements Bl
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\)\\]" + JdkRegEx.ICMS_DC_BLOCK + "?, "
             + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + "?[ ]*$";
 
+    private static final Pattern REGEX_FULL_GC_PATTERN = Pattern.compile(REGEX_FULL_GC);
+
     /**
      * Regular expression defining the logging beginning with "GC".
      */
@@ -266,6 +268,8 @@ public class CmsSerialOldEvent extends CmsIncrementalModeCollector implements Bl
             + JdkRegEx.SIZE_K + "\\)(, \\[(CMS Perm |Perm |Metaspace): " + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K
             + "\\(" + JdkRegEx.SIZE_K + "\\)\\])?" + JdkRegEx.ICMS_DC_BLOCK + "?, " + JdkRegEx.DURATION + "\\])?"
             + TimesData.REGEX + "?[ ]*$";
+
+    private static final Pattern REGEX_GC_PATTERN = Pattern.compile(REGEX_GC);
 
     /**
      * Create event from log entry.
@@ -495,6 +499,6 @@ public class CmsSerialOldEvent extends CmsIncrementalModeCollector implements Bl
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static boolean match(String logLine) {
-        return logLine.matches(REGEX_FULL_GC) || logLine.matches(REGEX_GC);
+        return REGEX_FULL_GC_PATTERN.matcher(logLine).matches() || REGEX_GC_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FlsStatisticsEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FlsStatisticsEvent.java
@@ -16,6 +16,10 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * FLS_STATISTICS
@@ -194,6 +198,8 @@ public class FlsStatisticsEvent implements ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -203,6 +209,12 @@ public class FlsStatisticsEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -236,8 +248,9 @@ public class FlsStatisticsEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean isMatch = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_LIST.size(); i++) {
+            Pattern pattern = REGEX_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 isMatch = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FooterHeapEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FooterHeapEvent.java
@@ -17,6 +17,10 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * FOOTER_HEAP
@@ -191,6 +195,8 @@ public class FooterHeapEvent implements ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -200,6 +206,12 @@ public class FooterHeapEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -233,8 +245,9 @@ public class FooterHeapEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FooterStatsEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/FooterStatsEvent.java
@@ -16,6 +16,10 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * FOOTER_STATS
@@ -538,6 +542,8 @@ public class FooterStatsEvent implements ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -547,6 +553,12 @@ public class FooterStatsEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -580,8 +592,9 @@ public class FooterStatsEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/G1YoungInitialMarkEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/G1YoungInitialMarkEvent.java
@@ -81,6 +81,8 @@ public class G1YoungInitialMarkEvent extends G1Collector
             + ")\\) )?\\(young\\) \\(initial-mark\\)(--)? " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\), " + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + "?[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * Regular expression preprocessed.
      * 
@@ -99,6 +101,8 @@ public class G1YoungInitialMarkEvent extends G1Collector
             + "\\(" + JdkRegEx.SIZE + "\\) Survivors: " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + " Heap: "
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\)->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\)\\]"
             + TimesData.REGEX + "?)?[ ]*$";
+
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
 
     /**
      * The log entry for the event. Can be used for debugging purposes.
@@ -158,10 +162,12 @@ public class G1YoungInitialMarkEvent extends G1Collector
      */
     public G1YoungInitialMarkEvent(String logEntry) {
         this.logEntry = logEntry;
-        if (logEntry.matches(REGEX)) {
+
+        Matcher matcher;
+
+        if ((matcher = REGEX_PATTERN.matcher(logEntry)).matches()) {
             // standard format
-            Pattern pattern = Pattern.compile(REGEX);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.find()) {
                 timestamp = JdkMath.convertSecsToMillis(matcher.group(11)).longValue();
                 trigger = matcher.group(13);
@@ -175,10 +181,9 @@ public class G1YoungInitialMarkEvent extends G1Collector
                     timeReal = JdkMath.convertSecsToCentis(matcher.group(30)).intValue();
                 }
             }
-        } else if (logEntry.matches(REGEX_PREPROCESSED)) {
+        } else if ((matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry)).matches()) {
             // preprocessed format
-            Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.find()) {
                 timestamp = JdkMath.convertSecsToMillis(matcher.group(11)).longValue();
                 if (matcher.group(13) != null) {
@@ -280,6 +285,6 @@ public class G1YoungInitialMarkEvent extends G1Collector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX) || logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PATTERN.matcher(logLine).matches() || REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/GcInfoEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/GcInfoEvent.java
@@ -17,6 +17,10 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * GC_INFO
@@ -139,6 +143,14 @@ public class GcInfoEvent implements ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -181,8 +193,9 @@ public class GcInfoEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/HeapAtGcEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/HeapAtGcEvent.java
@@ -16,6 +16,10 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * HEAP_AT_GC
@@ -273,6 +277,8 @@ public class HeapAtGcEvent implements ThrowAwayEvent {
             //
             "^  the space.+$" };
 
+    private static final List<Pattern> REGEX_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -282,6 +288,12 @@ public class HeapAtGcEvent implements ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -315,8 +327,9 @@ public class HeapAtGcEvent implements ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean isMatch = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_LIST.size(); i++) {
+            Pattern pattern = REGEX_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 isMatch = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ShenandoahStatsEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ShenandoahStatsEvent.java
@@ -16,6 +16,10 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * SHENANDOAH_STATS
@@ -133,6 +137,14 @@ public class ShenandoahStatsEvent extends ShenandoahCollector implements ThrowAw
             //
     };
 
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
+
     public String getLogEntry() {
         throw new UnsupportedOperationException("Event does not include log entry information");
     }
@@ -154,8 +166,9 @@ public class ShenandoahStatsEvent extends ShenandoahCollector implements ThrowAw
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ShenandoahTriggerEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/ShenandoahTriggerEvent.java
@@ -17,6 +17,10 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * SHENANDOAH_TRIGGER
@@ -84,6 +88,13 @@ public class ShenandoahTriggerEvent extends ShenandoahCollector implements Throw
             //
     };
 
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
+
     public String getLogEntry() {
         throw new UnsupportedOperationException("Event does not include log entry information");
     }
@@ -105,8 +116,9 @@ public class ShenandoahTriggerEvent extends ShenandoahCollector implements Throw
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedBlankLineEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedBlankLineEvent.java
@@ -16,6 +16,8 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * UNIFIED_BLANK_LINE
@@ -30,6 +32,8 @@ public class UnifiedBlankLineEvent implements ThrowAwayEvent {
      * Regular expression defining the logging.
      */
     private static final String REGEX = UnifiedRegEx.BLANK_LINE;
+
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
 
     /**
      * The log entry for the event. Can be used for debugging purposes.
@@ -72,6 +76,6 @@ public class UnifiedBlankLineEvent implements ThrowAwayEvent {
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX);
+        return REGEX_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedConcurrentEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedConcurrentEvent.java
@@ -19,6 +19,10 @@ import org.eclipselabs.garbagecat.util.jdk.JdkRegEx;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * UNIFIED_CONCURRENT
@@ -169,6 +173,12 @@ public class UnifiedConcurrentEvent extends UnknownCollector implements UnifiedL
             "^" + UnifiedRegEx.DECORATOR + " Using \\d workers of \\d for marking$"
             //
     };
+    private static final List<Pattern> REGEX_PATTERN_LIST = new ArrayList<>(REGEX.length);
+    static {
+        for (String regex : REGEX) {
+            REGEX_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     public String getLogEntry() {
         throw new UnsupportedOperationException("Event does not include log entry information");
@@ -191,8 +201,9 @@ public class UnifiedConcurrentEvent extends UnknownCollector implements UnifiedL
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_PATTERN_LIST.size(); i++) {
+            Pattern pattern = REGEX_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1CleanupEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1CleanupEvent.java
@@ -69,12 +69,16 @@ public class UnifiedG1CleanupEvent extends G1Collector
     private static final String REGEX = "^" + UnifiedRegEx.DECORATOR + " Pause Cleanup " + JdkRegEx.SIZE + "->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + "[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * Regular expression defining preprocessed logging.
      */
     private static final String REGEX_PREPROCESSED = "^" + UnifiedRegEx.DECORATOR + " Pause Cleanup " + JdkRegEx.SIZE
             + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + TimesData.REGEX_JDK9
             + "[ ]*$";
+
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
 
     /**
      * The log entry for the event. Can be used for debugging purposes.
@@ -129,9 +133,11 @@ public class UnifiedG1CleanupEvent extends G1Collector
      */
     public UnifiedG1CleanupEvent(String logEntry) {
         this.logEntry = logEntry;
-        if (logEntry.matches(REGEX)) {
-            Pattern pattern = Pattern.compile(REGEX);
-            Matcher matcher = pattern.matcher(logEntry);
+
+        Matcher matcher;
+
+        if ((matcher = REGEX_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 long endTimestamp;
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
@@ -158,9 +164,8 @@ public class UnifiedG1CleanupEvent extends G1Collector
                 timeUser = TimesData.NO_DATA;
                 timeReal = TimesData.NO_DATA;
             }
-        } else if (logEntry.matches(REGEX_PREPROCESSED)) {
-            Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
                     timestamp = Long.parseLong(matcher.group(12));
@@ -262,6 +267,6 @@ public class UnifiedG1CleanupEvent extends G1Collector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX) || logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PATTERN.matcher(logLine).matches() || REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1FullGcEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1FullGcEvent.java
@@ -79,6 +79,8 @@ public class UnifiedG1FullGcEvent extends G1Collector
             + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + TimesData.REGEX_JDK9
             + "[ ]*$";
 
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -153,8 +155,7 @@ public class UnifiedG1FullGcEvent extends G1Collector
     public UnifiedG1FullGcEvent(String logEntry) {
         this.logEntry = logEntry;
 
-        Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-        Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry);
         if (matcher.find()) {
             if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
                 timestamp = Long.parseLong(matcher.group(12));
@@ -287,6 +288,6 @@ public class UnifiedG1FullGcEvent extends G1Collector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1InfoEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1InfoEvent.java
@@ -16,6 +16,10 @@ import org.eclipselabs.garbagecat.domain.ThrowAwayEvent;
 import org.eclipselabs.garbagecat.util.jdk.JdkUtil;
 import org.eclipselabs.garbagecat.util.jdk.unified.UnifiedRegEx;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * <p>
  * UNIFIED_G1_INFO
@@ -45,6 +49,8 @@ public class UnifiedG1InfoEvent implements UnifiedLogging, ThrowAwayEvent {
             //
     };
 
+    private static final List<Pattern> REGEX_LIST = new ArrayList<>(REGEX.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -54,6 +60,12 @@ public class UnifiedG1InfoEvent implements UnifiedLogging, ThrowAwayEvent {
      * The time when the GC event started in milliseconds after JVM startup.
      */
     private long timestamp;
+
+    static {
+        for (String regex : REGEX) {
+            REGEX_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -87,8 +99,9 @@ public class UnifiedG1InfoEvent implements UnifiedLogging, ThrowAwayEvent {
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        for (int i = 0; i < REGEX.length; i++) {
-            if (logLine.matches(REGEX[i])) {
+        for (int i = 0; i < REGEX_LIST.size(); i++) {
+            Pattern pattern = REGEX_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 match = true;
                 break;
             }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1MixedPauseEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1MixedPauseEvent.java
@@ -77,6 +77,8 @@ public class UnifiedG1MixedPauseEvent extends G1Collector implements UnifiedLogg
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION
             + TimesData.REGEX_JDK9 + "[ ]*$";
 
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -151,8 +153,7 @@ public class UnifiedG1MixedPauseEvent extends G1Collector implements UnifiedLogg
     public UnifiedG1MixedPauseEvent(String logEntry) {
         this.logEntry = logEntry;
 
-        Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-        Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry);
         if (matcher.find()) {
             if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
                 timestamp = Long.parseLong(matcher.group(12));
@@ -285,6 +286,6 @@ public class UnifiedG1MixedPauseEvent extends G1Collector implements UnifiedLogg
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungInitialMarkEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungInitialMarkEvent.java
@@ -70,6 +70,8 @@ public class UnifiedG1YoungInitialMarkEvent extends G1Collector
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION
             + TimesData.REGEX_JDK9 + "[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -127,9 +129,9 @@ public class UnifiedG1YoungInitialMarkEvent extends G1Collector
      */
     public UnifiedG1YoungInitialMarkEvent(String logEntry) {
         this.logEntry = logEntry;
-        if (logEntry.matches(REGEX)) {
-            Pattern pattern = Pattern.compile(REGEX);
-            Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher;
+        if ((matcher = REGEX_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 long endTimestamp;
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
@@ -233,6 +235,6 @@ public class UnifiedG1YoungInitialMarkEvent extends G1Collector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX);
+        return REGEX_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungPauseEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungPauseEvent.java
@@ -93,6 +93,8 @@ public class UnifiedG1YoungPauseEvent extends G1Collector implements UnifiedLogg
             + " Pause Young \\((Normal|Concurrent Start)\\) \\(" + TRIGGER + "\\) " + JdkRegEx.SIZE + "->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + "[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * Regular expression defining preprocessed logging.
      * 
@@ -103,6 +105,8 @@ public class UnifiedG1YoungPauseEvent extends G1Collector implements UnifiedLogg
             + " Pause Young( \\((Normal|Concurrent Start)\\))? \\(" + TRIGGER + "\\) Metaspace: " + JdkRegEx.SIZE + "->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + TimesData.REGEX_JDK9 + "[ ]*$";
+
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
 
     /**
      * The log entry for the event. Can be used for debugging purposes.
@@ -177,9 +181,9 @@ public class UnifiedG1YoungPauseEvent extends G1Collector implements UnifiedLogg
      */
     public UnifiedG1YoungPauseEvent(String logEntry) {
         this.logEntry = logEntry;
-        if (logEntry.matches(REGEX)) {
-            Pattern pattern = Pattern.compile(REGEX);
-            Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher;
+        if ((matcher = REGEX_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 long endTimestamp;
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
@@ -207,9 +211,8 @@ public class UnifiedG1YoungPauseEvent extends G1Collector implements UnifiedLogg
                 timeUser = TimesData.NO_DATA;
                 timeReal = TimesData.NO_DATA;
             }
-        } else if (logEntry.matches(REGEX_PREPROCESSED)) {
-            Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
                     timestamp = Long.parseLong(matcher.group(12));
@@ -343,6 +346,6 @@ public class UnifiedG1YoungPauseEvent extends G1Collector implements UnifiedLogg
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX) || logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PATTERN.matcher(logLine).matches() || REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungPrepareMixedEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedG1YoungPrepareMixedEvent.java
@@ -71,6 +71,8 @@ public class UnifiedG1YoungPrepareMixedEvent extends G1Collector implements Unif
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + TimesData.REGEX_JDK9 + "[ ]*$";
 
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -145,8 +147,7 @@ public class UnifiedG1YoungPrepareMixedEvent extends G1Collector implements Unif
     public UnifiedG1YoungPrepareMixedEvent(String logEntry) {
         this.logEntry = logEntry;
 
-        Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-        Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry);
         if (matcher.find()) {
             if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
                 timestamp = Long.parseLong(matcher.group(12));
@@ -279,6 +280,6 @@ public class UnifiedG1YoungPrepareMixedEvent extends G1Collector implements Unif
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedRemarkEvent.java
+++ b/src/main/java/org/eclipselabs/garbagecat/domain/jdk/unified/UnifiedRemarkEvent.java
@@ -65,12 +65,16 @@ public class UnifiedRemarkEvent extends UnknownCollector
     private static final String REGEX = "^" + UnifiedRegEx.DECORATOR + " Pause Remark " + JdkRegEx.SIZE + "->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + "[ ]*$";
 
+    private static final Pattern REGEX_PATTERN = Pattern.compile(REGEX);
+
     /**
      * Regular expression defining preprocessed logging.
      */
     private static final String REGEX_PREPROCESSED = "^" + UnifiedRegEx.DECORATOR + " Pause Remark " + JdkRegEx.SIZE
             + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + TimesData.REGEX_JDK9
             + "[ ]*$";
+
+    private static final Pattern REGEX_PREPROCESSED_PATTERN = Pattern.compile(REGEX_PREPROCESSED);
 
     /**
      * The log entry for the event. Can be used for debugging purposes.
@@ -110,9 +114,9 @@ public class UnifiedRemarkEvent extends UnknownCollector
      */
     public UnifiedRemarkEvent(String logEntry) {
         this.logEntry = logEntry;
-        if (logEntry.matches(REGEX)) {
-            Pattern pattern = Pattern.compile(REGEX);
-            Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher;
+        if ((matcher = REGEX_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 long endTimestamp;
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
@@ -136,9 +140,8 @@ public class UnifiedRemarkEvent extends UnknownCollector
                 timeUser = TimesData.NO_DATA;
                 timeReal = TimesData.NO_DATA;
             }
-        } else if (logEntry.matches(REGEX_PREPROCESSED)) {
-            Pattern pattern = Pattern.compile(REGEX_PREPROCESSED);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_PREPROCESSED_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.find()) {
                 long endTimestamp;
                 if (matcher.group(1).matches(UnifiedRegEx.UPTIMEMILLIS)) {
@@ -227,6 +230,6 @@ public class UnifiedRemarkEvent extends UnknownCollector
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine) {
-        return logLine.matches(REGEX) || logLine.matches(REGEX_PREPROCESSED);
+        return REGEX_PATTERN.matcher(logLine).matches() || REGEX_PREPROCESSED_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ApplicationStoppedTimePreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/ApplicationStoppedTimePreprocessAction.java
@@ -77,17 +77,24 @@ public class ApplicationStoppedTimePreprocessAction implements PreprocessAction 
             + ")(: \\[CMS-concurrent-(abortable-preclean|mark|preclean): " + JdkRegEx.DURATION_FRACTION
             + "\\])?(Total time for which application threads were stopped: \\d{1,4}\\.\\d{7} seconds)$";
 
+    private static final Pattern REGEX_LINE1_PATTERN = Pattern.compile(REGEX_LINE1);
+
     /**
      * Regular expressions defining the 2nd logging line.
      */
     private static final String REGEX_LINE2 = "^(: \\[CMS-concurrent-abortable-preclean: " + JdkRegEx.DURATION_FRACTION
             + "\\])?" + TimesData.REGEX + "[ ]*$";
+
+    private static final Pattern REGEX_LINE2_PATTERN = Pattern.compile(REGEX_LINE2);
+
     /**
      * Regular expression for retained end.
      * 
      * [Times: user=0.15 sys=0.02, real=0.05 secs]
      */
     private static final String REGEX_RETAIN_END = "^" + TimesData.REGEX + "[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_END_PATTERN = Pattern.compile(REGEX_RETAIN_END);
 
     /**
      * Log entry in the entangle log list used to indicate the current high level preprocessor (e.g. CMS, G1). This
@@ -109,9 +116,9 @@ public class ApplicationStoppedTimePreprocessAction implements PreprocessAction 
      *            Information to make preprocessing decisions.
      */
     public ApplicationStoppedTimePreprocessAction(String logEntry, Set<String> context) {
-        if (logEntry.matches(REGEX_LINE1)) {
-            Pattern pattern = Pattern.compile(REGEX_LINE1);
-            Matcher matcher = pattern.matcher(logEntry);
+        Matcher matcher;
+        if ((matcher = REGEX_LINE1_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 // Split line1 logging apart
                 if (matcher.group(6) != null) {
@@ -126,9 +133,8 @@ public class ApplicationStoppedTimePreprocessAction implements PreprocessAction 
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_END)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_END_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
@@ -159,6 +165,8 @@ public class ApplicationStoppedTimePreprocessAction implements PreprocessAction 
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine, String priorLogLine) {
-        return logLine.matches(REGEX_LINE1) || logLine.matches(REGEX_LINE2) || logLine.matches(REGEX_RETAIN_END);
+        return REGEX_LINE1_PATTERN.matcher(logLine).matches()
+                || REGEX_LINE2_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_PATTERN.matcher(logLine).matches();
     }
 }

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/CmsPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/CmsPreprocessAction.java
@@ -195,6 +195,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + ": \\[CMS-concurrent-(abortable-preclean|mark|sweep|preclean|reset): " + JdkRegEx.DURATION_FRACTION
             + "\\]" + TimesData.REGEX + "?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT);
+
     /**
      * Regular expression for retained beginning PAR_NEW mixed with FLS_STATISTICS.
      * 
@@ -205,6 +208,9 @@ public class CmsPreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS = "^((" + JdkRegEx.DATESTAMP + ": )?"
             + JdkRegEx.TIMESTAMP + ": \\[GC( \\(" + JdkRegEx.TRIGGER_ALLOCATION_FAILURE + "\\))? )(Before GC:)$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS);
+
     /**
      * Regular expression for beginning CMS_SERIAL_OLD collection.
      * 
@@ -212,6 +218,9 @@ public class CmsPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_BEGINNING_SERIAL = "^((" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP
             + ": \\[Full GC (" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[Class Histogram:)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_SERIAL_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL);
 
     /**
      * Regular expression for beginning PAR_NEW collection.
@@ -232,6 +241,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]("
             + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[Class Histogram:)?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_PARNEW_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW);
+
     /**
      * Regular expression for retained beginning CMS_SERIAL_OLD mixed with CMS_CONCURRENT collection.
      * 
@@ -247,11 +259,17 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.TIMESTAMP + ": \\[CMS-concurrent-(mark|abortable-preclean|preclean|sweep): "
             + JdkRegEx.DURATION_FRACTION + "\\]" + TimesData.REGEX + "?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT);
+
     /**
      * Regular expression for retained beginning CMS_SERIAL_OLD bailing out collection.
      */
     private static final String REGEX_RETAIN_BEGINNING_SERIAL_BAILING = "^(" + JdkRegEx.TIMESTAMP + ": \\[Full GC "
             + JdkRegEx.TIMESTAMP + ": \\[CMSbailing out to foreground collection)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_SERIAL_BAILING_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_BAILING);
 
     /**
      * Regular expression for retained CMS_SERIAL_OLD with -XX:+UseGCOverheadLimit at end.
@@ -266,6 +284,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + "\\)\\] " + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\) \\[PSPermGen: "
             + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K
             + "\\)\\])(      |\t)GC time (would exceed|is exceeding) GCTimeLimit of 98%$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED);
 
     /**
      * Regular expression for retained beginning PrintHeapAtGC collection.
@@ -282,6 +303,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + "\\) )?(\\[YG occupancy: " + JdkRegEx.SIZE_K + " \\(" + JdkRegEx.SIZE_K
             + "\\)\\])?)\\{Heap before (gc|GC) invocations=\\d{1,10}( \\(full \\d{1,10}\\))?:[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC);
+
     /**
      * Regular expression for retained beginning PAR_NEW bailing out collection.
      */
@@ -290,6 +314,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]"
             + JdkRegEx.TIMESTAMP
             + ": \\[CMS(Java HotSpot\\(TM\\) Server VM warning: )?bailing out to foreground collection)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_PARNEW_BAILING_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_BAILING);
 
     /**
      * Regular expression for retained beginning CMS_CONCURRENT mixed with APPLICATION_CONCURRENT_TIME collection.
@@ -302,6 +329,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + ": )?(\\[CMS-concurrent-preclean: " + JdkRegEx.DURATION_FRACTION + "\\])(" + JdkRegEx.TIMESTAMP
             + ": Application time: \\d{1,4}\\.\\d{7} seconds)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME);
+
     /**
      * Regular expression for retained beginning concurrent mode failure.
      * 
@@ -312,6 +342,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]("
             + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[Class Histogram(:)?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE);
+
     /**
      * Middle line when logging is split over 3 lines (e.g. bailing).
      * 
@@ -319,6 +352,9 @@ public class CmsPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_MIDDLE_CONCURRENT = "^(" + JdkRegEx.TIMESTAMP
             + ": \\[CMS-concurrent-mark: " + JdkRegEx.DURATION_FRACTION + "\\]" + TimesData.REGEX + "?)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_CONCURRENT);
 
     /**
      * Middle line when mixed serial and concurrent logging.
@@ -340,6 +376,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + ": )?" + JdkRegEx.TIMESTAMP + ": \\[CMS-concurrent-(abortable-preclean|preclean|mark|sweep): "
             + JdkRegEx.DURATION_FRACTION + "\\]" + TimesData.REGEX + "?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED);
+
     /**
      * Middle line when mixed PAR_NEW and concurrent logging.
      * 
@@ -356,6 +395,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[CMS)?)((" + JdkRegEx.DATESTAMP + ": )?"
             + JdkRegEx.TIMESTAMP + ": \\[CMS-concurrent-(abortable-preclean|preclean|mark): "
             + JdkRegEx.DURATION_FRACTION + "\\]" + TimesData.REGEX + "?)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED);
 
     /**
      * Middle line PAR_NEW with FLS_STATISTICS
@@ -387,6 +429,10 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE_K + "\\)(, " + JdkRegEx.DURATION + "\\])?( " + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K
             + "\\(" + JdkRegEx.SIZE_K + "\\))?((" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP
             + ": \\[CMS)?)(After GC:|CMS: Large block " + JdkRegEx.ADDRESS + ")$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS);
+
     /**
      * Middle serial line with FLS_STATISTICS
      * 
@@ -398,6 +444,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), \\[Metaspace: " + JdkRegEx.SIZE_K + "->"
             + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\)\\])After GC:$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS);
+
     /**
      * Middle line with PrintHeapAtGC.
      */
@@ -407,12 +456,18 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE_K + "\\)(, \\[CMS Perm : " + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\("
             + JdkRegEx.SIZE_K + "\\)])?)Heap after gc invocations=\\d{1,10}:[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC);
+
     /**
      * Middle line with PrintClassHistogram
      */
     private static final String REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM = "^((" + JdkRegEx.TIMESTAMP + ": \\[CMS)?: "
             + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]"
             + JdkRegEx.TIMESTAMP + ": \\[Class Histogram(:)?)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM);
 
     /**
      * Regular expression for CMS_REMARK without <code>-XX:+PrintGCDetails</code>.
@@ -425,6 +480,9 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.TIMESTAMP + ": \\[GC (\\(" + JdkRegEx.TRIGGER_CMS_FINAL_REMARK + "\\))?(  " + JdkRegEx.SIZE_K
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\])?( ("
             + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[ParNew)?)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_CMS_REMARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_CMS_REMARK);
 
     /**
      * Regular expression for retained end.
@@ -466,6 +524,8 @@ public class CmsPreprocessAction implements PreprocessAction {
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\)\\])?" + JdkRegEx.ICMS_DC_BLOCK + "?, "
             + JdkRegEx.DURATION + "\\])?" + TimesData.REGEX + "?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_END_PATTERN = Pattern.compile(REGEX_RETAIN_END);
+
     /**
      * Regular expression for retained PAR_NEW end.
      * 
@@ -477,6 +537,8 @@ public class CmsPreprocessAction implements PreprocessAction {
             + JdkRegEx.DURATION + "\\] " + JdkRegEx.SIZE_K + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), "
             + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + ")[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_END_PAR_NEW_PATTERN = Pattern.compile(REGEX_RETAIN_END_PAR_NEW);
+
     /**
      * Regular expression for retained duration. This can come in the middle or at the end of a logging event split over
      * multiple lines. Check the TOKEN to see if in the middle of preprocessing an event that spans multiple lines.
@@ -484,6 +546,8 @@ public class CmsPreprocessAction implements PreprocessAction {
      * , 27.5589374 secs]
      */
     private static final String REGEX_RETAIN_DURATION = "(, " + JdkRegEx.DURATION + "\\]" + TimesData.REGEX + "?)[ ]*";
+
+    private static final Pattern REGEX_RETAIN_DURATION_PATTERN = Pattern.compile(REGEX_RETAIN_DURATION);
 
     /**
      * Regular expression for PAR_NEW with extraneous prefix.
@@ -494,6 +558,8 @@ public class CmsPreprocessAction implements PreprocessAction {
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\] " + JdkRegEx.SIZE_K
             + "->" + JdkRegEx.SIZE_K + "\\(" + JdkRegEx.SIZE_K + "\\), " + JdkRegEx.DURATION + "\\]" + TimesData.REGEX
             + "?)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_PAR_NEW_PATTERN = Pattern.compile(REGEX_RETAIN_PAR_NEW);
 
     /**
      * Log entry in the entangle log list used to indicate the current high level preprocessor (e.g. CMS, G1). This
@@ -523,11 +589,11 @@ public class CmsPreprocessAction implements PreprocessAction {
     public CmsPreprocessAction(String priorLogEntry, String logEntry, String nextLogEntry,
             List<String> entangledLogLines, Set<String> context) {
 
+        Matcher matcher;
         // Beginning logging
-        if (logEntry.matches(REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT)) {
+        if ((matcher = REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
             // Par_NEW mixed with CMS_CONCURRENT
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 entangledLogLines.add(matcher.group(46));
             }
@@ -535,20 +601,18 @@ public class CmsPreprocessAction implements PreprocessAction {
             this.logEntry = matcher.group(1);
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS_PATTERN.matcher(logEntry)).matches()) {
             // Par_NEW mixed with FLS_STATISTICS
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 // Output beginning of PAR_NEW line
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
             // CMS_SERIAL_OLD mixed with CMS_CONCURRENT
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 entangledLogLines.add(matcher.group(28));
             }
@@ -557,58 +621,53 @@ public class CmsPreprocessAction implements PreprocessAction {
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
 
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SERIAL_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_PARNEW)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_PARNEW_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC_PATTERN.matcher(logEntry)).matches()) {
             // Remove PrintHeapAtGC output
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL_BAILING)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_BAILING);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SERIAL_BAILING_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED_PATTERN.matcher(logEntry))
+                .matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_PARNEW_BAILING)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PARNEW_BAILING);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_PARNEW_BAILING_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME_PATTERN
+                .matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1) + matcher.group(23);
                 if (matcher.group(13) != null) {
@@ -619,9 +678,8 @@ public class CmsPreprocessAction implements PreprocessAction {
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_CONCURRENT)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 if (!context.contains(TOKEN)) {
                     // Output now
@@ -632,72 +690,63 @@ public class CmsPreprocessAction implements PreprocessAction {
                 }
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED_PATTERN.matcher(logEntry)).matches()) {
             // Output serial part, save concurrent to output later
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
                 entangledLogLines.add(matcher.group(20));
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED_PATTERN.matcher(logEntry)).matches()) {
             // Output ParNew part, save concurrent to output later
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
                 entangledLogLines.add(matcher.group(33));
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS_PATTERN.matcher(logEntry)).matches()) {
             // Output ParNew part minus FL stats
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS_PATTERN.matcher(logEntry)).matches()) {
             // Output serial part minus FL stats
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC_PATTERN.matcher(logEntry)).matches()) {
             // Remove PrintHeapAtGC output
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_CMS_REMARK)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_CMS_REMARK);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_CMS_REMARK_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_DURATION)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_DURATION);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_DURATION_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
@@ -706,35 +755,33 @@ public class CmsPreprocessAction implements PreprocessAction {
                 clearEntangledLines(entangledLogLines);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_END)
-                && !priorLogEntry.matches(REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM)) {
+        } else if ((matcher = REGEX_RETAIN_END_PATTERN.matcher(logEntry)).matches()
+                && !REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM_PATTERN.matcher(priorLogEntry).matches()) {
             // End of logging event
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             clearEntangledLines(entangledLogLines);
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.remove(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_END_PAR_NEW)) {
+        } else if ((matcher = REGEX_RETAIN_END_PAR_NEW_PATTERN.matcher(logEntry)).matches()) {
             // End of logging event
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END_PAR_NEW);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             clearEntangledLines(entangledLogLines);
-            if (context.contains(TOKEN) && !priorLogEntry.matches(REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT)) {
+            if (context.contains(TOKEN)
+                    && !REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT_PATTERN.matcher(priorLogEntry).matches()) {
                 // End of multi-line event or PAR_NEW truncated
                 context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             } else {
                 context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             }
             context.remove(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_PAR_NEW)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_PAR_NEW);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_PAR_NEW_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(4);
             }
@@ -763,26 +810,29 @@ public class CmsPreprocessAction implements PreprocessAction {
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine, String priorLogLine, String nextLogLine) {
-        return logLine.matches(REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SERIAL_BAILING)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SERIAL) || logLine.matches(REGEX_RETAIN_BEGINNING_PARNEW)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_PARNEW_BAILING)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_CMS_REMARK) || logLine.matches(REGEX_RETAIN_END)
-                || logLine.matches(REGEX_RETAIN_END_PAR_NEW) || logLine.matches(REGEX_RETAIN_DURATION)
-                || logLine.matches(REGEX_RETAIN_PAR_NEW);
+        return REGEX_RETAIN_BEGINNING_PARNEW_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_PARNEW_FLS_STATISTICS_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SERIAL_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SERIAL_BAILING_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SERIAL_GC_TIME_LIMIT_EXCEEDED_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SERIAL_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_PARNEW_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_PARNEW_BAILING_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_PRINT_HEAP_AT_GC_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_CMS_CONCURRENT_APPLICATION_CONCURRENT_TIME_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_CONCURRENT_MODE_FAILURE_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PRINT_CLASS_HISTOGRAM_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_SERIAL_CONCURRENT_MIXED_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PARNEW_CONCURRENT_MIXED_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PAR_NEW_FLS_STATISTICS_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_SERIAL_FLS_STATISTICS_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PRINT_HEAP_AT_GC_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_CMS_REMARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_PAR_NEW_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_DURATION_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_PAR_NEW_PATTERN.matcher(logLine).matches();
     }
 
     /**

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/G1PreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/G1PreprocessAction.java
@@ -12,6 +12,7 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -308,6 +309,8 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.DURATION + "\\])?)((" + JdkRegEx.DATESTAMP + ": )?(" + JdkRegEx.TIMESTAMP + ": )?( )?"
             + JdkRegEx.TIMESTAMP + ": \\[G1Ergonomics.+)?(Before GC RS summary)?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_YOUNG_PAUSE_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE);
     /**
      * Regular expression for retained beginning G1_YOUNG_INITIAL_MARK collection.
      * 
@@ -320,6 +323,8 @@ public class G1PreprocessAction implements PreprocessAction {
             + ")\\))? \\(young\\) \\(initial-mark\\)(, " + JdkRegEx.DURATION + "\\])?)( " + JdkRegEx.TIMESTAMP
             + ": \\[G1Ergonomics.+)?(Before GC RS summary)?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK);
     /**
      * Regular expression for retained beginning G1_FULL_GC collection.
      */
@@ -329,6 +334,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD + ")\\))?[ ]{0,2}(" + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\), " + JdkRegEx.DURATION + "\\])?)( Before GC RS summary)?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_FULL_GC_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_GC);
+
     /**
      * Regular expression for retained beginning G1_FULL_GC with PRINT_CLASS_HISTOGRAM collection.
      */
@@ -336,11 +344,16 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.TIMESTAMP + ": \\[Full GC(" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP
             + ": \\[Class Histogram \\(before full gc\\):)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM);
     /**
      * Regular expression for retained beginning PRINT_CLASS_HISTOGRAM collection.
      */
     private static final String REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM = "^(" + JdkRegEx.TIMESTAMP
             + ": \\[Class Histogram \\(after full gc\\):)[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM);
 
     /**
      * Regular expression for retained beginning G1_CONCURRENT collection.
@@ -353,6 +366,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + ")?(\\[GC concurrent-((root-region-scan|mark|cleanup)-(start|end|abort))(, " + JdkRegEx.DURATION
             + ")?\\])[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_CONCURRENT);
+
     /**
      * Regular expression for retained beginning G1_REMARK collection.
      */
@@ -361,6 +377,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.DURATION + "\\] (" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": )?\\[GC ref-proc, "
             + JdkRegEx.DURATION + "\\]( (" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP + ": \\[Unloading, "
             + JdkRegEx.DURATION + "\\])?(, " + JdkRegEx.DURATION + "\\])[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_REMARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_REMARK);
 
     /**
      * Regular expression for retained beginning G1_MIXED collection.
@@ -374,11 +393,17 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED + ")\\))?(, " + JdkRegEx.DURATION + "\\])?)( " + JdkRegEx.TIMESTAMP
             + ": \\[G1Ergonomics.+)?(Before GC RS summary)?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_MIXED_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_MIXED);
+
     /**
      * Regular expression for retained beginning G1_CLEANUP collection.
      */
     private static final String REGEX_RETAIN_BEGINNING_CLEANUP = "^(" + JdkRegEx.TIMESTAMP + ": \\[GC cleanup "
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\), " + JdkRegEx.DURATION + "\\])[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_CLEANUP_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_CLEANUP);
 
     /**
      * Regular expression for retained beginning G1_YOUNG_PAUSE mixed with G1_CONCURRENT collection.
@@ -399,6 +424,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC + "|" + JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION
             + ")\\))? \\(young\\))((" + JdkRegEx.DATESTAMP + ": )?" + JdkRegEx.TIMESTAMP
             + ": \\[GC concurrent-(root-region-scan|cleanup|mark)-(start|end)(, " + JdkRegEx.DURATION + ")?\\])[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT);
 
     /**
      * Regular expression for retained beginning G1_FULL_GC mixed with G1_CONCURRENT collection.
@@ -434,6 +462,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + "\\)\\], \\[Metaspace: " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\)\\]"
             + TimesData.REGEX + ")?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_FULL_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT);
+
     /**
      * Regular expression for retained middle G1_YOUNG_PAUSE collection.
      * 
@@ -442,6 +473,9 @@ public class G1PreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_MIDDLE_YOUNG_PAUSE = "^   (\\[ " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE
             + "\\(" + JdkRegEx.SIZE + "\\)\\])[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_YOUNG_PAUSE_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE);
+
     /**
      * Regular expression for retained middle G1_YOUNG_INTIAL_MARK collection.
      * 
@@ -449,6 +483,9 @@ public class G1PreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK = "^( \\(initial-mark\\), " + JdkRegEx.DURATION
             + "\\])[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK);
 
     /**
      * Regular expression for retained middle G1_FULL_GC collection.
@@ -464,6 +501,7 @@ public class G1PreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_MIDDLE_FULL = "^ (" + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\)(, " + JdkRegEx.DURATION + "\\])?)(After GC RS summary)?[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_FULL_PATTERN = Pattern.compile(REGEX_RETAIN_MIDDLE_FULL);
     /**
      * Regular expression for retained middle.
      * 
@@ -480,6 +518,8 @@ public class G1PreprocessAction implements PreprocessAction {
             + "\\)\\](, \\[(Perm|Metaspace): " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE
             + "\\)\\])?)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_PATTERN = Pattern.compile(REGEX_RETAIN_MIDDLE);
+
     /**
      * Regular expression for retained middle duration.
      * 
@@ -492,12 +532,16 @@ public class G1PreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_MIDDLE_DURATION = "^(( \\((" + JdkRegEx.TRIGGER_TO_SPACE_EXHAUSTED + "|"
             + JdkRegEx.TRIGGER_TO_SPACE_OVERFLOW + ")\\))?, " + JdkRegEx.DURATION + "\\])[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_DURATION_PATTERN = Pattern.compile(REGEX_RETAIN_MIDDLE_DURATION);
+
     /**
      * Regular expression for retained end.
      * 
      * [Times: user=0.01 sys=0.00, real=0.01 secs]
      */
     private static final String REGEX_RETAIN_END = "^(" + TimesData.REGEX + ")( )?[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_END_PATTERN = Pattern.compile(REGEX_RETAIN_END);
 
     /**
      * Regular expression for retained end concurrent mixed with young pause.
@@ -512,6 +556,9 @@ public class G1PreprocessAction implements PreprocessAction {
             + "\\(" + JdkRegEx.SIZE + "\\)->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) Survivors: "
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + " Heap: " + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\)->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\)\\]" + TimesData.REGEX + ")( )?[ ]*$";
+
+    private static final Pattern REGEX_RETAIN_END_CONCURRENT_YOUNG_PATTERN =
+            Pattern.compile(REGEX_RETAIN_END_CONCURRENT_YOUNG);
 
     /**
      * Regular expressions for lines thrown away.
@@ -669,6 +716,8 @@ public class G1PreprocessAction implements PreprocessAction {
             //
     };
 
+    private static final List<Pattern> THROWAWAY_PATTERN_LIST = new ArrayList<>(REGEX_THROWAWAY.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -682,6 +731,12 @@ public class G1PreprocessAction implements PreprocessAction {
      * non-concurrent events to store them in the intermingled log lines list for output after the non-concurrent event.
      */
     public static final String TOKEN = "G1_PREPROCESS_ACTION_TOKEN";
+
+    static {
+        for (String regex : REGEX_THROWAWAY) {
+            THROWAWAY_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -700,43 +755,40 @@ public class G1PreprocessAction implements PreprocessAction {
     public G1PreprocessAction(String priorLogEntry, String logEntry, String nextLogEntry,
             List<String> entangledLogLines, Set<String> context) {
 
+        Matcher matcher;
+
         // Beginning logging
-        if (logEntry.matches(REGEX_RETAIN_BEGINNING_FULL_GC)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_GC);
-            Matcher matcher = pattern.matcher(logEntry);
+        if ((matcher = REGEX_RETAIN_BEGINNING_FULL_GC_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_CLEANUP)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_CLEANUP);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_CLEANUP_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
             // Handle concurrent mixed with young collections. See datasets 47-48 and 51-52, 54.
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 entangledLogLines.add(matcher.group(15));
             }
@@ -744,10 +796,9 @@ public class G1PreprocessAction implements PreprocessAction {
             this.logEntry = matcher.group(1);
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_FULL_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
             // Handle concurrent mixed with full collections. See dataset 74.
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             int indexG1FullDatestamp = 11;
             int indexG1FullTimestamp = 21;
             int indexFullBlock = 38;
@@ -804,10 +855,9 @@ public class G1PreprocessAction implements PreprocessAction {
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_CONCURRENT)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
             // Strip out any leading colon
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 // Handle concurrent mixed with young collections. See datasets 47-48 and 51-52, 54.
                 if (!context.contains(TOKEN)) {
@@ -836,92 +886,81 @@ public class G1PreprocessAction implements PreprocessAction {
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_YOUNG_PAUSE_PATTERN.matcher(logEntry)).matches()) {
             // Strip out G1Ergonomics
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_REMARK)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_REMARK);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_REMARK_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1) + matcher.group(57);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_MIXED)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_MIXED_PATTERN.matcher(logEntry)).matches()) {
             // Strip out G1Ergonomics
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_MIXED);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK_PATTERN.matcher(logEntry)).matches()) {
             // Strip out G1Ergonomics
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_YOUNG_PAUSE_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_FULL)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_FULL);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_FULL_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_DURATION)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_DURATION);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_DURATION_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_END)) {
+        } else if ((matcher = REGEX_RETAIN_END_PATTERN.matcher(logEntry)).matches()) {
             // End of logging event
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             clearEntangledLines(entangledLogLines);
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.remove(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_END_CONCURRENT_YOUNG)) {
+        } else if ((matcher = REGEX_RETAIN_END_CONCURRENT_YOUNG_PATTERN.matcher(logEntry)).matches()) {
             // End of logging event
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END_CONCURRENT_YOUNG);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 entangledLogLines.add(matcher.group(1));
                 this.logEntry = matcher.group(6);
@@ -952,29 +991,30 @@ public class G1PreprocessAction implements PreprocessAction {
      * @return true if the log line matches the event pattern, false otherwise.
      */
     public static final boolean match(String logLine, String priorLogLine, String nextLogLine) {
-        if (logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_PAUSE) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_REMARK) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_MIXED) //
-                || (logLine.matches(REGEX_RETAIN_BEGINNING_CLEANUP) && nextLogLine.matches(REGEX_RETAIN_END)) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_CONCURRENT) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT) //
-                || logLine.matches(REGEX_RETAIN_BEGINNING_FULL_CONCURRENT) //
-                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_PAUSE) //
-                || logLine.matches(REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK) //
-                || logLine.matches(REGEX_RETAIN_MIDDLE_FULL) //
-                || logLine.matches(REGEX_RETAIN_MIDDLE) //
-                || logLine.matches(REGEX_RETAIN_MIDDLE_DURATION) //
-                || logLine.matches(REGEX_RETAIN_END) //
-                || logLine.matches(REGEX_RETAIN_END_CONCURRENT_YOUNG)) {
+        if ( REGEX_RETAIN_BEGINNING_YOUNG_PAUSE_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_YOUNG_INITIAL_MARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_FULL_GC_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_FULL_GC_CLASS_HISTOGRAM_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_CLASS_HISTOGRAM_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_REMARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_MIXED_PATTERN.matcher(logLine).matches()
+                || (REGEX_RETAIN_BEGINNING_CLEANUP_PATTERN.matcher(logLine).matches() &&
+                        REGEX_RETAIN_END_PATTERN.matcher(nextLogLine).matches())
+                || REGEX_RETAIN_BEGINNING_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_YOUNG_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_FULL_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_YOUNG_PAUSE_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_YOUNG_INITIAL_MARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_FULL_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_DURATION_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_CONCURRENT_YOUNG_PATTERN.matcher(logLine).matches()) {
             return true;
         }
         // TODO: Get rid of this and make them throwaway events?
-        for (String element : REGEX_THROWAWAY) {
-            if (logLine.matches(element)) {
+        for (Pattern pattern : THROWAWAY_PATTERN_LIST) {
+            if (pattern.matcher(logLine).matches()) {
                 return true;
             }
         }

--- a/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/UnifiedPreprocessAction.java
+++ b/src/main/java/org/eclipselabs/garbagecat/preprocess/jdk/unified/UnifiedPreprocessAction.java
@@ -12,6 +12,7 @@
  *********************************************************************************************************************/
 package org.eclipselabs.garbagecat.preprocess.jdk.unified;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -249,6 +250,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT = "^(" + UnifiedRegEx.DECORATOR
             + " Concurrent (Mark|Preclean|Reset|Sweep) " + UnifiedRegEx.DURATION + ")$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT);
+
     /**
      * Regular expression for retained beginning @link
      * org.eclipselabs.garbagecat.domain.jdk.unified.UnifiedCmsInitialMarkEvent}.
@@ -260,6 +264,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK = "^(" + UnifiedRegEx.DECORATOR
             + " Pause Initial Mark " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) "
             + UnifiedRegEx.DURATION + ")[ ]{0,}$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK);
 
     /**
      * Regular expression for retained beginning @link
@@ -273,6 +280,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION
             + ")[ ]{0,}$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_UNIFIED_REMARK_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_REMARK);
+
     /**
      * Regular expression for retained beginning @link org.eclipselabs.garbagecat.domain.jdk.unified.UnifiedYoungEvent}.
      * 
@@ -282,6 +292,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_BEGINNING_PAUSE_YOUNG = "^(" + UnifiedRegEx.DECORATOR + " Pause Young \\("
             + JdkRegEx.TRIGGER_ALLOCATION_FAILURE + "\\))$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_PAUSE_YOUNG_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_PAUSE_YOUNG);
 
     /**
      * Regular expression for retained beginning @link
@@ -297,6 +310,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_ALLOCATION_FAILURE + "|" + JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD + "|"
             + JdkRegEx.TRIGGER_SYSTEM_GC + ")\\))$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_SERIAL_OLD_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_OLD);
+
     /**
      * Regular expression for retained beginning @link
      * org.eclipselabs.garbagecat.domain.jdk.unified.UnifiedG1FullGCEvent}.
@@ -307,6 +323,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_BEGINNING_G1_FULL_GC = "^(" + UnifiedRegEx.DECORATOR + " Pause Full \\(("
             + JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE + "|" + JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC + ")\\))$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_G1_FULL_GC_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_G1_FULL_GC);
 
     /**
      * Regular expression for retained beginning @link
@@ -335,6 +354,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_G1_EVACUATION_PAUSE + "|" + JdkRegEx.TRIGGER_GCLOCKER_INITIATED_GC + "|"
             + JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD + ")\\))$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_YOUNG_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG);
+
     /**
      * Regular expression for retained beginning @link
      * org.eclipselabs.garbagecat.domain.jdk.unified.UnifiedG1CleanupEvent}.
@@ -346,6 +368,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_BEGINNING_G1_CLEANUP = "^(" + UnifiedRegEx.DECORATOR + " Pause Cleanup "
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + ")$";
 
+    private static final Pattern REGEX_RETAIN_BEGINNING_G1_CLEANUP_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_G1_CLEANUP);
+
     /**
      * Regular expression for retained 1st line of safepoint logging.
      * 
@@ -354,6 +379,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_BEGINNING_SAFEPOINT = "^(" + UnifiedRegEx.DECORATOR
             + " Entering safepoint region: " + UnifiedSafepoint.triggerRegEx() + ")$";
+
+    private static final Pattern REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_BEGINNING_SAFEPOINT);
 
     /**
      * Regular expression for retained space data.
@@ -382,6 +410,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + "( (CMS|DefNew|Metaspace|ParNew|PSYoungGen|PSOldGen|ParOldGen|Tenured): " + JdkRegEx.SIZE + "->"
             + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\))$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_SPACE_DATA_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_SPACE_DATA);
+
     /**
      * Regular expression for retained Pause Young data.
      * 
@@ -392,6 +423,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
     private static final String REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA = "^" + UnifiedRegEx.DECORATOR + " Pause Young \\("
             + JdkRegEx.TRIGGER_ALLOCATION_FAILURE + "\\)( " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\("
             + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + ")$";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA);
 
     /**
      * Regular expression for retained Pause Full data.
@@ -419,6 +453,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_SYSTEM_GC + ")\\)( " + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE
             + "\\) " + UnifiedRegEx.DURATION + ")$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA);
+
     /**
      * Regular expression for retained Pause Young data.
      * 
@@ -445,6 +482,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + JdkRegEx.TRIGGER_G1_HUMONGOUS_ALLOCATION + "|" + JdkRegEx.TRIGGER_METADATA_GC_THRESHOLD + ")\\)( "
             + JdkRegEx.SIZE + "->" + JdkRegEx.SIZE + "\\(" + JdkRegEx.SIZE + "\\) " + UnifiedRegEx.DURATION + ")$";
 
+    private static final Pattern REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA);
+
     /**
      * Regular expression for retained 2nd line of safepoint logging.
      * 
@@ -452,6 +492,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     private static final String REGEX_RETAIN_MIDDLE_SAFEPOINT = "^(" + UnifiedRegEx.DECORATOR
             + " Leaving safepoint region$)";
+
+    private static final Pattern REGEX_RETAIN_MIDDLE_SAFEPOINT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_MIDDLE_SAFEPOINT);
 
     /**
      * Regular expression for retained 3rd line of safepoint logging.
@@ -465,6 +508,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             + " Total time for which application threads were stopped: (\\d{1,4}[\\.\\,]\\d{7}) seconds, "
             + "Stopping threads took: (\\d{1,4}[\\.\\,]\\d{7}) seconds)[ ]*$";
 
+    private static final Pattern REGEX_RETAIN_END_SAFEPOINT_PATTERN =
+            Pattern.compile(REGEX_RETAIN_END_SAFEPOINT);
+
     /**
      * Regular expression for retained end times data.
      * 
@@ -475,6 +521,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      * </pre>
      */
     private static final String REGEX_RETAIN_END_TIMES_DATA = "^" + UnifiedRegEx.DECORATOR + TimesData.REGEX_JDK9 + "$";
+
+    private static final Pattern REGEX_RETAIN_END_TIMES_DATA_PATTERN =
+            Pattern.compile(REGEX_RETAIN_END_TIMES_DATA);
 
     /**
      * Regular expressions for lines thrown away.
@@ -614,6 +663,8 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             //
     };
 
+    private static final List<Pattern> THROWAWAY_PATTERN_LIST = new ArrayList<>(REGEX_THROWAWAY.length);
+
     /**
      * The log entry for the event. Can be used for debugging purposes.
      */
@@ -628,6 +679,12 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      * event.
      */
     public static final String TOKEN = "UNIFIED_PREPROCESS_ACTION_TOKEN";
+
+    static {
+        for (String regex : REGEX_THROWAWAY) {
+            THROWAWAY_PATTERN_LIST.add(Pattern.compile(regex));
+        }
+    }
 
     /**
      * Create event from log entry.
@@ -645,78 +702,74 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     public UnifiedPreprocessAction(String priorLogEntry, String logEntry, String nextLogEntry,
             List<String> entangledLogLines, Set<String> context) {
-        if (logEntry.matches(REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT);
-            Matcher matcher = pattern.matcher(logEntry);
+
+        Matcher matcher;
+
+        if ((matcher = REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_UNIFIED_REMARK)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_UNIFIED_REMARK);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_UNIFIED_REMARK_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_PAUSE_YOUNG)) {
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_PAUSE_YOUNG_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             // Only report young collections that do not trigger an old collection
             if (nextLogEntry == null || !nextLogEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL_OLD)) {
-                Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_PAUSE_YOUNG);
-                Matcher matcher = pattern.matcher(logEntry);
-                if (matcher.matches()) {
-                    this.logEntry = matcher.group(1);
+
+                Matcher pauseMatcher = REGEX_RETAIN_BEGINNING_PAUSE_YOUNG_PATTERN.matcher(logEntry);
+                if (pauseMatcher.matches()) {
+                    this.logEntry = pauseMatcher.group(1);
                 }
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SERIAL_OLD)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SERIAL_OLD);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SERIAL_OLD_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_G1_FULL_GC)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_G1_FULL_GC);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_G1_FULL_GC_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_YOUNG)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_YOUNG);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_YOUNG_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_G1_CLEANUP)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_G1_CLEANUP);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_G1_CLEANUP_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.add(TOKEN);
-        } else if (logEntry.matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_BEGINNING_SAFEPOINT);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
-                if (nextLogEntry == null || nextLogEntry.matches(REGEX_RETAIN_MIDDLE_SAFEPOINT)) {
+                if (nextLogEntry == null || REGEX_RETAIN_MIDDLE_SAFEPOINT_PATTERN.matcher(nextLogEntry).matches()) {
                     // Non GC safepoint
                     this.logEntry = matcher.group(1);
                     context.add(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
@@ -726,16 +779,14 @@ public class UnifiedPreprocessAction implements PreprocessAction {
                 }
                 context.add(TOKEN);
             }
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_SPACE_DATA)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_SPACE_DATA);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_SPACE_DATA_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(24);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 if (context.contains(TOKEN)) {
                     this.logEntry = matcher.group(24);
@@ -750,11 +801,10 @@ public class UnifiedPreprocessAction implements PreprocessAction {
                 }
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA)) {
-            if (nextLogEntry != null && nextLogEntry.matches(REGEX_RETAIN_END_TIMES_DATA)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
+            if (nextLogEntry != null && REGEX_RETAIN_END_TIMES_DATA_PATTERN.matcher(nextLogEntry).matches()) {
                 // Middle logging
-                Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA);
-                Matcher matcher = pattern.matcher(logEntry);
                 if (matcher.matches()) {
                     this.logEntry = matcher.group(26);
                 }
@@ -768,11 +818,10 @@ public class UnifiedPreprocessAction implements PreprocessAction {
                 }
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA)) {
-            if (nextLogEntry != null && nextLogEntry.matches(REGEX_RETAIN_END_TIMES_DATA)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
+            if (nextLogEntry != null && REGEX_RETAIN_END_TIMES_DATA_PATTERN.matcher(nextLogEntry).matches()) {
                 // Middle logging
-                Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA);
-                Matcher matcher = pattern.matcher(logEntry);
                 if (matcher.matches()) {
                     this.logEntry = matcher.group(27);
                 }
@@ -786,19 +835,18 @@ public class UnifiedPreprocessAction implements PreprocessAction {
                 }
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
-        } else if (logEntry.matches(REGEX_RETAIN_MIDDLE_SAFEPOINT)) {
-            if (priorLogEntry != null && priorLogEntry.matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)) {
+        } else if ((matcher = REGEX_RETAIN_MIDDLE_SAFEPOINT_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
+            if (priorLogEntry != null && REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(priorLogEntry).matches()) {
                 this.logEntry = logEntry;
                 context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             } else {
                 // Get beginning safepoint logging from entangledLogLines
                 if (entangledLogLines.size() == 1
-                        && entangledLogLines.get(0).matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)) {
+                        && REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(entangledLogLines.get(0)).matches()) {
                     this.logEntry = entangledLogLines.get(0);
                     entangledLogLines.clear();
                 }
-                Pattern pattern = Pattern.compile(REGEX_RETAIN_MIDDLE_SAFEPOINT);
-                Matcher matcher = pattern.matcher(logEntry);
                 if (matcher.matches()) {
                     if (this.logEntry == null) {
                         this.logEntry = matcher.group(1);
@@ -808,25 +856,25 @@ public class UnifiedPreprocessAction implements PreprocessAction {
                     }
                 }
             }
-        } else if (logEntry.matches(REGEX_RETAIN_END_SAFEPOINT)) {
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END_SAFEPOINT);
-            Matcher matcher = pattern.matcher(logEntry);
+        } else if ((matcher = REGEX_RETAIN_END_SAFEPOINT_PATTERN.matcher(logEntry)).matches()) {
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(1);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
             context.remove(TOKEN);
             clearEntangledLines(entangledLogLines);
-        } else if (logEntry.matches(REGEX_RETAIN_END_TIMES_DATA)) {
+        } else if ((matcher = REGEX_RETAIN_END_TIMES_DATA_PATTERN.matcher(logEntry)).matches()) {
             // End logging
-            Pattern pattern = Pattern.compile(REGEX_RETAIN_END_TIMES_DATA);
-            Matcher matcher = pattern.matcher(logEntry);
+            matcher.reset();
             if (matcher.matches()) {
                 this.logEntry = matcher.group(24);
             }
             // Only output beginning safepoint logging if middle safepoint line is next, or it's the last log line
-            if (!(entangledLogLines.size() == 1 && entangledLogLines.get(0).matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)
-                    && (nextLogEntry == null || !nextLogEntry.matches(REGEX_RETAIN_MIDDLE_SAFEPOINT)))) {
+            if (!(entangledLogLines.size() == 1
+                    && REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(entangledLogLines.get(0)).matches()
+                    && (nextLogEntry == null
+                    || !REGEX_RETAIN_MIDDLE_SAFEPOINT_PATTERN.matcher(nextLogEntry).matches()))) {
                 clearEntangledLines(entangledLogLines);
             }
             context.remove(PreprocessAction.TOKEN_BEGINNING_OF_EVENT);
@@ -838,7 +886,7 @@ public class UnifiedPreprocessAction implements PreprocessAction {
             } else {
                 // Get beginning safepoint logging from entangledLogLines
                 if (entangledLogLines.size() == 1
-                        && entangledLogLines.get(0).matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)) {
+                        && REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(entangledLogLines.get(0)).matches()) {
                     this.logEntry = entangledLogLines.get(0);
                     entangledLogLines.clear();
                     context.add(TOKEN_BEGINNING_OF_EVENT);
@@ -863,19 +911,22 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     public static final boolean match(String logLine) {
         boolean match = false;
-        if (logLine.matches(REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_UNIFIED_REMARK)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_PAUSE_YOUNG)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SERIAL_OLD)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_G1_FULL_GC) || logLine.matches(REGEX_RETAIN_BEGINNING_YOUNG)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_G1_CLEANUP)
-                || logLine.matches(REGEX_RETAIN_BEGINNING_SAFEPOINT)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA)
-                || logLine.matches(REGEX_RETAIN_MIDDLE_SPACE_DATA) || logLine.matches(REGEX_RETAIN_MIDDLE_SAFEPOINT)
-                || logLine.matches(REGEX_RETAIN_END_SAFEPOINT) || logLine.matches(REGEX_RETAIN_END_TIMES_DATA)
+        if (REGEX_RETAIN_BEGINNING_UNIFIED_CONCURRENT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_UNIFIED_CMS_INITIAL_MARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_UNIFIED_REMARK_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_PAUSE_YOUNG_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SERIAL_OLD_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_G1_FULL_GC_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_YOUNG_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_G1_CLEANUP_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_BEGINNING_SAFEPOINT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_G1_YOUNG_DATA_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PAUSE_YOUNG_DATA_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_PAUSE_FULL_DATA_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_SPACE_DATA_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_MIDDLE_SAFEPOINT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_SAFEPOINT_PATTERN.matcher(logLine).matches()
+                || REGEX_RETAIN_END_TIMES_DATA_PATTERN.matcher(logLine).matches()
                 || JdkUtil.parseLogLine(logLine) instanceof UnifiedConcurrentEvent) {
             match = true;
         } else if (isThrowaway(logLine)) {
@@ -909,8 +960,9 @@ public class UnifiedPreprocessAction implements PreprocessAction {
      */
     private static final boolean isThrowaway(String logLine) {
         boolean throwaway = false;
-        for (int i = 0; i < REGEX_THROWAWAY.length; i++) {
-            if (logLine.matches(REGEX_THROWAWAY[i])) {
+        for (int i = 0; i < THROWAWAY_PATTERN_LIST.size(); i++) {
+            Pattern pattern = THROWAWAY_PATTERN_LIST.get(i);
+            if (pattern.matcher(logLine).matches()) {
                 throwaway = true;
                 break;
             }


### PR DESCRIPTION
Added a calculation for the Allocation Rate for the G1GC garbage collector to help determine how fast objects are being created by the application.

Also to improve performance of processing a GC file, specifically for those JVMs using the G1GC collector, added caching of the REGEX Pattern for re-use. This improved parsing of 10MB file from 165 seconds to 14 seconds.